### PR TITLE
feat(localshadowservice): send publish messages over IPC whenever a handler is invoked.

### DIFF
--- a/.license/header.txt
+++ b/.license/header.txt
@@ -1,0 +1,2 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/.license/style.xml
+++ b/.license/style.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<additionalHeaders>
+    <java_style>
+        <firstLine>/*</firstLine>
+        <beforeEachLine> * </beforeEachLine>
+        <endLine> */EOL</endLine>
+        <firstLineDetectionPattern>(\\s|\\t)*/\\*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>.*\\*/(\\s|\\t)*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </java_style>
+</additionalHeaders>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,38 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>4.0.rc2</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>.license/header.txt</header>
+                            <headerDefinitions>
+                                <headerDefinition>.license/style.xml</headerDefinition>
+                            </headerDefinitions>
+                            <useDefaultExcludes>true</useDefaultExcludes>
+                            <excludes>
+                                <exclude>*</exclude>
+                                <exclude>codestyle/**</exclude>
+                                <exclude>src/*/resources/**</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                    <mapping>
+                        <java>JAVA_STYLE</java>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.5</version>
@@ -204,8 +236,7 @@
                             <goal>check</goal>
                         </goals>
                     </execution>
-                </executions>
-            </plugin>
+                </executions>            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager;
 
 import java.util.Optional;

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager;
 
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager;
 
 import com.aws.greengrass.lifecyclemanager.Kernel;

--- a/src/main/java/com/aws/greengrass/shadowmanager/exception/ShadowManagerDataException.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/exception/ShadowManagerDataException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager.exception;
 
 public class ShadowManagerDataException extends RuntimeException {

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowIPCHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowIPCHandler.java
@@ -7,10 +7,12 @@ package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
+import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractDeleteThingShadowOperationHandler;
 import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest;
 import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowResponse;
@@ -21,7 +23,10 @@ import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DELETE_THING_SHADOW;
 
 /**
@@ -29,25 +34,29 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DEL
  */
 public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingShadowOperationHandler {
     private static final Logger logger = LogManager.getLogger(DeleteThingShadowIPCHandler.class);
+    private static final String PUBLISH_TOPIC_OP = "/delete";
     private final String serviceName;
 
     private final ShadowManagerDAO dao;
     private final AuthorizationHandler authorizationHandler;
+    private final PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent;
 
     /**
      * IPC Handler class for responding to DeleteThingShadow requests.
      *
-     * @param context              topics passed by the Nucleus
-     * @param dao                  Local shadow database management
-     * @param authorizationHandler The authorization handler
+     * @param context                   topics passed by the Nucleus
+     * @param dao                       Local shadow database management
+     * @param authorizationHandler      The authorization handler
+     * @param pubSubIPCEventStreamAgent The pubsub agent for new IPC
      */
     public DeleteThingShadowIPCHandler(
             OperationContinuationHandlerContext context,
             ShadowManagerDAO dao,
-            AuthorizationHandler authorizationHandler) {
+            AuthorizationHandler authorizationHandler, PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent) {
         super(context);
         this.authorizationHandler = authorizationHandler;
         this.dao = dao;
+        this.pubSubIPCEventStreamAgent = pubSubIPCEventStreamAgent;
         this.serviceName = context.getAuthenticationData().getIdentityLabel();
     }
 
@@ -71,6 +80,7 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
         return translateExceptions(() -> {
             String thingName = request.getThingName();
             String shadowName = request.getShadowName();
+            AtomicReference<String> shadowNamePrefix = IPCUtil.getShadowNamePrefix(shadowName, PUBLISH_TOPIC_OP);
 
             try {
                 logger.atTrace("ipc-update-thing-shadow-request").log();
@@ -83,37 +93,59 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
                         .orElseThrow(() -> {
                             ResourceNotFoundError rnf = new ResourceNotFoundError("No shadow found");
                             rnf.setResourceType(IPCUtil.SHADOW_RESOURCE_TYPE);
-                            logger.atInfo()
+                            logger.atWarn()
                                     .setEventType(IPCUtil.LogEvents.DELETE_THING_SHADOW.code())
                                     .setCause(rnf)
-                                    .log("Could not process DeleteThingShadow Request for thingName: {}, "
-                                            + "shadowName: {}", thingName, shadowName);
+                                    .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                                    .log("Unable to process delete shadow since shadow does not exist");
+                            IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName,
+                                    shadowNamePrefix.get(), IPCUtil.LogEvents.DELETE_THING_SHADOW.code(),
+                                    ErrorMessage.createShadowNotFoundMessage(shadowName));
                             return rnf;
                         });
 
+                logger.atDebug()
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Successfully delete shadow");
                 response.setPayload(result);
+
+                pubSubIPCEventStreamAgent.publish(
+                        String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_ACCEPTED_FORMAT, thingName, shadowNamePrefix.get()),
+                        new byte[0], SERVICE_NAME);
                 return response;
 
             } catch (AuthorizationException e) {
                 logger.atWarn()
                         .setEventType(IPCUtil.LogEvents.DELETE_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process DeleteThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Not authorized to update shadow");
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.DELETE_THING_SHADOW.code(), ErrorMessage.UNAUTHORIZED_MESSAGE);
                 throw new UnauthorizedError(e.getMessage());
             } catch (InvalidArgumentsError e) {
-                logger.atInfo()
+                logger.atWarn()
                         .setEventType(IPCUtil.LogEvents.DELETE_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process DeleteThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log();
+                // TODO: Get the Error Message based on the exception message we get from the validate.
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.DELETE_THING_SHADOW.code(), ErrorMessage.INVALID_VERSION_MESSAGE);
                 throw e;
             } catch (ShadowManagerDataException e) {
                 logger.atError()
                         .setEventType(IPCUtil.LogEvents.DELETE_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process DeleteThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Could not process UpdateThingShadow Request due to internal service error");
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.DELETE_THING_SHADOW.code(), ErrorMessage.createInternalServiceErrorMessage());
                 throw new ServiceError(e.getMessage());
             }
         });

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/GetThingShadowIPCHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/GetThingShadowIPCHandler.java
@@ -7,10 +7,12 @@ package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
+import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractGetThingShadowOperationHandler;
 import software.amazon.awssdk.aws.greengrass.model.GetThingShadowRequest;
 import software.amazon.awssdk.aws.greengrass.model.GetThingShadowResponse;
@@ -21,7 +23,10 @@ import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_THING_SHADOW;
 
 /**
@@ -29,25 +34,29 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET
  */
 public class GetThingShadowIPCHandler extends GeneratedAbstractGetThingShadowOperationHandler {
     private static final Logger logger = LogManager.getLogger(GetThingShadowIPCHandler.class);
+    private static final String PUBLISH_TOPIC_OP = "/get";
     private final String serviceName;
 
     private final ShadowManagerDAO dao;
     private final AuthorizationHandler authorizationHandler;
+    private final PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent;
 
     /**
      * IPC Handler class for responding to GetThingShadow requests.
      *
-     * @param context              topics passed by the Nucleus
-     * @param dao                  Local shadow database management
-     * @param authorizationHandler The authorization handler
+     * @param context                   topics passed by the Nucleus
+     * @param dao                       Local shadow database management
+     * @param authorizationHandler      The authorization handler
+     * @param pubSubIPCEventStreamAgent The pubsub agent for new IPC
      */
-    public GetThingShadowIPCHandler(
-            OperationContinuationHandlerContext context,
-            ShadowManagerDAO dao,
-            AuthorizationHandler authorizationHandler) {
+    public GetThingShadowIPCHandler(OperationContinuationHandlerContext context,
+                                    ShadowManagerDAO dao,
+                                    AuthorizationHandler authorizationHandler,
+                                    PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent) {
         super(context);
         this.authorizationHandler = authorizationHandler;
         this.dao = dao;
+        this.pubSubIPCEventStreamAgent = pubSubIPCEventStreamAgent;
         this.serviceName = context.getAuthenticationData().getIdentityLabel();
     }
 
@@ -71,6 +80,7 @@ public class GetThingShadowIPCHandler extends GeneratedAbstractGetThingShadowOpe
         return translateExceptions(() -> {
             String thingName = request.getThingName();
             String shadowName = request.getShadowName();
+            AtomicReference<String> shadowNamePrefix = IPCUtil.getShadowNamePrefix(shadowName, PUBLISH_TOPIC_OP);
 
             try {
                 logger.atTrace("ipc-get-thing-shadow-request").log();
@@ -83,37 +93,55 @@ public class GetThingShadowIPCHandler extends GeneratedAbstractGetThingShadowOpe
                         .orElseThrow(() -> {
                             ResourceNotFoundError rnf = new ResourceNotFoundError("No shadow found");
                             rnf.setResourceType(IPCUtil.SHADOW_RESOURCE_TYPE);
-                            logger.atInfo()
+                            logger.atWarn()
                                     .setEventType(IPCUtil.LogEvents.GET_THING_SHADOW.code())
                                     .setCause(rnf)
-                                    .log("Could not process GetThingShadow Request for thingName: {}, shadowName: {}",
-                                            thingName, shadowName);
+                                    .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                                    .log("Shadow does not exist");
+                            IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName,
+                                    shadowNamePrefix.get(), IPCUtil.LogEvents.GET_THING_SHADOW.code(),
+                                    ErrorMessage.createShadowNotFoundMessage(shadowName));
                             return rnf;
                         });
 
                 response.setPayload(result);
+
+                pubSubIPCEventStreamAgent.publish(
+                        String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_ACCEPTED_FORMAT, thingName, shadowNamePrefix.get()),
+                        result, SERVICE_NAME);
                 return response;
 
             } catch (AuthorizationException e) {
                 logger.atWarn()
                         .setEventType(IPCUtil.LogEvents.GET_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process GetThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Not authorized to update shadow");
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.GET_THING_SHADOW.code(), ErrorMessage.UNAUTHORIZED_MESSAGE);
                 throw new UnauthorizedError(e.getMessage());
             } catch (InvalidArgumentsError e) {
-                logger.atInfo()
+                logger.atWarn()
                         .setEventType(IPCUtil.LogEvents.GET_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process GetThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log();
+                // TODO: Get the Error Message based on the exception message we get from the validate.
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.GET_THING_SHADOW.code(), ErrorMessage.INVALID_CLIENT_TOKEN_MESSAGE);
                 throw e;
             } catch (ShadowManagerDataException e) {
                 logger.atError()
                         .setEventType(IPCUtil.LogEvents.GET_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process GetThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Could not process UpdateThingShadow Request due to internal service error");
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.GET_THING_SHADOW.code(), ErrorMessage.createInternalServiceErrorMessage());
                 throw new ServiceError(e.getMessage());
             }
         });

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/IPCUtil.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/IPCUtil.java
@@ -1,18 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 
 import java.util.StringJoiner;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 
 public final class IPCUtil {
 
+    private static final Logger logger = LogManager.getLogger(IPCUtil.class);
+    private static final ObjectMapper STRICT_MAPPER_JSON = new ObjectMapper(new JsonFactory());
     static final String SHADOW_RESOURCE_TYPE = "shadow";
     static final String SHADOW_RESOURCE_JOINER = "shadow";
     static final String SHADOW_MANAGER_NAME = "aws.greengrass.ShadowManager";
+    static final String SHADOW_PUBLISH_TOPIC_ACCEPTED_FORMAT = "$aws/things/%s/shadow%s/accepted";
+    static final String SHADOW_PUBLISH_TOPIC_REJECTED_FORMAT = "$aws/things/%s/shadow%s/rejected";
+    static final String SHADOW_PUBLISH_TOPIC_DELTA_FORMAT = "$aws/things/%s/shadow%s/delta";
+    static final String NAMED_SHADOW_TOPIC_PREFIX = "/name/%s";
+    static final String LOG_THING_NAME_KEY = "thing name";
+    static final String LOG_SHADOW_NAME_KEY = "shadow name";
 
     enum LogEvents {
         GET_THING_SHADOW("handle-get-thing-shadow"),
@@ -31,7 +55,8 @@ public final class IPCUtil {
     }
 
     private IPCUtil() {
-
+        STRICT_MAPPER_JSON.findAndRegisterModules();
+        STRICT_MAPPER_JSON.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
     }
 
     static void validateThingNameAndDoAuthorization(AuthorizationHandler authorizationHandler, String opCode,
@@ -57,5 +82,57 @@ public final class IPCUtil {
                         .operation(opCode)
                         .resource(shadowResource.toString())
                         .build());
+    }
+
+    /**
+     * Publish the message using PubSub agent when a desired operation for a shadow has been rejected.
+     *
+     * @param pubSubIPCEventStreamAgent The pubsub agent for new IPC
+     * @param shadowName                The name of the shadow for which the publish event is for
+     * @param thingName                 The name of the thing for which the publish event is for
+     * @param publishOp                 The operation causing the publish
+     * @param eventType                 The type of event causing the publish
+     * @param errorMessage              The error message object containing reject information
+     */
+    static void handleRejectedPublish(PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent,
+                                      String shadowName, String thingName, String publishOp, String eventType,
+                                      ErrorMessage errorMessage) {
+        if (Utils.isEmpty(thingName)) {
+            logger.atWarn()
+                    .setEventType(eventType)
+                    .log("Unable to publish to rejected pubsub topic since the thing name {} is empty",
+                            shadowName, thingName);
+            return;
+        }
+        byte[] payload;
+        try {
+            payload = STRICT_MAPPER_JSON.writeValueAsBytes(errorMessage);
+        } catch (JsonProcessingException e) {
+            logger.atError()
+                    .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                    .cause(e)
+                    .log("Unable to publish reject message over IPC");
+            return;
+        }
+        pubSubIPCEventStreamAgent.publish(
+                String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_REJECTED_FORMAT, thingName, publishOp),
+                payload, SERVICE_NAME);
+    }
+
+    /**
+     * Gets the Shadow name topic prefix.
+     *
+     * @param shadowName     The name of the shadow
+     * @param publishTopicOp The operation causing the publish
+     * @return the full topic prefix for the shadow name for the publish topic.
+     */
+    static AtomicReference<String> getShadowNamePrefix(String shadowName, String publishTopicOp) {
+        AtomicReference<String> shadowNamePrefix = new AtomicReference<>(publishTopicOp);
+        if (!Utils.isEmpty(shadowName)) {
+            shadowNamePrefix.set(String.format(IPCUtil.NAMED_SHADOW_TOPIC_PREFIX, shadowName)
+                    + shadowNamePrefix.get());
+        }
+        return shadowNamePrefix;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowIPCHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowIPCHandler.java
@@ -7,10 +7,12 @@ package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
+import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractUpdateThingShadowOperationHandler;
 import software.amazon.awssdk.aws.greengrass.model.ConflictError;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
@@ -21,7 +23,10 @@ import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowResponse;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_THING_SHADOW;
 
 /**
@@ -29,26 +34,31 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPD
  */
 public class UpdateThingShadowIPCHandler extends GeneratedAbstractUpdateThingShadowOperationHandler {
     private static final Logger logger = LogManager.getLogger(UpdateThingShadowIPCHandler.class);
+    private static final String PUBLISH_TOPIC_OP = "/update";
     private final String serviceName;
 
     private final ShadowManagerDAO dao;
     private final AuthorizationHandler authorizationHandler;
+    private final PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent;
 
     /**
      * IPC Handler class for responding to UpdateThingShadow requests.
      *
-     * @param context              topics passed by the Nucleus
-     * @param dao                  Local shadow database management
-     * @param authorizationHandler The authorization handler
+     * @param context                   topics passed by the Nucleus
+     * @param dao                       Local shadow database management
+     * @param authorizationHandler      The authorization handler
+     * @param pubSubIPCEventStreamAgent The pubsub agent for new IPC
      */
     public UpdateThingShadowIPCHandler(
             OperationContinuationHandlerContext context,
             ShadowManagerDAO dao,
-            AuthorizationHandler authorizationHandler) {
+            AuthorizationHandler authorizationHandler,
+            PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent) {
         super(context);
         this.authorizationHandler = authorizationHandler;
         this.dao = dao;
         this.serviceName = context.getAuthenticationData().getIdentityLabel();
+        this.pubSubIPCEventStreamAgent = pubSubIPCEventStreamAgent;
     }
 
     @Override
@@ -70,19 +80,29 @@ public class UpdateThingShadowIPCHandler extends GeneratedAbstractUpdateThingSha
     @Override
     public UpdateThingShadowResponse handleRequest(UpdateThingShadowRequest request) {
         return translateExceptions(() -> {
+            // TODO: Sync this entire function possibly with delete handler as well.
+            // TODO: Define Shadow Document models and validate payload.
+            // TODO: Calculate delta and publish update.
             String thingName = request.getThingName();
             String shadowName = request.getShadowName();
+            AtomicReference<String> shadowNamePrefix = IPCUtil.getShadowNamePrefix(shadowName, PUBLISH_TOPIC_OP);
             byte[] payload = request.getPayload();
 
             try {
-                logger.atTrace("ipc-update-thing-shadow-request").log();
+                logger.atTrace("ipc-update-thing-shadow-request")
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log();
 
                 IPCUtil.validateThingNameAndDoAuthorization(authorizationHandler, UPDATE_THING_SHADOW,
                         serviceName, thingName, shadowName);
                 if (payload == null || payload.length == 0) {
                     throw new InvalidArgumentsError("Missing update payload");
                 }
-                validatePayloadVersion(thingName, shadowName, payload);
+                byte[] source = dao.getShadowThing(thingName, shadowName)
+                        .orElse(new byte[0]);
+
+                validatePayloadVersion(thingName, shadowName, payload, source);
 
                 byte[] result = dao.updateShadowThing(thingName, shadowName, payload)
                         .orElseThrow(() -> {
@@ -90,44 +110,89 @@ public class UpdateThingShadowIPCHandler extends GeneratedAbstractUpdateThingSha
                                     + "update shadow thing.");
                             logger.atError()
                                     .setEventType(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code())
+                                    .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
                                     .setCause(error)
-                                    .log("Could not process UpdateThingShadow Request for "
-                                            + "thingName: {}, shadowName: {}", thingName, shadowName);
+                                    .log();
                             return error;
                         });
+                pubSubIPCEventStreamAgent.publish(
+                        String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_ACCEPTED_FORMAT, thingName, shadowNamePrefix.get()),
+                        result, SERVICE_NAME);
+
+                //TODO: Calculate delta
+                byte[] delta = calculateDelta(source, payload);
+                pubSubIPCEventStreamAgent.publish(
+                        String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_DELTA_FORMAT, thingName, shadowNamePrefix.get()),
+                        delta, SERVICE_NAME);
 
                 UpdateThingShadowResponse response = new UpdateThingShadowResponse();
                 response.setPayload(result);
+                logger.atDebug()
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Successfully updated shadow");
                 return response;
 
             } catch (AuthorizationException e) {
                 logger.atWarn()
                         .setEventType(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process UpdateThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Not authorized to update shadow");
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.UPDATE_THING_SHADOW.code(), ErrorMessage.UNAUTHORIZED_MESSAGE);
                 throw new UnauthorizedError(e.getMessage());
-            } catch (ConflictError | InvalidArgumentsError e) {
-                logger.atInfo()
+            } catch (ConflictError e) {
+                logger.atWarn()
                         .setEventType(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process UpdateThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Conflicting version in shadow update message");
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.UPDATE_THING_SHADOW.code(), ErrorMessage.createVersionConflictMessage());
+                throw e;
+            } catch (InvalidArgumentsError e) {
+                logger.atWarn()
+                        .setEventType(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code())
+                        .setCause(e)
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log();
+                // TODO: Get the Error Message based on the exception message we get from the validate.
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.UPDATE_THING_SHADOW.code(), ErrorMessage.INVALID_CLIENT_TOKEN_MESSAGE);
                 throw e;
             } catch (ShadowManagerDataException e) {
                 logger.atError()
                         .setEventType(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code())
                         .setCause(e)
-                        .log("Could not process UpdateThingShadow Request for thingName: {}, shadowName: {}",
-                                thingName, shadowName);
+                        .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                        .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                        .log("Could not process UpdateThingShadow Request due to internal service error");
+                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
+                        IPCUtil.LogEvents.UPDATE_THING_SHADOW.code(), ErrorMessage.createInternalServiceErrorMessage());
                 throw new ServiceError(e.getMessage());
             }
         });
     }
 
     // TODO: Implement version conflict validation
-    private void validatePayloadVersion(String thingName, String shadowName, byte[] updatePayload) throws ConflictError{
+    private void validatePayloadVersion(String thingName, String shadowName, byte[] payload, byte[] sourceDocument)
+            throws ConflictError {
+        if (sourceDocument.length == 0) {
+            logger.atTrace()
+                    .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
+                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
+                    .log("No need to check check version for new shadow");
+            return;
+        }
+    }
 
+    private byte[] calculateDelta(byte[] source, byte[] payload) {
+        return new byte[0];
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/ErrorMessage.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/ErrorMessage.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.model;
+
+import com.aws.greengrass.util.Utils;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Class that manages error messages to send when a Shadow Operation is rejected.
+ */
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorMessage {
+    private int errorCode;
+    private String message;
+    private long timestamp;
+    // TOOD: Set the client token correctly based on the Shadow Request.
+    private String clientToken;
+
+    public static final ErrorMessage INVALID_VERSION_MESSAGE =
+            ErrorMessage.builder().errorCode(400).message("Invalid version").build();
+
+    public static final ErrorMessage INVALID_CLIENT_TOKEN_MESSAGE =
+            ErrorMessage.builder().errorCode(400).message("Invalid clientToken").build();
+
+    public static final ErrorMessage UNAUTHORIZED_MESSAGE =
+            ErrorMessage.builder().errorCode(401).message("Unauthorized").build();
+
+    public static final ErrorMessage FORBIDDEN_MESSAGE =
+            ErrorMessage.builder().errorCode(403).message("Forbidden").build();
+
+    /**
+     * Creates the error message when the thing is not found.
+     *
+     * @return the ErrorMessage object for thing Not Found exception.
+     */
+    public static ErrorMessage createThingNotFoundMessage() {
+       return ErrorMessage.builder().errorCode(404).timestamp(Instant.now().toEpochMilli())
+                .message("Thing not found").build();
+    }
+
+    /**
+     * Creates the error message when the shadow is not found.
+     *
+     * @param shadowName The name of the shdaow.
+     * @return the ErrorMessage object for Shadow Not Found exception.
+     */
+    public static ErrorMessage createShadowNotFoundMessage(String shadowName) {
+        shadowName = Utils.isEmpty(shadowName) ? "Unnamed Shadow" : shadowName;
+        return ErrorMessage.builder().errorCode(404).timestamp(Instant.now().toEpochMilli())
+                .message(String.format("No shadow exists with name: %s", shadowName)).build();
+    }
+
+    /**
+     * Creates the error message when there is a version conflict in the request. The version of the
+     * update should be exactly one higher than the last received update.
+     *
+     * @return the ErrorMessage object for Version Conflict exception.
+     */
+    public static ErrorMessage createVersionConflictMessage() {
+        return ErrorMessage.builder().errorCode(409).timestamp(Instant.now().toEpochMilli())
+                .message("Version conflict").build();
+    }
+
+    /**
+     * Creates the error message when there is an internal server error.
+     *
+     * @return the ErrorMessage object for Internal Service Failure exception.
+     */
+    public static ErrorMessage createInternalServiceErrorMessage() {
+        return ErrorMessage.builder().errorCode(500).timestamp(Instant.now().toEpochMilli())
+                .message("Internal service failure").build();
+    }
+}

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager;
 
 import com.aws.greengrass.lifecyclemanager.Kernel;

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabaseTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabaseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager;
 
 import com.aws.greengrass.dependency.State;

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowIPCHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowIPCHandlerTest.java
@@ -1,14 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
+import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
+import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.model.*;
@@ -16,22 +28,32 @@ import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
 import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
+import java.io.IOException;
+import java.time.Instant;
 import java.util.Optional;
 
+import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class DeleteThingShadowIPCHandlerTest {
+class DeleteThingShadowIPCHandlerTest {
 
     private static final String TEST_SERVICE = "TestService";
     private static final String THING_NAME = "testThingName";
     private static final String SHADOW_NAME = "testShadowName";
-    private static final byte[] BASE_DOCUMENT =  "{\"id\": 1, \"name\": \"The Beatles\"}".getBytes();
+    private static final byte[] BASE_DOCUMENT = "{\"id\": 1, \"name\": \"The Beatles\"}".getBytes();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new JsonFactory());
 
     @Mock
     OperationContinuationHandlerContext mockContext;
@@ -45,16 +67,25 @@ public class DeleteThingShadowIPCHandlerTest {
     @Mock
     ShadowManagerDAO mockDao;
 
+    @Mock
+    PubSubIPCEventStreamAgent mockPubSubIPCEventStreamAgent;
+
+    @Captor
+    ArgumentCaptor<String> serviceNameCaptor;
+    @Captor
+    ArgumentCaptor<String> topicCaptor;
+    @Captor
+    ArgumentCaptor<byte[]> payloadCaptor;
+
     @BeforeEach
-    void setup () {
+    void setup() {
         when(mockContext.getContinuation()).thenReturn(mock(ServerConnectionContinuation.class));
         when(mockContext.getAuthenticationData()).thenReturn(mockAuthenticationData);
         when(mockAuthenticationData.getIdentityLabel()).thenReturn(TEST_SERVICE);
     }
 
     @Test
-    void GIVEN_delete_thing_shadow_ipc_handler_WHEN_handle_request_THEN_delete_thing_shadow() {
-
+    void GIVEN_delete_thing_shadow_ipc_handler_with_named_shadow_WHEN_handle_request_THEN_delete_thing_shadow() {
         DeleteThingShadowRequest request = new DeleteThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
@@ -62,23 +93,89 @@ public class DeleteThingShadowIPCHandlerTest {
         DeleteThingShadowResponse expectedResponse = new DeleteThingShadowResponse();
         expectedResponse.setPayload(BASE_DOCUMENT);
 
-        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         when(mockDao.deleteShadowThing(any(), any())).thenReturn(Optional.of(BASE_DOCUMENT));
 
         DeleteThingShadowResponse actualResponse = deleteThingShadowIPCHandler.handleRequest(request);
         assertEquals(expectedResponse, actualResponse);
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        assertArrayEquals(new byte[0], payloadCaptor.getValue());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/delete/accepted", topicCaptor.getValue());
     }
 
     @Test
-    void GIVEN_delete_thing_shadow_ipc_handler_WHEN_document_not_found_THEN_throw_resource_not_found_exception(ExtensionContext context) throws Exception {
+    void GIVEN_delete_thing_shadow_ipc_handler_with_empty_shadow_name_WHEN_handle_request_THEN_delete_thing_shadow() throws IOException {
+        DeleteThingShadowRequest request = new DeleteThingShadowRequest();
+        request.setThingName(THING_NAME);
+        request.setShadowName("");
+
+        DeleteThingShadowResponse expectedResponse = new DeleteThingShadowResponse();
+        expectedResponse.setPayload(BASE_DOCUMENT);
+
+        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        when(mockDao.deleteShadowThing(any(), any())).thenReturn(Optional.of(BASE_DOCUMENT));
+
+        DeleteThingShadowResponse actualResponse = deleteThingShadowIPCHandler.handleRequest(request);
+        assertEquals(expectedResponse, actualResponse);
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        assertArrayEquals(new byte[0], payloadCaptor.getValue());
+        assertEquals("$aws/things/testThingName/shadow/delete/accepted", topicCaptor.getValue());
+    }
+
+    @Test
+    void GIVEN_delete_thing_shadow_ipc_handler_WHEN_document_not_found_THEN_throw_resource_not_found_exception(ExtensionContext context) throws IOException {
         ignoreExceptionOfType(context, ResourceNotFoundError.class);
         DeleteThingShadowRequest request = new DeleteThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
 
         when(mockDao.deleteShadowThing(any(), any())).thenReturn(Optional.empty());
-        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         assertThrows(ResourceNotFoundError.class, () -> deleteThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        assertNotEquals(Instant.EPOCH.toEpochMilli(), errorMessage.getTimestamp());
+        assertEquals(404, errorMessage.getErrorCode());
+        assertEquals("No shadow exists with name: testShadowName", errorMessage.getMessage());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/delete/rejected", topicCaptor.getValue());
+    }
+
+    @Test
+    void GIVEN_delete_thing_shadow_ipc_handler_WHEN_dao_sends_data_exception_THEN_throw_service_exception(ExtensionContext context) throws IOException {
+        ignoreExceptionOfType(context, ShadowManagerDataException.class);
+        DeleteThingShadowRequest request = new DeleteThingShadowRequest();
+        request.setThingName(THING_NAME);
+        request.setShadowName(SHADOW_NAME);
+
+        doThrow(ShadowManagerDataException.class).when(mockDao).deleteShadowThing(any(), any());
+        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        assertThrows(ServiceError.class, () -> deleteThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        assertNotEquals(Instant.EPOCH.toEpochMilli(), errorMessage.getTimestamp());
+        assertEquals(500, errorMessage.getErrorCode());
+        assertEquals("Internal service failure", errorMessage.getMessage());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/delete/rejected", topicCaptor.getValue());
     }
 
     @Test
@@ -90,18 +187,30 @@ public class DeleteThingShadowIPCHandlerTest {
         when(mockAuthorizationHandler.isAuthorized(any(), any(Permission.class)))
                 .thenThrow(AuthorizationException.class);
 
-        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         assertThrows(UnauthorizedError.class, () -> deleteThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        assertEquals(401, errorMessage.getErrorCode());
+        assertEquals("Unauthorized", errorMessage.getMessage());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/delete/rejected", topicCaptor.getValue());
     }
 
     @Test
-    void GIVEN_delete_thing_shadow_ipc_handler_WHEN_missing_thing_name_THEN_throw_invalid_arguments_exception(ExtensionContext context) throws Exception {
+    void GIVEN_delete_thing_shadow_ipc_handler_WHEN_missing_thing_name_THEN_throw_invalid_arguments_exception(ExtensionContext context) {
         ignoreExceptionOfType(context, InvalidArgumentsError.class);
         DeleteThingShadowRequest request = new DeleteThingShadowRequest();
         request.setThingName("");
         request.setShadowName(SHADOW_NAME);
 
-        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        DeleteThingShadowIPCHandler deleteThingShadowIPCHandler = new DeleteThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         assertThrows(InvalidArgumentsError.class, () -> deleteThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(0)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
     }
 }

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowIPCHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowIPCHandlerTest.java
@@ -1,15 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
+import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.model.*;
@@ -17,23 +28,33 @@ import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
 import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
+import java.io.IOException;
+import java.time.Instant;
 import java.util.Optional;
 
+import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class UpdateThingShadowIPCHandlerTest {
+class UpdateThingShadowIPCHandlerTest {
 
     private static final String TEST_SERVICE = "TestService";
     private static final String THING_NAME = "testThingName";
     private static final String SHADOW_NAME = "testShadowName";
     private static final byte[] UPDATE_DOCUMENT =  "{\"id\": 1, \"name\": \"The Beatles\"}".getBytes();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new JsonFactory());
 
     @Mock
     OperationContinuationHandlerContext mockContext;
@@ -47,6 +68,16 @@ public class UpdateThingShadowIPCHandlerTest {
     @Mock
     ShadowManagerDAO mockDao;
 
+    @Mock
+    PubSubIPCEventStreamAgent mockPubSubIPCEventStreamAgent;
+
+    @Captor
+    ArgumentCaptor<String> serviceNameCaptor;
+    @Captor
+    ArgumentCaptor<String> topicCaptor;
+    @Captor
+    ArgumentCaptor<byte[]> payloadCaptor;
+
     @BeforeEach
     void setup () {
         when(mockContext.getContinuation()).thenReturn(mock(ServerConnectionContinuation.class));
@@ -55,7 +86,7 @@ public class UpdateThingShadowIPCHandlerTest {
     }
 
     @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_handle_request_THEN_update_thing_shadow() {
+    void GIVEN_update_thing_shadow_ipc_handler_with_named_shadow_WHEN_handle_request_THEN_update_thing_shadow() {
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
@@ -64,22 +95,106 @@ public class UpdateThingShadowIPCHandlerTest {
         UpdateThingShadowResponse expectedResponse = new UpdateThingShadowResponse();
         expectedResponse.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        when(mockDao.getShadowThing(any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
         when(mockDao.updateShadowThing(any(), any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
 
         UpdateThingShadowResponse actualResponse = updateThingShadowIPCHandler.handleRequest(request);
         assertEquals(expectedResponse, actualResponse);
+        verify(mockPubSubIPCEventStreamAgent, times(2)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertEquals(2, serviceNameCaptor.getAllValues().size());
+        assertEquals(2, payloadCaptor.getAllValues().size());
+        assertEquals(2, topicCaptor.getAllValues().size());
+
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(0));
+        assertArrayEquals(UPDATE_DOCUMENT, payloadCaptor.getAllValues().get(0));
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/accepted", topicCaptor.getAllValues().get(0));
+
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(1));
+        assertArrayEquals(new byte[0], payloadCaptor.getAllValues().get(1));
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/delta", topicCaptor.getAllValues().get(1));
     }
 
     @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_update_thing_shadow(ExtensionContext context) {
+    void GIVEN_update_thing_shadow_ipc_handler_with_empty_shadow_name_WHEN_handle_request_THEN_update_thing_shadow() {
+        UpdateThingShadowRequest request = new UpdateThingShadowRequest();
+        request.setThingName(THING_NAME);
+        request.setShadowName("");
+        request.setPayload(UPDATE_DOCUMENT);
+
+        UpdateThingShadowResponse expectedResponse = new UpdateThingShadowResponse();
+        expectedResponse.setPayload(UPDATE_DOCUMENT);
+
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        when(mockDao.getShadowThing(any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
+        when(mockDao.updateShadowThing(any(), any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
+
+        UpdateThingShadowResponse actualResponse = updateThingShadowIPCHandler.handleRequest(request);
+        assertEquals(expectedResponse, actualResponse);
+        verify(mockPubSubIPCEventStreamAgent, times(2)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertEquals(2, serviceNameCaptor.getAllValues().size());
+        assertEquals(2, payloadCaptor.getAllValues().size());
+        assertEquals(2, topicCaptor.getAllValues().size());
+
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(0));
+        assertArrayEquals(UPDATE_DOCUMENT, payloadCaptor.getAllValues().get(0));
+        assertEquals("$aws/things/testThingName/shadow/update/accepted", topicCaptor.getAllValues().get(0));
+
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(1));
+        assertArrayEquals(new byte[0], payloadCaptor.getAllValues().get(1));
+        assertEquals("$aws/things/testThingName/shadow/update/delta", topicCaptor.getAllValues().get(1));
+    }
+
+    @Test
+    void GIVEN_update_thing_shadow_WHEN_dao_update_sends_data_exception_THEN_update_thing_shadow_fails(ExtensionContext context) throws IOException {
+        ignoreExceptionOfType(context, ShadowManagerDataException.class);
+        UpdateThingShadowRequest request = new UpdateThingShadowRequest();
+        request.setThingName(THING_NAME);
+        request.setShadowName(SHADOW_NAME);
+        request.setPayload(UPDATE_DOCUMENT);
+
+        UpdateThingShadowResponse expectedResponse = new UpdateThingShadowResponse();
+        expectedResponse.setPayload(UPDATE_DOCUMENT);
+
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        doThrow(ShadowManagerDataException.class).when(mockDao).getShadowThing(any(), any());
+
+        assertThrows(ServiceError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
+
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        assertNotEquals(Instant.EPOCH.toEpochMilli(), errorMessage.getTimestamp());
+        assertEquals(500, errorMessage.getErrorCode());
+        assertEquals("Internal service failure", errorMessage.getMessage());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
+    }
+
+    @Test
+    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_update_thing_shadow(ExtensionContext context) throws IOException {
         ignoreExceptionOfType(context, InvalidArgumentsError.class);
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
 
         assertThrows(InvalidArgumentsError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        assertEquals(400, errorMessage.getErrorCode());
+        assertEquals("Invalid clientToken", errorMessage.getMessage());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
     }
 
     @Test
@@ -92,60 +207,69 @@ public class UpdateThingShadowIPCHandlerTest {
         when(mockAuthorizationHandler.isAuthorized(any(), any(Permission.class)))
                 .thenThrow(AuthorizationException.class);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         assertThrows(UnauthorizedError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        assertEquals(401, errorMessage.getErrorCode());
+        assertEquals("Unauthorized", errorMessage.getMessage());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
     }
 
     @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_thing_name_THEN_throw_invalid_arguments_exception(ExtensionContext context) throws Exception {
+    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_thing_name_THEN_throw_invalid_arguments_exception(ExtensionContext context) {
         ignoreExceptionOfType(context, InvalidArgumentsError.class);
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName("");
         request.setShadowName(SHADOW_NAME);
         request.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         assertThrows(InvalidArgumentsError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(0)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
     }
 
     @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_throw_invalid_arguments_exception(ExtensionContext context) throws Exception {
+    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_throw_invalid_arguments_exception(ExtensionContext context) throws IOException {
         ignoreExceptionOfType(context, InvalidArgumentsError.class);
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
         request.setPayload(new byte[0]);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         assertThrows(InvalidArgumentsError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
+        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
+                payloadCaptor.capture(), serviceNameCaptor.capture());
+        assertNotNull(serviceNameCaptor.getValue());
+        assertNotNull(payloadCaptor.getValue());
+        assertNotNull(topicCaptor.getValue());
+        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
+        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        assertEquals(400, errorMessage.getErrorCode());
+        assertEquals("Invalid clientToken", errorMessage.getMessage());
+        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
     }
 
 
     @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_unexpected_empty_return_during_update_THEN_throw_service_error_exception(ExtensionContext context) throws Exception {
+    void GIVEN_update_thing_shadow_ipc_handler_WHEN_unexpected_empty_return_during_update_THEN_throw_service_error_exception(ExtensionContext context) {
         ignoreExceptionOfType(context, ServiceError.class);
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
         request.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
         when(mockDao.updateShadowThing(any(), any(), any())).thenReturn(Optional.empty());
 
         ServiceError thrown = assertThrows(ServiceError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
         assertTrue(thrown.getMessage().contains("Unexpected error"));
-    }
-
-    @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_data_exception_occurs_THEN_throw_service_error_exception(ExtensionContext context) throws Exception {
-        ignoreExceptionOfType(context, ShadowManagerDataException.class);
-        UpdateThingShadowRequest request = new UpdateThingShadowRequest();
-        request.setThingName(THING_NAME);
-        request.setShadowName(SHADOW_NAME);
-        request.setPayload(UPDATE_DOCUMENT);
-
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler);
-        when(mockDao.updateShadowThing(any(), any(), any())).thenThrow(ShadowManagerDataException.class);
-        assertThrows(ServiceError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Shadow-1

**Description of changes:**
Based on the IPC method invoked, publish the relevant message over PubSub for other components to react off of.
Injected `PubSubIPCEventStreamAgent` in the `ShadowManager` class in order to have the instance of the pubsub agent available to pass to the shadow method handlers.
If there is any error while performing the operation (`GET`, `UPDATE` or `DELETE`), then send a message on the `rejected` topic.
If the operation is successful for `GET`, then send the current document in the payload on the `accepted` topic.
If the operation is successful for `DELETE`, then send a message on the `accepted` topic with zero byte payload.
If the operation is successful for `UPDATE`, then send the current document in the payload on the `accepted` topic, calculate the delta between the updated document and then send the delta document in the payload on the `delta` topic.

TODO:
Implement the `calculateDelta` and `validatePayload` functions.
Increase the unit test coverage

**Why is this change necessary:**
This feature is to bring parity with V1 as well as enabling the customers to react to any changes to the shadow document like triggering a lambda component.

**How was this change tested:**
Added unit tests.

**Any additional information or context required to review the change:**
This will not be able to build on Github. These changes are dependent on a new version of Nucleus with shadow changes in the IoTDeviceSDK. Prior to releasing the Nucleus and IoTDeviceSDK these changes will need to be tested locally in ShadowManager and UAT's added for the nucleus. These changes will be merged to the reviewed-ipc-update branch so that we can review the ShadowManager IPC changes without merging to master.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
