### PR TITLE
refactor: add a pubsub client wrapper for making shadow API handlers agnostic of pubusub event stream agent.

### DIFF
--- a/codestyle/IntelliJ.xml
+++ b/codestyle/IntelliJ.xml
@@ -1,8 +1,3 @@
-<!--
-  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~ SPDX-License-Identifier: Apache-2.0
-  -->
-
 <code_scheme name="Greengrass" version="173">
   <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
   <JavaCodeStyleSettings>

--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ Copyright Amazon.com Inc. or its affiliates.
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 

--- a/codestyle/findbugs-exclude.xml
+++ b/codestyle/findbugs-exclude.xml
@@ -1,10 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ Copyright Amazon.com Inc. or its affiliates.
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
 <FindBugsFilter>
     <Match>
+        <Or>
+            <Bug pattern="DM_CONVERT_CASE"/>
+            <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
+            <!-- Added for JDK-11 executable -->
+            <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+            <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+
+            <Bug pattern="EI_EXPOSE_REP"/>
+            <Bug pattern="EI_EXPOSE_REP2"/>
+        </Or>
+    </Match>
+    <Match>
+        <Or>
+            <Package name="software.amazon.awssdk.aws.greengrass"/>
+            <Package name="software.amazon.awssdk.aws.greengrass.model"/>
+            <Package name="software.amazon.awssdk.eventstreamrpc"/>
+            <Package name="software.amazon.awssdk.eventstreamrpc.model"/>
+            <Package name="software.amazon.awssdk.http.apache.internal.conn"/>
+        </Or>
     </Match>
 </FindBugsFilter>

--- a/codestyle/pmd-eg-ruleset.xml
+++ b/codestyle/pmd-eg-ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ Copyright Amazon.com Inc. or its affiliates.
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 

--- a/codestyle/pmd-eg-tests-ruleset.xml
+++ b/codestyle/pmd-eg-tests-ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ Copyright Amazon.com Inc. or its affiliates.
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -7,13 +7,13 @@ package com.aws.greengrass.shadowmanager;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
-import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowIPCHandler;
 import com.aws.greengrass.shadowmanager.ipc.GetThingShadowIPCHandler;
+import com.aws.greengrass.shadowmanager.ipc.PubSubClientWrapper;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowIPCHandler;
 import org.flywaydb.core.api.FlywayException;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
@@ -57,7 +57,7 @@ public class ShadowManager extends PluginService {
     private final ShadowManagerDAO dao;
     private final ShadowManagerDatabase database;
     private final AuthorizationHandler authorizationHandler;
-    private final PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent;
+    private final PubSubClientWrapper pubSubClientWrapper;
 
     @Inject
     private GreengrassCoreIPCService greengrassCoreIPCService;
@@ -65,11 +65,11 @@ public class ShadowManager extends PluginService {
     /**
      * Ctr for ShadowManager.
      *
-     * @param topics                    topics passed by the Nucleus
-     * @param database                  Local shadow database management
-     * @param dao                       Local shadow database management
-     * @param authorizationHandler      The authorization handler
-     * @param pubSubIPCEventStreamAgent The pubsub agent for new IPC
+     * @param topics               topics passed by the Nucleus
+     * @param database             Local shadow database management
+     * @param dao                  Local shadow database management
+     * @param authorizationHandler The authorization handler
+     * @param pubSubClientWrapper  The PubSub client wrapper
      */
     @Inject
     public ShadowManager(
@@ -77,12 +77,12 @@ public class ShadowManager extends PluginService {
             ShadowManagerDatabase database,
             ShadowManagerDAOImpl dao,
             AuthorizationHandler authorizationHandler,
-            PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent) {
+            PubSubClientWrapper pubSubClientWrapper) {
         super(topics);
         this.database = database;
         this.authorizationHandler = authorizationHandler;
         this.dao = dao;
-        this.pubSubIPCEventStreamAgent = pubSubIPCEventStreamAgent;
+        this.pubSubClientWrapper = pubSubClientWrapper;
     }
 
     private void registerHandlers() {
@@ -96,11 +96,11 @@ public class ShadowManager extends PluginService {
         }
 
         greengrassCoreIPCService.setGetThingShadowHandler(context -> new GetThingShadowIPCHandler(context,
-                dao, authorizationHandler, pubSubIPCEventStreamAgent));
+                dao, authorizationHandler, pubSubClientWrapper));
         greengrassCoreIPCService.setDeleteThingShadowHandler(context -> new DeleteThingShadowIPCHandler(context,
-                dao, authorizationHandler, pubSubIPCEventStreamAgent));
+                dao, authorizationHandler, pubSubClientWrapper));
         greengrassCoreIPCService.setUpdateThingShadowHandler(context -> new UpdateThingShadowIPCHandler(context,
-                dao, authorizationHandler, pubSubIPCEventStreamAgent));
+                dao, authorizationHandler, pubSubClientWrapper));
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowIPCHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowIPCHandler.java
@@ -7,11 +7,13 @@ package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
-import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
+import com.aws.greengrass.shadowmanager.ipc.model.AcceptRequest;
+import com.aws.greengrass.shadowmanager.ipc.model.Operation;
+import com.aws.greengrass.shadowmanager.ipc.model.RejectRequest;
 import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractDeleteThingShadowOperationHandler;
 import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest;
@@ -23,10 +25,7 @@ import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
-import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DELETE_THING_SHADOW;
 
 /**
@@ -34,12 +33,11 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DEL
  */
 public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingShadowOperationHandler {
     private static final Logger logger = LogManager.getLogger(DeleteThingShadowIPCHandler.class);
-    private static final String PUBLISH_TOPIC_OP = "/delete";
     private final String serviceName;
 
     private final ShadowManagerDAO dao;
     private final AuthorizationHandler authorizationHandler;
-    private final PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent;
+    private final PubSubClientWrapper pubSubClientWrapper;
 
     /**
      * IPC Handler class for responding to DeleteThingShadow requests.
@@ -47,16 +45,17 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
      * @param context                   topics passed by the Nucleus
      * @param dao                       Local shadow database management
      * @param authorizationHandler      The authorization handler
-     * @param pubSubIPCEventStreamAgent The pubsub agent for new IPC
+     * @param pubSubClientWrapper       The PubSub client wrapper
      */
     public DeleteThingShadowIPCHandler(
             OperationContinuationHandlerContext context,
             ShadowManagerDAO dao,
-            AuthorizationHandler authorizationHandler, PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent) {
+            AuthorizationHandler authorizationHandler,
+            PubSubClientWrapper pubSubClientWrapper) {
         super(context);
         this.authorizationHandler = authorizationHandler;
         this.dao = dao;
-        this.pubSubIPCEventStreamAgent = pubSubIPCEventStreamAgent;
+        this.pubSubClientWrapper = pubSubClientWrapper;
         this.serviceName = context.getAuthenticationData().getIdentityLabel();
     }
 
@@ -80,7 +79,6 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
         return translateExceptions(() -> {
             String thingName = request.getThingName();
             String shadowName = request.getShadowName();
-            AtomicReference<String> shadowNamePrefix = IPCUtil.getShadowNamePrefix(shadowName, PUBLISH_TOPIC_OP);
 
             try {
                 logger.atTrace("ipc-update-thing-shadow-request").log();
@@ -99,9 +97,11 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
                                     .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
                                     .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
                                     .log("Unable to process delete shadow since shadow does not exist");
-                            IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName,
-                                    shadowNamePrefix.get(), IPCUtil.LogEvents.DELETE_THING_SHADOW.code(),
-                                    ErrorMessage.createShadowNotFoundMessage(shadowName));
+                            pubSubClientWrapper.reject(RejectRequest.builder().thingName(thingName)
+                                    .shadowName(shadowName)
+                                    .errorMessage(ErrorMessage.createShadowNotFoundMessage(shadowName))
+                                    .publishOperation(Operation.DELETE_SHADOW)
+                                    .build());
                             return rnf;
                         });
 
@@ -111,9 +111,10 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
                         .log("Successfully delete shadow");
                 response.setPayload(result);
 
-                pubSubIPCEventStreamAgent.publish(
-                        String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_ACCEPTED_FORMAT, thingName, shadowNamePrefix.get()),
-                        new byte[0], SERVICE_NAME);
+                pubSubClientWrapper.accept(AcceptRequest.builder().thingName(thingName).shadowName(shadowName)
+                        .payload(new byte[0]).publishOperation(Operation.DELETE_SHADOW)
+                        .publishOperation(Operation.DELETE_SHADOW)
+                        .build());
                 return response;
 
             } catch (AuthorizationException e) {
@@ -123,8 +124,10 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
                         .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
                         .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
                         .log("Not authorized to update shadow");
-                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
-                        IPCUtil.LogEvents.DELETE_THING_SHADOW.code(), ErrorMessage.UNAUTHORIZED_MESSAGE);
+                pubSubClientWrapper.reject(RejectRequest.builder().thingName(thingName).shadowName(shadowName)
+                        .errorMessage(ErrorMessage.UNAUTHORIZED_MESSAGE)
+                        .publishOperation(Operation.DELETE_SHADOW)
+                        .build());
                 throw new UnauthorizedError(e.getMessage());
             } catch (InvalidArgumentsError e) {
                 logger.atWarn()
@@ -134,8 +137,10 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
                         .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
                         .log();
                 // TODO: Get the Error Message based on the exception message we get from the validate.
-                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
-                        IPCUtil.LogEvents.DELETE_THING_SHADOW.code(), ErrorMessage.INVALID_VERSION_MESSAGE);
+                pubSubClientWrapper.reject(RejectRequest.builder().thingName(thingName).shadowName(shadowName)
+                        .errorMessage(ErrorMessage.INVALID_CLIENT_TOKEN_MESSAGE)
+                        .publishOperation(Operation.DELETE_SHADOW)
+                        .build());
                 throw e;
             } catch (ShadowManagerDataException e) {
                 logger.atError()
@@ -144,8 +149,10 @@ public class DeleteThingShadowIPCHandler extends GeneratedAbstractDeleteThingSha
                         .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
                         .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
                         .log("Could not process UpdateThingShadow Request due to internal service error");
-                IPCUtil.handleRejectedPublish(pubSubIPCEventStreamAgent, shadowName, thingName, shadowNamePrefix.get(),
-                        IPCUtil.LogEvents.DELETE_THING_SHADOW.code(), ErrorMessage.createInternalServiceErrorMessage());
+                pubSubClientWrapper.reject(RejectRequest.builder().thingName(thingName).shadowName(shadowName)
+                        .errorMessage(ErrorMessage.createInternalServiceErrorMessage())
+                        .publishOperation(Operation.DELETE_SHADOW)
+                        .build());
                 throw new ServiceError(e.getMessage());
             }
         });

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/IPCUtil.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/IPCUtil.java
@@ -8,37 +8,25 @@ package com.aws.greengrass.shadowmanager.ipc;
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
-import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import com.aws.greengrass.util.Utils;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 
 import java.util.StringJoiner;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 
 public final class IPCUtil {
 
-    private static final Logger logger = LogManager.getLogger(IPCUtil.class);
-    private static final ObjectMapper STRICT_MAPPER_JSON = new ObjectMapper(new JsonFactory());
     static final String SHADOW_RESOURCE_TYPE = "shadow";
     static final String SHADOW_RESOURCE_JOINER = "shadow";
     static final String SHADOW_MANAGER_NAME = "aws.greengrass.ShadowManager";
     static final String SHADOW_PUBLISH_TOPIC_ACCEPTED_FORMAT = "$aws/things/%s/shadow%s/accepted";
     static final String SHADOW_PUBLISH_TOPIC_REJECTED_FORMAT = "$aws/things/%s/shadow%s/rejected";
     static final String SHADOW_PUBLISH_TOPIC_DELTA_FORMAT = "$aws/things/%s/shadow%s/delta";
+    static final String SHADOW_PUBLISH_TOPIC_DOCUMENTS_FORMAT = "$aws/things/%s/shadow%s/documents";
     static final String NAMED_SHADOW_TOPIC_PREFIX = "/name/%s";
     static final String LOG_THING_NAME_KEY = "thing name";
     static final String LOG_SHADOW_NAME_KEY = "shadow name";
 
-    enum LogEvents {
+    public enum LogEvents {
         GET_THING_SHADOW("handle-get-thing-shadow"),
         UPDATE_THING_SHADOW("handle-update-thing-shadow"),
         DELETE_THING_SHADOW("handle-delete-thing-shadow");
@@ -55,8 +43,6 @@ public final class IPCUtil {
     }
 
     private IPCUtil() {
-        STRICT_MAPPER_JSON.findAndRegisterModules();
-        STRICT_MAPPER_JSON.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
     }
 
     static void validateThingNameAndDoAuthorization(AuthorizationHandler authorizationHandler, String opCode,
@@ -82,57 +68,5 @@ public final class IPCUtil {
                         .operation(opCode)
                         .resource(shadowResource.toString())
                         .build());
-    }
-
-    /**
-     * Publish the message using PubSub agent when a desired operation for a shadow has been rejected.
-     *
-     * @param pubSubIPCEventStreamAgent The pubsub agent for new IPC
-     * @param shadowName                The name of the shadow for which the publish event is for
-     * @param thingName                 The name of the thing for which the publish event is for
-     * @param publishOp                 The operation causing the publish
-     * @param eventType                 The type of event causing the publish
-     * @param errorMessage              The error message object containing reject information
-     */
-    static void handleRejectedPublish(PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent,
-                                      String shadowName, String thingName, String publishOp, String eventType,
-                                      ErrorMessage errorMessage) {
-        if (Utils.isEmpty(thingName)) {
-            logger.atWarn()
-                    .setEventType(eventType)
-                    .log("Unable to publish to rejected pubsub topic since the thing name {} is empty",
-                            shadowName, thingName);
-            return;
-        }
-        byte[] payload;
-        try {
-            payload = STRICT_MAPPER_JSON.writeValueAsBytes(errorMessage);
-        } catch (JsonProcessingException e) {
-            logger.atError()
-                    .kv(IPCUtil.LOG_THING_NAME_KEY, thingName)
-                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, shadowName)
-                    .cause(e)
-                    .log("Unable to publish reject message over IPC");
-            return;
-        }
-        pubSubIPCEventStreamAgent.publish(
-                String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_REJECTED_FORMAT, thingName, publishOp),
-                payload, SERVICE_NAME);
-    }
-
-    /**
-     * Gets the Shadow name topic prefix.
-     *
-     * @param shadowName     The name of the shadow
-     * @param publishTopicOp The operation causing the publish
-     * @return the full topic prefix for the shadow name for the publish topic.
-     */
-    static AtomicReference<String> getShadowNamePrefix(String shadowName, String publishTopicOp) {
-        AtomicReference<String> shadowNamePrefix = new AtomicReference<>(publishTopicOp);
-        if (!Utils.isEmpty(shadowName)) {
-            shadowNamePrefix.set(String.format(IPCUtil.NAMED_SHADOW_TOPIC_PREFIX, shadowName)
-                    + shadowNamePrefix.get());
-        }
-        return shadowNamePrefix;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapper.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.ipc;
+
+import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.ipc.model.AcceptRequest;
+import com.aws.greengrass.shadowmanager.ipc.model.RejectRequest;
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+
+import javax.inject.Inject;
+
+import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
+
+/**
+ * Class to handle PubSub interaction with the PubSub Event Stream Agent.
+ */
+public class PubSubClientWrapper {
+    private static final Logger logger = LogManager.getLogger(PubSubClientWrapper.class);
+    private static final ObjectMapper STRICT_MAPPER_JSON = new ObjectMapper(new JsonFactory());
+    private final PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent;
+
+    /**
+     * Constructor.
+     *
+     * @param pubSubIPCEventStreamAgent PubSub event stream agent
+     */
+    @Inject
+    public PubSubClientWrapper(PubSubIPCEventStreamAgent pubSubIPCEventStreamAgent) {
+        STRICT_MAPPER_JSON.findAndRegisterModules();
+        STRICT_MAPPER_JSON.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+        this.pubSubIPCEventStreamAgent = pubSubIPCEventStreamAgent;
+    }
+
+    /**
+     * Publish the message using PubSub agent when a desired operation for a shadow has been rejected.
+     *
+     * @param rejectRequest The request object containing the reject information.
+     */
+    public void reject(RejectRequest rejectRequest) {
+        byte[] payload;
+        try {
+            payload = STRICT_MAPPER_JSON.writeValueAsBytes(rejectRequest.getErrorMessage());
+        } catch (JsonProcessingException e) {
+            logger.atError()
+                    .setEventType(rejectRequest.getPublishOperation().getLogEventType())
+                    .kv(IPCUtil.LOG_THING_NAME_KEY, rejectRequest.getThingName())
+                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, rejectRequest.getShadowName())
+                    .cause(e)
+                    .log("Unable to publish reject message over IPC");
+            return;
+        }
+        try {
+            this.pubSubIPCEventStreamAgent.publish(
+                    String.format(IPCUtil.SHADOW_PUBLISH_TOPIC_REJECTED_FORMAT,
+                            rejectRequest.getThingName(),
+                            getShadowNamePrefix(rejectRequest.getShadowName(),
+                                    rejectRequest.getPublishOperation().getOp())),
+                    payload, SERVICE_NAME);
+            logger.atTrace()
+                    .setEventType(rejectRequest.getPublishOperation().getLogEventType())
+                    .kv(IPCUtil.LOG_THING_NAME_KEY, rejectRequest.getThingName())
+                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, rejectRequest.getShadowName())
+                    .log("Successfully published reject message over PubSub IPC");
+        } catch (InvalidArgumentsError e) {
+            logger.atError().cause(e)
+                    .kv(IPCUtil.LOG_THING_NAME_KEY, rejectRequest.getThingName())
+                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, rejectRequest.getShadowName())
+                    .log("Unable to publish reject message over PubSub");
+        }
+    }
+
+    /**
+     * Publish the message using PubSub agent when a desired operation for a shadow has been accepted.
+     *
+     * @param acceptRequest The request object containing the accepted information.
+     */
+    public void accept(AcceptRequest acceptRequest) {
+        handleAcceptedMessage(acceptRequest, IPCUtil.SHADOW_PUBLISH_TOPIC_ACCEPTED_FORMAT);
+    }
+
+
+    /**
+     * Publish the message using PubSub agent when a desired operation for a shadow has been accepted and the delta
+     * information needs to be published.
+     *
+     * @param acceptRequest The request object containing the delta information.
+     */
+    public void delta(AcceptRequest acceptRequest) {
+        handleAcceptedMessage(acceptRequest, IPCUtil.SHADOW_PUBLISH_TOPIC_DELTA_FORMAT);
+    }
+
+    /**
+     * Publish the message using PubSub agent when a desired operation for a shadow has been accepted and the documents
+     * information needs to be published.
+     *
+     * @param acceptRequest The request object containing the documents information.
+     */
+    public void documents(AcceptRequest acceptRequest) {
+        handleAcceptedMessage(acceptRequest, IPCUtil.SHADOW_PUBLISH_TOPIC_DOCUMENTS_FORMAT);
+    }
+
+    /**
+     * Publish the message using PubSub agent when a desired operation for a shadow has been accepted.
+     *
+     * @param acceptRequest     The request object containing the accepted information.
+     * @param shadowTopicFormat The format for the shadow topic on which to publish the message
+     */
+    private void handleAcceptedMessage(AcceptRequest acceptRequest, String shadowTopicFormat) {
+        try {
+
+            this.pubSubIPCEventStreamAgent.publish(String.format(shadowTopicFormat, acceptRequest.getThingName(),
+                    getShadowNamePrefix(acceptRequest.getShadowName(),
+                            acceptRequest.getPublishOperation().getOp())),
+                    acceptRequest.getPayload(), SERVICE_NAME);
+            logger.atTrace()
+                    .setEventType(acceptRequest.getPublishOperation().getLogEventType())
+                    .kv(IPCUtil.LOG_THING_NAME_KEY, acceptRequest.getThingName())
+                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, acceptRequest.getShadowName())
+                    .log("Successfully published reject message over PubSub IPC");
+        } catch (InvalidArgumentsError e) {
+            logger.atError().cause(e)
+                    .kv(IPCUtil.LOG_THING_NAME_KEY, acceptRequest.getThingName())
+                    .kv(IPCUtil.LOG_SHADOW_NAME_KEY, acceptRequest.getShadowName())
+                    .log("Unable to publish accepted message over PubSub");
+        }
+    }
+
+    /**
+     * Gets the Shadow name topic prefix.
+     *
+     * @param shadowName     The name of the shadow
+     * @param publishTopicOp The operation causing the publish
+     * @return the full topic prefix for the shadow name for the publish topic.
+     */
+    private String getShadowNamePrefix(String shadowName, String publishTopicOp) {
+        String shadowNamePrefix = publishTopicOp;
+        if (!Utils.isEmpty(shadowName)) {
+            shadowNamePrefix = String.format(IPCUtil.NAMED_SHADOW_TOPIC_PREFIX, shadowName) + publishTopicOp;
+        }
+        return shadowNamePrefix;
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/AcceptRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/AcceptRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.ipc.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Class containing the details when a shadow operation is accepted.
+ */
+@Getter
+public class AcceptRequest extends IPCRequest {
+    byte[] payload;
+
+    Operation publishOperation;
+
+    /**
+     * Constructor/Builder for Accept request class.
+     *
+     * @param thingName        The thing name
+     * @param shadowName       The name of the shadow on which the operation was requested
+     * @param payload          The payload to be published
+     * @param publishOperation The Operation type to be performed on the shadow
+     */
+    @Builder
+    public AcceptRequest(String thingName, String shadowName, byte[] payload,
+                         Operation publishOperation) {
+        super(thingName, shadowName);
+        this.payload = payload;
+        this.publishOperation = publishOperation;
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/IPCRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/IPCRequest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.ipc.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Base class containing IPC request information for publishing messages for Shadow operations.
+ */
+@Getter
+@AllArgsConstructor
+public class IPCRequest {
+    @NotNull
+    String thingName;
+    String shadowName;
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/Operation.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/Operation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.ipc.model;
+
+import com.aws.greengrass.shadowmanager.ipc.IPCUtil;
+import lombok.Getter;
+
+/**
+ * Enum to state the operation for the shadow.
+ */
+public enum Operation {
+    GET_SHADOW("/get", IPCUtil.LogEvents.GET_THING_SHADOW.code()),
+    DELETE_SHADOW("/delete", IPCUtil.LogEvents.DELETE_THING_SHADOW.code()),
+    UPDATE_SHADOW("/update", IPCUtil.LogEvents.UPDATE_THING_SHADOW.code());
+
+    @Getter
+    String op;
+
+    @Getter
+    String logEventType;
+
+    Operation(String op, String logEventType) {
+        this.op = op;
+        this.logEventType = logEventType;
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/RejectRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/model/RejectRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.ipc.model;
+
+import com.aws.greengrass.shadowmanager.model.ErrorMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Class containing the details when a shadow operation is rejected.
+ */
+@Getter
+public class RejectRequest extends IPCRequest {
+    ErrorMessage errorMessage;
+    Operation publishOperation;
+
+    /**
+     * Constructor/Builder for Reject request class.
+     *
+     * @param thingName        The thing name
+     * @param shadowName       The name of the shadow on which the operation was requested
+     * @param errorMessage     The ErrorMessage class containing the error information for rejection
+     * @param publishOperation The Operation type to be performed on the shadow
+     */
+    @Builder
+    public RejectRequest(String thingName, String shadowName, ErrorMessage errorMessage,
+                         Operation publishOperation) {
+        super(thingName, shadowName);
+        this.errorMessage = errorMessage;
+        this.publishOperation = publishOperation;
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/ErrorMessage.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/ErrorMessage.java
@@ -24,7 +24,7 @@ public class ErrorMessage {
     private int errorCode;
     private String message;
     private long timestamp;
-    // TOOD: Set the client token correctly based on the Shadow Request.
+    // TODO: Set the client token correctly based on the Shadow Request.
     private String clientToken;
 
     public static final ErrorMessage INVALID_VERSION_MESSAGE =

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowIPCHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowIPCHandlerTest.java
@@ -8,13 +8,13 @@ package com.aws.greengrass.shadowmanager.ipc;
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
-import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
+import com.aws.greengrass.shadowmanager.ipc.model.AcceptRequest;
+import com.aws.greengrass.shadowmanager.ipc.model.Operation;
+import com.aws.greengrass.shadowmanager.ipc.model.RejectRequest;
 import com.aws.greengrass.shadowmanager.model.ErrorMessage;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,11 +28,9 @@ import software.amazon.awssdk.crt.eventstream.ServerConnectionContinuation;
 import software.amazon.awssdk.eventstreamrpc.AuthenticationData;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
 
-import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,14 +45,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+//TODO: Change the names of the tests to be in the correct format.
+//TODO: Use Hamcrest assertions
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class UpdateThingShadowIPCHandlerTest {
 
     private static final String TEST_SERVICE = "TestService";
     private static final String THING_NAME = "testThingName";
     private static final String SHADOW_NAME = "testShadowName";
-    private static final byte[] UPDATE_DOCUMENT =  "{\"id\": 1, \"name\": \"The Beatles\"}".getBytes();
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new JsonFactory());
+    private static final byte[] UPDATE_DOCUMENT = "{\"id\": 1, \"name\": \"The Beatles\"}".getBytes();
 
     @Mock
     OperationContinuationHandlerContext mockContext;
@@ -69,17 +68,15 @@ class UpdateThingShadowIPCHandlerTest {
     ShadowManagerDAO mockDao;
 
     @Mock
-    PubSubIPCEventStreamAgent mockPubSubIPCEventStreamAgent;
+    PubSubClientWrapper mockPubSubClientWrapper;
 
     @Captor
-    ArgumentCaptor<String> serviceNameCaptor;
+    ArgumentCaptor<RejectRequest> rejectRequestCaptor;
     @Captor
-    ArgumentCaptor<String> topicCaptor;
-    @Captor
-    ArgumentCaptor<byte[]> payloadCaptor;
+    ArgumentCaptor<AcceptRequest> acceptRequestCaptor;
 
     @BeforeEach
-    void setup () {
+    void setup() {
         when(mockContext.getContinuation()).thenReturn(mock(ServerConnectionContinuation.class));
         when(mockContext.getAuthenticationData()).thenReturn(mockAuthenticationData);
         when(mockAuthenticationData.getIdentityLabel()).thenReturn(TEST_SERVICE);
@@ -95,25 +92,32 @@ class UpdateThingShadowIPCHandlerTest {
         UpdateThingShadowResponse expectedResponse = new UpdateThingShadowResponse();
         expectedResponse.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
         when(mockDao.getShadowThing(any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
         when(mockDao.updateShadowThing(any(), any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
 
         UpdateThingShadowResponse actualResponse = updateThingShadowIPCHandler.handleRequest(request);
         assertEquals(expectedResponse, actualResponse);
-        verify(mockPubSubIPCEventStreamAgent, times(2)).publish(topicCaptor.capture(),
-                payloadCaptor.capture(), serviceNameCaptor.capture());
-        assertEquals(2, serviceNameCaptor.getAllValues().size());
-        assertEquals(2, payloadCaptor.getAllValues().size());
-        assertEquals(2, topicCaptor.getAllValues().size());
+        verify(mockPubSubClientWrapper, times(1))
+                .accept(acceptRequestCaptor.capture());
+        verify(mockPubSubClientWrapper, times(0))
+                .delta(acceptRequestCaptor.capture());
+        verify(mockPubSubClientWrapper, times(1))
+                .documents(acceptRequestCaptor.capture());
+        assertEquals(2, acceptRequestCaptor.getAllValues().size());
 
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(0));
-        assertArrayEquals(UPDATE_DOCUMENT, payloadCaptor.getAllValues().get(0));
-        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/accepted", topicCaptor.getAllValues().get(0));
 
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(1));
-        assertArrayEquals(new byte[0], payloadCaptor.getAllValues().get(1));
-        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/delta", topicCaptor.getAllValues().get(1));
+        assertEquals(SHADOW_NAME, acceptRequestCaptor.getAllValues().get(0).getShadowName());
+        assertArrayEquals(UPDATE_DOCUMENT, acceptRequestCaptor.getAllValues().get(0).getPayload());
+        assertEquals(THING_NAME, acceptRequestCaptor.getAllValues().get(0).getThingName());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, acceptRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
+        assertEquals(Operation.UPDATE_SHADOW, acceptRequestCaptor.getAllValues().get(0).getPublishOperation());
+
+        assertEquals(SHADOW_NAME, acceptRequestCaptor.getAllValues().get(1).getShadowName());
+        assertArrayEquals(new byte[0], acceptRequestCaptor.getAllValues().get(1).getPayload());
+        assertEquals(THING_NAME, acceptRequestCaptor.getAllValues().get(1).getThingName());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, acceptRequestCaptor.getAllValues().get(1).getPublishOperation().getLogEventType());
+        assertEquals(Operation.UPDATE_SHADOW, acceptRequestCaptor.getAllValues().get(1).getPublishOperation());
     }
 
     @Test
@@ -126,29 +130,36 @@ class UpdateThingShadowIPCHandlerTest {
         UpdateThingShadowResponse expectedResponse = new UpdateThingShadowResponse();
         expectedResponse.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
         when(mockDao.getShadowThing(any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
         when(mockDao.updateShadowThing(any(), any(), any())).thenReturn(Optional.of(UPDATE_DOCUMENT));
 
         UpdateThingShadowResponse actualResponse = updateThingShadowIPCHandler.handleRequest(request);
         assertEquals(expectedResponse, actualResponse);
-        verify(mockPubSubIPCEventStreamAgent, times(2)).publish(topicCaptor.capture(),
-                payloadCaptor.capture(), serviceNameCaptor.capture());
-        assertEquals(2, serviceNameCaptor.getAllValues().size());
-        assertEquals(2, payloadCaptor.getAllValues().size());
-        assertEquals(2, topicCaptor.getAllValues().size());
+        verify(mockPubSubClientWrapper, times(1))
+                .accept(acceptRequestCaptor.capture());
+        verify(mockPubSubClientWrapper, times(0))
+                .delta(acceptRequestCaptor.capture());
+        verify(mockPubSubClientWrapper, times(1))
+                .documents(acceptRequestCaptor.capture());
+        assertEquals(2, acceptRequestCaptor.getAllValues().size());
 
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(0));
-        assertArrayEquals(UPDATE_DOCUMENT, payloadCaptor.getAllValues().get(0));
-        assertEquals("$aws/things/testThingName/shadow/update/accepted", topicCaptor.getAllValues().get(0));
 
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getAllValues().get(1));
-        assertArrayEquals(new byte[0], payloadCaptor.getAllValues().get(1));
-        assertEquals("$aws/things/testThingName/shadow/update/delta", topicCaptor.getAllValues().get(1));
+        assertEquals("", acceptRequestCaptor.getAllValues().get(0).getShadowName());
+        assertArrayEquals(UPDATE_DOCUMENT, acceptRequestCaptor.getAllValues().get(0).getPayload());
+        assertEquals(THING_NAME, acceptRequestCaptor.getAllValues().get(0).getThingName());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, acceptRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
+        assertEquals(Operation.UPDATE_SHADOW, acceptRequestCaptor.getAllValues().get(0).getPublishOperation());
+
+        assertEquals("", acceptRequestCaptor.getAllValues().get(1).getShadowName());
+        assertArrayEquals(new byte[0], acceptRequestCaptor.getAllValues().get(1).getPayload());
+        assertEquals(THING_NAME, acceptRequestCaptor.getAllValues().get(1).getThingName());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, acceptRequestCaptor.getAllValues().get(1).getPublishOperation().getLogEventType());
+        assertEquals(Operation.UPDATE_SHADOW, acceptRequestCaptor.getAllValues().get(1).getPublishOperation());
     }
 
     @Test
-    void GIVEN_update_thing_shadow_WHEN_dao_update_sends_data_exception_THEN_update_thing_shadow_fails(ExtensionContext context) throws IOException {
+    void GIVEN_update_thing_shadow_WHEN_dao_update_sends_data_exception_THEN_update_thing_shadow_fails(ExtensionContext context) {
         ignoreExceptionOfType(context, ShadowManagerDataException.class);
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(THING_NAME);
@@ -158,43 +169,45 @@ class UpdateThingShadowIPCHandlerTest {
         UpdateThingShadowResponse expectedResponse = new UpdateThingShadowResponse();
         expectedResponse.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
         doThrow(ShadowManagerDataException.class).when(mockDao).getShadowThing(any(), any());
 
         assertThrows(ServiceError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
 
-        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
-                payloadCaptor.capture(), serviceNameCaptor.capture());
-        assertNotNull(serviceNameCaptor.getValue());
-        assertNotNull(payloadCaptor.getValue());
-        assertNotNull(topicCaptor.getValue());
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
-        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        verify(mockPubSubClientWrapper, times(1))
+                .reject(rejectRequestCaptor.capture());
+
+        assertNotNull(rejectRequestCaptor.getValue());
+
+        assertEquals(SHADOW_NAME, rejectRequestCaptor.getValue().getShadowName());
+        ErrorMessage errorMessage = rejectRequestCaptor.getValue().getErrorMessage();
         assertNotEquals(Instant.EPOCH.toEpochMilli(), errorMessage.getTimestamp());
+        assertEquals(Operation.UPDATE_SHADOW, rejectRequestCaptor.getValue().getPublishOperation());
         assertEquals(500, errorMessage.getErrorCode());
         assertEquals("Internal service failure", errorMessage.getMessage());
-        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, rejectRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
     }
 
     @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_update_thing_shadow(ExtensionContext context) throws IOException {
+    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_update_thing_shadow(ExtensionContext context) {
         ignoreExceptionOfType(context, InvalidArgumentsError.class);
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
 
         assertThrows(InvalidArgumentsError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
-        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
-                payloadCaptor.capture(), serviceNameCaptor.capture());
-        assertNotNull(serviceNameCaptor.getValue());
-        assertNotNull(payloadCaptor.getValue());
-        assertNotNull(topicCaptor.getValue());
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
-        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        verify(mockPubSubClientWrapper, times(1))
+                .reject(rejectRequestCaptor.capture());
+
+        assertNotNull(rejectRequestCaptor.getValue());
+
+        assertEquals(SHADOW_NAME, rejectRequestCaptor.getValue().getShadowName());
+        ErrorMessage errorMessage = rejectRequestCaptor.getValue().getErrorMessage();
+        assertEquals(Operation.UPDATE_SHADOW, rejectRequestCaptor.getValue().getPublishOperation());
         assertEquals(400, errorMessage.getErrorCode());
         assertEquals("Invalid clientToken", errorMessage.getMessage());
-        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, rejectRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
     }
 
     @Test
@@ -207,18 +220,18 @@ class UpdateThingShadowIPCHandlerTest {
         when(mockAuthorizationHandler.isAuthorized(any(), any(Permission.class)))
                 .thenThrow(AuthorizationException.class);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
         assertThrows(UnauthorizedError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
-        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
-                payloadCaptor.capture(), serviceNameCaptor.capture());
-        assertNotNull(serviceNameCaptor.getValue());
-        assertNotNull(payloadCaptor.getValue());
-        assertNotNull(topicCaptor.getValue());
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
-        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+        verify(mockPubSubClientWrapper, times(1)).reject(rejectRequestCaptor.capture());
+
+        assertNotNull(rejectRequestCaptor.getValue());
+
+        assertEquals(SHADOW_NAME, rejectRequestCaptor.getValue().getShadowName());
+        ErrorMessage errorMessage = rejectRequestCaptor.getValue().getErrorMessage();
+        assertEquals(Operation.UPDATE_SHADOW, rejectRequestCaptor.getValue().getPublishOperation());
         assertEquals(401, errorMessage.getErrorCode());
         assertEquals("Unauthorized", errorMessage.getMessage());
-        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, rejectRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
     }
 
     @Test
@@ -229,32 +242,43 @@ class UpdateThingShadowIPCHandlerTest {
         request.setShadowName(SHADOW_NAME);
         request.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
         assertThrows(InvalidArgumentsError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
-        verify(mockPubSubIPCEventStreamAgent, times(0)).publish(topicCaptor.capture(),
-                payloadCaptor.capture(), serviceNameCaptor.capture());
+        verify(mockPubSubClientWrapper, times(1))
+                .reject(rejectRequestCaptor.capture());
+
+        assertNotNull(rejectRequestCaptor.getValue());
+
+        assertEquals(SHADOW_NAME, rejectRequestCaptor.getValue().getShadowName());
+        ErrorMessage errorMessage = rejectRequestCaptor.getValue().getErrorMessage();
+        assertEquals(Operation.UPDATE_SHADOW, rejectRequestCaptor.getValue().getPublishOperation());
+        assertEquals(400, errorMessage.getErrorCode());
+        assertEquals("Invalid clientToken", errorMessage.getMessage());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, rejectRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
     }
 
     @Test
-    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_throw_invalid_arguments_exception(ExtensionContext context) throws IOException {
+    void GIVEN_update_thing_shadow_ipc_handler_WHEN_missing_payload_THEN_throw_invalid_arguments_exception(ExtensionContext context) {
         ignoreExceptionOfType(context, InvalidArgumentsError.class);
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(THING_NAME);
         request.setShadowName(SHADOW_NAME);
         request.setPayload(new byte[0]);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
         assertThrows(InvalidArgumentsError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
-        verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
-                payloadCaptor.capture(), serviceNameCaptor.capture());
-        assertNotNull(serviceNameCaptor.getValue());
-        assertNotNull(payloadCaptor.getValue());
-        assertNotNull(topicCaptor.getValue());
-        assertEquals(SERVICE_NAME, serviceNameCaptor.getValue());
-        ErrorMessage errorMessage = OBJECT_MAPPER.readValue(payloadCaptor.getValue(), ErrorMessage.class);
+
+        verify(mockPubSubClientWrapper, times(1))
+                .reject(rejectRequestCaptor.capture());
+
+        assertNotNull(rejectRequestCaptor.getValue());
+
+        assertEquals(SHADOW_NAME, rejectRequestCaptor.getValue().getShadowName());
+        ErrorMessage errorMessage = rejectRequestCaptor.getValue().getErrorMessage();
+        assertEquals(Operation.UPDATE_SHADOW, rejectRequestCaptor.getValue().getPublishOperation());
         assertEquals(400, errorMessage.getErrorCode());
         assertEquals("Invalid clientToken", errorMessage.getMessage());
-        assertEquals("$aws/things/testThingName/shadow/name/testShadowName/update/rejected", topicCaptor.getValue());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, rejectRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
     }
 
 
@@ -266,10 +290,23 @@ class UpdateThingShadowIPCHandlerTest {
         request.setShadowName(SHADOW_NAME);
         request.setPayload(UPDATE_DOCUMENT);
 
-        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubIPCEventStreamAgent);
+        UpdateThingShadowIPCHandler updateThingShadowIPCHandler = new UpdateThingShadowIPCHandler(mockContext, mockDao, mockAuthorizationHandler, mockPubSubClientWrapper);
         when(mockDao.updateShadowThing(any(), any(), any())).thenReturn(Optional.empty());
 
         ServiceError thrown = assertThrows(ServiceError.class, () -> updateThingShadowIPCHandler.handleRequest(request));
         assertTrue(thrown.getMessage().contains("Unexpected error"));
+
+        verify(mockPubSubClientWrapper, times(1))
+                .reject(rejectRequestCaptor.capture());
+
+        assertNotNull(rejectRequestCaptor.getValue());
+
+        assertEquals(SHADOW_NAME, rejectRequestCaptor.getValue().getShadowName());
+        ErrorMessage errorMessage = rejectRequestCaptor.getValue().getErrorMessage();
+        assertNotEquals(Instant.EPOCH.toEpochMilli(), errorMessage.getTimestamp());
+        assertEquals(Operation.UPDATE_SHADOW, rejectRequestCaptor.getValue().getPublishOperation());
+        assertEquals(500, errorMessage.getErrorCode());
+        assertEquals("Internal service failure", errorMessage.getMessage());
+        assertEquals(IPCUtil.LogEvents.UPDATE_THING_SHADOW.code, rejectRequestCaptor.getAllValues().get(0).getPublishOperation().getLogEventType());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Shadow-1

**Description of changes:**
Refactored the code to have a `PubSubClientWrapper` class to handle all the interactions with the PubSub agent.

**Why is this change necessary:**
Better code quality and structure.

**How was this change tested:**
Added unit tests and updated unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
