### PR TITLE
fix: add localVersion to the sync table.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
@@ -252,15 +252,15 @@ class ShadowManagerDAOImplTest {
 
     static Stream<Arguments> validUpdateSyncInformationTests() {
         return Stream.of(
-                arguments(BASE_DOCUMENT, 1, false),
-                arguments(null, 2, true),
-                arguments(UPDATED_DOCUMENT, 3, false)
+                arguments(BASE_DOCUMENT, 1, false, 5),
+                arguments(null, 2, true, 6),
+                arguments(UPDATED_DOCUMENT, 3, false, 7 )
         );
     }
 
     @ParameterizedTest
     @MethodSource("validUpdateSyncInformationTests")
-    void GIVEN_valid_sync_information_WHEN_update_and_get_THEN_successfully_updates_and_gets_sync_information(byte[] cloudDocument, long cloudVersion, boolean cloudDeleted) {
+    void GIVEN_valid_sync_information_WHEN_update_and_get_THEN_successfully_updates_and_gets_sync_information(byte[] cloudDocument, long cloudVersion, boolean cloudDeleted, long localVersion) {
         long epochMinus60Seconds = Instant.now().minusSeconds(60).getEpochSecond();
         SyncInformation syncInformation = SyncInformation.builder()
                 .thingName(THING_NAME)
@@ -269,6 +269,7 @@ class ShadowManagerDAOImplTest {
                 .cloudVersion(cloudVersion)
                 .cloudUpdateTime(epochMinus60Seconds)
                 .cloudDocument(cloudDocument)
+                .localVersion(localVersion)
                 .build();
         assertTrue(dao.updateSyncInformation(syncInformation));
 
@@ -279,7 +280,7 @@ class ShadowManagerDAOImplTest {
 
     @ParameterizedTest
     @MethodSource("validUpdateSyncInformationTests")
-    void GIVEN_valid_sync_information_WHEN_update_delete_and_get_THEN_successfully_updates_and_deletes_sync_information(byte[] cloudDocument, long cloudVersion, boolean cloudDeleted) {
+    void GIVEN_valid_sync_information_WHEN_update_delete_and_get_THEN_successfully_updates_and_deletes_sync_information(byte[] cloudDocument, long cloudVersion, boolean cloudDeleted, long localVersion) {
         long epochMinus60Seconds = Instant.now().minusSeconds(60).getEpochSecond();
         SyncInformation syncInformation = SyncInformation.builder()
                 .thingName(THING_NAME)
@@ -288,6 +289,7 @@ class ShadowManagerDAOImplTest {
                 .cloudVersion(cloudVersion)
                 .cloudUpdateTime(epochMinus60Seconds)
                 .cloudDocument(cloudDocument)
+                .localVersion(localVersion)
                 .build();
         assertTrue(dao.updateSyncInformation(syncInformation));
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
@@ -153,7 +153,8 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
     @Override
     public boolean updateSyncInformation(final SyncInformation request) {
         return execute("MERGE INTO sync(thingName, shadowName, cloudDocument, cloudVersion, cloudDeleted, "
-                        + "cloudUpdateTime, lastSyncTime) KEY (thingName, shadowName) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        + "cloudUpdateTime, lastSyncTime, localVersion) KEY (thingName, shadowName) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 preparedStatement -> {
                     preparedStatement.setString(1, request.getThingName());
                     preparedStatement.setString(2, request.getShadowName());
@@ -162,6 +163,7 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
                     preparedStatement.setBoolean(5, request.isCloudDeleted());
                     preparedStatement.setLong(6, request.getCloudUpdateTime());
                     preparedStatement.setLong(7, request.getLastSyncTime());
+                    preparedStatement.setLong(8, request.getLocalVersion());
                     int result = preparedStatement.executeUpdate();
                     return result == 1;
                 });
@@ -176,8 +178,8 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
      */
     @Override
     public Optional<SyncInformation> getShadowSyncInformation(String thingName, String shadowName) {
-        return execute("SELECT cloudDocument, cloudVersion, cloudUpdateTime, lastSyncTime, cloudDeleted FROM sync "
-                        + "WHERE thingName = ? AND shadowName = ?",
+        return execute("SELECT cloudDocument, cloudVersion, cloudUpdateTime, lastSyncTime, cloudDeleted, "
+                        + "localVersion FROM sync WHERE thingName = ? AND shadowName = ?",
                 preparedStatement -> {
                     preparedStatement.setString(1, thingName);
                     preparedStatement.setString(2, shadowName);
@@ -189,6 +191,7 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
                                     .cloudUpdateTime(resultSet.getLong(3))
                                     .lastSyncTime(resultSet.getLong(4))
                                     .cloudDeleted(resultSet.getBoolean(5))
+                                    .localVersion(resultSet.getLong(6))
                                     .shadowName(shadowName)
                                     .thingName(thingName)
                                     .build());

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/dao/SyncInformation.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/dao/SyncInformation.java
@@ -18,6 +18,7 @@ public class SyncInformation {
     private String thingName;
     private String shadowName;
     private byte[] cloudDocument;
+    private long localVersion;
     private long cloudVersion;
     private long cloudUpdateTime;
     @Builder.Default

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
@@ -14,7 +14,6 @@ import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalUpdateSyncRequest;
 
-import java.time.Instant;
 import javax.inject.Inject;
 
 /**

--- a/src/main/resources/db/migration/V1__InitialRelease.sql
+++ b/src/main/resources/db/migration/V1__InitialRelease.sql
@@ -12,6 +12,7 @@ CREATE TABLE sync (
     thingName VARCHAR(255) NOT NULL,
     shadowName VARCHAR(255) NOT NULL,
     cloudDocument TEXT,
+    localVersion NUMBER,
     cloudVersion NUMBER,
     cloudDeleted BIT,
     cloudUpdateTime NUMBER,

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
@@ -146,7 +146,7 @@ class ShadowManagerDAOImplTest {
 
     private void assertUpdateShadowSyncStatementMocks(long epochNow) {
         assertThat(stringArgumentCaptor.getAllValues().size(), is(2));
-        assertThat(longArgumentCaptor.getAllValues().size(), is(3));
+        assertThat(longArgumentCaptor.getAllValues().size(), is(4));
         assertThat(bytesArgumentCaptor.getValue(), is(notNullValue()));
         assertThat(booleanArgumentCaptor.getValue(), is(notNullValue()));
 
@@ -157,6 +157,7 @@ class ShadowManagerDAOImplTest {
         assertThat(longArgumentCaptor.getAllValues().get(0), is(2L));
         assertThat(longArgumentCaptor.getAllValues().get(1), is(lessThanOrEqualTo(epochNow)));
         assertThat(longArgumentCaptor.getAllValues().get(2), is(greaterThanOrEqualTo(epochNow)));
+        assertThat(longArgumentCaptor.getAllValues().get(3), is(5L));
     }
 
     private void assertDeleteShadowSyncMocks() {
@@ -178,6 +179,7 @@ class ShadowManagerDAOImplTest {
         doNothing().when(mockPreparedStatement).setBoolean(eq(5), booleanArgumentCaptor.capture());
         doNothing().when(mockPreparedStatement).setLong(eq(6), longArgumentCaptor.capture());
         doNothing().when(mockPreparedStatement).setLong(eq(7), longArgumentCaptor.capture());
+        doNothing().when(mockPreparedStatement).setLong(eq(8), longArgumentCaptor.capture());
     }
 
     @BeforeEach
@@ -364,6 +366,7 @@ class ShadowManagerDAOImplTest {
                 .cloudUpdateTime(Instant.now().minusSeconds(60).getEpochSecond())
                 .cloudVersion(2)
                 .cloudDocument(BASE_DOCUMENT)
+                .localVersion(5)
                 .build()));
 
         assertUpdateShadowSyncStatementMocks(epochNow);
@@ -381,6 +384,7 @@ class ShadowManagerDAOImplTest {
                 .shadowName(SHADOW_NAME)
                 .cloudUpdateTime(Instant.now().minusSeconds(60).getEpochSecond())
                 .cloudVersion(2)
+                .localVersion(5)
                 .cloudDocument(BASE_DOCUMENT)
                 .build()));
 
@@ -400,6 +404,7 @@ class ShadowManagerDAOImplTest {
                 .cloudUpdateTime(Instant.now().minusSeconds(60).getEpochSecond())
                 .cloudVersion(2)
                 .cloudDocument(BASE_DOCUMENT)
+                .localVersion(5)
                 .build()));
         assertUpdateShadowSyncStatementMocks(epochNow);
     }
@@ -414,6 +419,7 @@ class ShadowManagerDAOImplTest {
         when(mockResultSet.getLong(3)).thenReturn(epochMinus60Seconds);
         when(mockResultSet.getLong(4)).thenReturn(epochNow);
         when(mockResultSet.getBoolean(5)).thenReturn(true);
+        when(mockResultSet.getLong(6)).thenReturn(5L);
         when(mockResultSet.next()).thenReturn(true);
         when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
 
@@ -425,6 +431,7 @@ class ShadowManagerDAOImplTest {
         assertThat(shadowSyncInformation.get().getCloudUpdateTime(), is(epochMinus60Seconds));
         assertThat(shadowSyncInformation.get().getLastSyncTime(), is(epochNow));
         assertThat(shadowSyncInformation.get().getCloudVersion(), is(2L));
+        assertThat(shadowSyncInformation.get().getLocalVersion(), is(5L));
         assertThat(shadowSyncInformation.get().getShadowName(), is(SHADOW_NAME));
         assertThat(shadowSyncInformation.get().getThingName(), is(THING_NAME));
         assertGetShadowStatementMocks();


### PR DESCRIPTION
**Issue #, if available:**
Shadow-2

**Description of changes:**
Add `localVersion` to the sync table.

**Why is this change necessary:**
`localVersion` will be used in the `Request` models for sync to determine what version of the local shadow we are going to update/delete.

**How was this change tested:**
Updated unit and integration tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
