### PR TITLE
refactor(syncHandler): refactoring requests to pull data from dao

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
@@ -83,81 +83,52 @@ public class SyncHandler {
     }
 
     /**
-     * Pushes a cloud update sync request to the sync request queue.
+     * Pushes an update sync request to the request queue to update shadow in the cloud after a local shadow has
+     * been successfully updated.
      * TODO: implement message queue data structure to push SyncRequest
      *
-     * @param thingName      The thing name associated with the sync shadow update
-     * @param shadowName     The shadow name associated with the sync shadow update
-     * @param version        The version of the specific sync shadow update
-     * @param updateTime     The update time of the specific sync shadow update
-     * @param updateDocument The update document from the cloud
+     * @param thingName  The thing name associated with the sync shadow update
+     * @param shadowName The shadow name associated with the sync shadow update
      */
-    public void pushCloudUpdateSyncRequest(String thingName, String shadowName, int version, Instant updateTime,
-                                           String updateDocument) {
-        CloudUpdateSyncRequest cloudUpdateSyncRequest = new CloudUpdateSyncRequest(thingName,
-                shadowName,
-                updateDocument,
-                updateTime,
-                version,
-                this.dao,
+    public void pushCloudUpdateSyncRequest(String thingName, String shadowName) {
+        CloudUpdateSyncRequest cloudUpdateSyncRequest = new CloudUpdateSyncRequest(thingName, shadowName, this.dao);
+    }
+
+    /**
+     * Pushes an update sync request to the request queue to update local shadow after a cloud shadow has
+     * been successfully updated.
+     * TODO: implement message queue data structure to push SyncRequest
+     *
+     * @param thingName  The thing name associated with the sync shadow update
+     * @param shadowName The shadow name associated with the sync shadow update
+     */
+    public void pushLocalUpdateSyncRequest(String thingName, String shadowName) {
+        LocalUpdateSyncRequest localUpdateSyncRequest = new LocalUpdateSyncRequest(thingName, shadowName, this.dao,
                 this.updateThingShadowIPCHandler);
     }
 
     /**
-     * Adds local update sync request to the request queue.
+     * Pushes a delete sync request in the request queue to delete a shadow in the cloud after a local shadow has
+     * been successfully deleted.
      * TODO: implement message queue data structure to push SyncRequest
      *
-     * @param thingName      The thing name associated with the sync shadow update
-     * @param shadowName     The shadow name associated with the sync shadow update
-     * @param version        The version of the specific sync shadow update
-     * @param updateTime     The update time of the specific sync shadow update
-     * @param updateDocument The update document from the local shadow update
+     * @param thingName  The thing name associated with the sync shadow update
+     * @param shadowName The shadow name associated with the sync shadow update
      */
-    public void pushLocalUpdateSyncRequest(String thingName, String shadowName, int version, Instant updateTime,
-                                           String updateDocument) {
-        LocalUpdateSyncRequest localUpdateSyncRequest = new LocalUpdateSyncRequest(thingName,
-                shadowName,
-                updateDocument,
-                updateTime,
-                version,
-                this.dao,
-                this.updateThingShadowIPCHandler);
+    public void pushCloudDeleteSyncRequest(String thingName, String shadowName) {
+        CloudDeleteSyncRequest cloudDeleteSyncRequest = new CloudDeleteSyncRequest(thingName, shadowName, this.dao);
     }
 
     /**
-     * Adds cloud delete sync request to the request queue.
+     * Pushes a delete sync request in the request queue to delete a local shadow after a cloud shadow has
+     * been successfully deleted.
      * TODO: implement message queue data structure to push SyncRequest
      *
-     * @param thingName      The thing name associated with the sync shadow update
-     * @param shadowName     The shadow name associated with the sync shadow update
-     * @param version        The version of the specific sync shadow update
-     * @param updateTime     The update time of the specific sync shadow update
+     * @param thingName  The thing name associated with the sync shadow update
+     * @param shadowName The shadow name associated with the sync shadow update
      */
-    public void pushCloudDeleteSyncRequest(String thingName, String shadowName, int version, Instant updateTime) {
-        CloudDeleteSyncRequest cloudDeleteSyncRequest = new CloudDeleteSyncRequest(thingName,
-                shadowName,
-                updateTime,
-                version,
-                this.dao,
+    public void pushLocalDeleteSyncRequest(String thingName, String shadowName) {
+        LocalDeleteSyncRequest localDeleteSyncRequest = new LocalDeleteSyncRequest(thingName, shadowName, this.dao,
                 this.deleteThingShadowIPCHandler);
     }
-
-    /**
-     * Adds local delete sync request to the request queue.
-     * TODO: implement message queue data structure to push SyncRequest
-     *
-     * @param thingName      The thing name associated with the sync shadow update
-     * @param shadowName     The shadow name associated with the sync shadow update
-     * @param version        The version of the specific sync shadow update
-     * @param updateTime     The update time of the specific sync shadow update
-     */
-    public void pushLocalDeleteSyncRequest(String thingName, String shadowName, int version, Instant updateTime) {
-        LocalDeleteSyncRequest localDeleteSyncRequest = new LocalDeleteSyncRequest(thingName,
-                shadowName,
-                updateTime,
-                version,
-                this.dao,
-                this.deleteThingShadowIPCHandler);
-    }
-
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
@@ -9,17 +9,10 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.model.ShadowRequest;
 import lombok.NonNull;
 
-import java.time.Instant;
-
 /**
  * Base class for all sync requests.
  */
 public abstract class BaseSyncRequest extends ShadowRequest implements SyncRequest {
-
-    int version;
-
-    @NonNull
-    Instant updateTime;
 
     @NonNull
     ShadowManagerDAO dao;
@@ -29,18 +22,12 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
      *
      * @param thingName  The thing name associated with the sync shadow update
      * @param shadowName The shadow name associated with the sync shadow update
-     * @param updateTime The update time of the specific sync shadow update
-     * @param version    The version of the specific sync shadow update
      * @param dao        Local shadow database management
      */
     public BaseSyncRequest(String thingName,
                            String shadowName,
-                           Instant updateTime,
-                           int version,
                            ShadowManagerDAO dao) {
         super(thingName, shadowName);
-        this.version = version;
-        this.updateTime = updateTime;
         this.dao = dao;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
@@ -7,37 +7,23 @@ package com.aws.greengrass.shadowmanager.sync.model;
 
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.SyncException;
-import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowIPCHandler;
-import lombok.NonNull;
-
-import java.time.Instant;
 
 /**
- * Sync request handling a delete from cloud.
+ * Sync request to delete shadow in the cloud.
  */
 public class CloudDeleteSyncRequest extends BaseSyncRequest {
-
-    @NonNull
-    DeleteThingShadowIPCHandler deleteThingShadowIPCHandler;
 
     /**
      * Ctr for CloudDeleteSyncRequest.
      *
      * @param thingName                   The thing name associated with the sync shadow update
      * @param shadowName                  The shadow name associated with the sync shadow update
-     * @param updateTime                  The update time of the specific sync shadow update
-     * @param version                     The version of the specific sync shadow update
      * @param dao                         Local shadow database management
-     * @param deleteThingShadowIPCHandler Reference to the DeleteThingShadow IPC Handler
      */
     public CloudDeleteSyncRequest(String thingName,
                                   String shadowName,
-                                  Instant updateTime,
-                                  int version,
-                                  ShadowManagerDAO dao,
-                                  DeleteThingShadowIPCHandler deleteThingShadowIPCHandler) {
-        super(thingName, shadowName, updateTime, version, dao);
-        this.deleteThingShadowIPCHandler = deleteThingShadowIPCHandler;
+                                  ShadowManagerDAO dao) {
+        super(thingName, shadowName, dao);
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
@@ -7,45 +7,24 @@ package com.aws.greengrass.shadowmanager.sync.model;
 
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.SyncException;
-import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowIPCHandler;
-import lombok.NonNull;
-
-import java.time.Instant;
 
 /**
- * Sync request handling an update from cloud.
+ * Sync request to update shadow in the cloud.
  */
 public class CloudUpdateSyncRequest extends BaseSyncRequest {
-
-    // TODO: determine update document type
-    String updateDocument;
-
-    @NonNull
-    UpdateThingShadowIPCHandler updateThingShadowIPCHandler;
 
     /**
      * Ctr for CloudUpdateSyncRequest.
      *
      * @param thingName                   The thing name associated with the sync shadow update
      * @param shadowName                  The shadow name associated with the sync shadow update
-     * @param updateTime                  The update time of the specific sync shadow update
-     * @param updateDocument              The update document from the cloud
-     * @param version                     The version of the specific sync shadow update
      * @param dao                         Local shadow database management
-     * @param updateThingShadowIPCHandler Reference to the UpdateThingShadow IPC Handler
      */
     public CloudUpdateSyncRequest(String thingName,
                                   String shadowName,
-                                  String updateDocument,
-                                  Instant updateTime,
-                                  int version,
-                                  ShadowManagerDAO dao,
-                                  UpdateThingShadowIPCHandler updateThingShadowIPCHandler) {
-        super(thingName, shadowName, updateTime, version, dao);
-        this.updateDocument = updateDocument;
-        this.updateThingShadowIPCHandler = updateThingShadowIPCHandler;
+                                  ShadowManagerDAO dao) {
+        super(thingName, shadowName, dao);
     }
-
 
     @Override
     public void execute() throws SyncException {

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -9,22 +9,18 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.exception.SyncException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowIPCHandler;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowIPCHandler;
-import com.aws.greengrass.shadowmanager.model.ShadowRequest;
 import lombok.NonNull;
 
 /**
  * Sync request handling a full sync request for a particular shadow.
  */
-public class FullShadowSyncRequest extends ShadowRequest implements SyncRequest {
-    @NonNull
-    ShadowManagerDAO dao;
+public class FullShadowSyncRequest extends BaseSyncRequest {
 
     @NonNull
     UpdateThingShadowIPCHandler updateThingShadowIPCHandler;
 
     @NonNull
     DeleteThingShadowIPCHandler deleteThingShadowIPCHandler;
-
 
     /**
      * Ctr for FullShadowSyncRequest.
@@ -40,8 +36,7 @@ public class FullShadowSyncRequest extends ShadowRequest implements SyncRequest 
                                  ShadowManagerDAO dao,
                                  UpdateThingShadowIPCHandler updateThingShadowIPCHandler,
                                  DeleteThingShadowIPCHandler deleteThingShadowIPCHandler) {
-        super(thingName, shadowName);
-        this.dao = dao;
+        super(thingName, shadowName, dao);
         this.updateThingShadowIPCHandler = updateThingShadowIPCHandler;
         this.deleteThingShadowIPCHandler = deleteThingShadowIPCHandler;
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequest.java
@@ -10,10 +10,8 @@ import com.aws.greengrass.shadowmanager.exception.SyncException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowIPCHandler;
 import lombok.NonNull;
 
-import java.time.Instant;
-
 /**
- * Sync request handling a delete from local shadow update.
+ * Sync request to delete a locally stored shadow.
  */
 public class LocalDeleteSyncRequest extends BaseSyncRequest {
 
@@ -25,18 +23,14 @@ public class LocalDeleteSyncRequest extends BaseSyncRequest {
      *
      * @param thingName                   The thing name associated with the sync shadow update
      * @param shadowName                  The shadow name associated with the sync shadow update
-     * @param updateTime                  The update time of the specific sync shadow update
-     * @param version                     The version of the specific sync shadow update
      * @param dao                         Local shadow database management
      * @param deleteThingShadowIPCHandler Reference to the DeleteThingShadow IPC Handler
      */
     public LocalDeleteSyncRequest(String thingName,
                                   String shadowName,
-                                  Instant updateTime,
-                                  int version,
                                   ShadowManagerDAO dao,
                                   DeleteThingShadowIPCHandler deleteThingShadowIPCHandler) {
-        super(thingName, shadowName, updateTime, version, dao);
+        super(thingName, shadowName, dao);
         this.deleteThingShadowIPCHandler = deleteThingShadowIPCHandler;
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -10,15 +10,10 @@ import com.aws.greengrass.shadowmanager.exception.SyncException;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowIPCHandler;
 import lombok.NonNull;
 
-import java.time.Instant;
-
 /**
- * Sync request handling an update from local shadow update.
+ * Sync request to update locally stored shadow.
  */
 public class LocalUpdateSyncRequest extends BaseSyncRequest {
-
-    // TODO: determine correct type
-    String updateDocument;
 
     @NonNull
     UpdateThingShadowIPCHandler updateThingShadowIPCHandler;
@@ -28,21 +23,14 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
      *
      * @param thingName                   The thing name associated with the sync shadow update
      * @param shadowName                  The shadow name associated with the sync shadow update
-     * @param updateTime                  The update time of the specific sync shadow update
-     * @param updateDocument              The update document from the local shadow update
-     * @param version                     The version of the specific sync shadow update
      * @param dao                         Local shadow database management
      * @param updateThingShadowIPCHandler Reference to the UpdateThingShadow IPC Handler
      */
     public LocalUpdateSyncRequest(String thingName,
                                   String shadowName,
-                                  String updateDocument,
-                                  Instant updateTime,
-                                  int version,
                                   ShadowManagerDAO dao,
                                   UpdateThingShadowIPCHandler updateThingShadowIPCHandler) {
-        super(thingName, shadowName, updateTime, version, dao);
-        this.updateDocument = updateDocument;
+        super(thingName, shadowName, dao);
         this.updateThingShadowIPCHandler = updateThingShadowIPCHandler;
     }
 


### PR DESCRIPTION
**Issue #, if available:**
Shadow-2

**Description of changes:**
1. Refactoring requests to pull version, updateTime, and updateDocument (if applicable) from dao instead of through parameters
2. Refactoring request to clear up ambiguous names
`CloudUpdateSyncRequest` -> Sync request to update shadow in cloud
`CloudDeleteSyncRequest` -> Sync request to delete shadow in cloud
`LocalUpdateSyncRequest` -> Sync request to update local shadow
`LocalDeleteSyncRequest` -> Sync request to delete local shadow
3. Cloud update/delete does not need reference to the respective IPC handler

**Why is this change necessary:**
To reduce IO expense of holding update documents, updateTime, and version for each request

**How was this change tested:**
Sync Request implementation have not yet been completed, regression unit tests passing

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
