### PR TITLE
refactor: store iotdevicesdk generated abstract handlers

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -129,14 +129,14 @@ public class ShadowManager extends PluginService {
                     .log("Failed to initialize the ShadowManager service with the Authorization module.");
         }
 
-        greengrassCoreIPCService.setGetThingShadowHandler(context -> new GetThingShadowIPCHandler(context,
+        greengrassCoreIPCService.setOperationHandler(GET_THING_SHADOW, context -> new GetThingShadowIPCHandler(context,
                 dao, authorizationHandlerWrapper, pubSubClientWrapper));
-        greengrassCoreIPCService.setDeleteThingShadowHandler(context -> new DeleteThingShadowIPCHandler(context,
-                deleteThingShadowRequestHandler));
-        greengrassCoreIPCService.setUpdateThingShadowHandler(context -> new UpdateThingShadowIPCHandler(context,
-                updateThingShadowRequestHandler));
-        greengrassCoreIPCService.setListNamedShadowsForThingHandler(context -> new ListNamedShadowsForThingIPCHandler(
-                context, dao, authorizationHandlerWrapper));
+        greengrassCoreIPCService.setOperationHandler(DELETE_THING_SHADOW, context ->
+                new DeleteThingShadowIPCHandler(context, deleteThingShadowRequestHandler));
+        greengrassCoreIPCService.setOperationHandler(UPDATE_THING_SHADOW, context ->
+                new UpdateThingShadowIPCHandler(context, updateThingShadowRequestHandler));
+        greengrassCoreIPCService.setOperationHandler(LIST_NAMED_SHADOWS_FOR_THING, context ->
+                new ListNamedShadowsForThingIPCHandler(context, dao, authorizationHandlerWrapper));
     }
 
     void handleDeviceThingNameChange(Object whatHappened, Node changedNode) {

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractDeleteThingShadowOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractDeleteThingShadowOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractDeleteThingShadowOperationHandler extends OperationContinuationHandler<DeleteThingShadowRequest, DeleteThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractDeleteThingShadowOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<DeleteThingShadowRequest, DeleteThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getDeleteThingShadowModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetThingShadowOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractGetThingShadowOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.GetThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.GetThingShadowResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractGetThingShadowOperationHandler extends OperationContinuationHandler<GetThingShadowRequest, GetThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractGetThingShadowOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<GetThingShadowRequest, GetThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getGetThingShadowModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListNamedShadowsForThingOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractListNamedShadowsForThingOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.ListNamedShadowsForThingRequest;
+import software.amazon.awssdk.aws.greengrass.model.ListNamedShadowsForThingResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractListNamedShadowsForThingOperationHandler extends OperationContinuationHandler<ListNamedShadowsForThingRequest, ListNamedShadowsForThingResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractListNamedShadowsForThingOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<ListNamedShadowsForThingRequest, ListNamedShadowsForThingResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getListNamedShadowsForThingModelContext();
+  }
+}

--- a/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateThingShadowOperationHandler.java
+++ b/src/main/java/software/amazon/awssdk/aws/greengrass/GeneratedAbstractUpdateThingShadowOperationHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.awssdk.aws.greengrass;
+
+import java.lang.Override;
+import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandler;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.OperationModelContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+public abstract class GeneratedAbstractUpdateThingShadowOperationHandler extends OperationContinuationHandler<UpdateThingShadowRequest, UpdateThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> {
+  protected GeneratedAbstractUpdateThingShadowOperationHandler(
+      OperationContinuationHandlerContext context) {
+    super(context);
+  }
+
+  @Override
+  public OperationModelContext<UpdateThingShadowRequest, UpdateThingShadowResponse, EventStreamJsonMessage, EventStreamJsonMessage> getOperationModelContext(
+      ) {
+    return GreengrassCoreIPCServiceModel.getUpdateThingShadowModelContext();
+  }
+}


### PR DESCRIPTION
**Issue #, if available:**
Shadow-1 

**Description of changes:**
Maintain generated iotdevicesdk code in ShadowManager repo instead of nucleus.

**Why is this change necessary:**
Keep ShadowManager related code in ShadowManager.

**How was this change tested:**
Compiled code with stripped down nucleus.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
