### PR TITLE
refactor: rename cloudDocument to lastSyncedDocument in sync table.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
@@ -274,7 +274,7 @@ class ShadowManagerDAOImplTest {
 
     @ParameterizedTest
     @MethodSource("validUpdateSyncInformationTests")
-    void GIVEN_valid_sync_information_WHEN_update_and_get_THEN_successfully_updates_and_gets_sync_information(byte[] cloudDocument, long cloudVersion, boolean cloudDeleted, long localVersion) {
+    void GIVEN_valid_sync_information_WHEN_update_and_get_THEN_successfully_updates_and_gets_sync_information(byte[] lastSyncedDocument, long cloudVersion, boolean cloudDeleted, long localVersion) {
         long epochMinus60Seconds = Instant.now().minusSeconds(60).getEpochSecond();
         SyncInformation syncInformation = SyncInformation.builder()
                 .thingName(THING_NAME)
@@ -282,7 +282,7 @@ class ShadowManagerDAOImplTest {
                 .cloudDeleted(cloudDeleted)
                 .cloudVersion(cloudVersion)
                 .cloudUpdateTime(epochMinus60Seconds)
-                .cloudDocument(cloudDocument)
+                .lastSyncedDocument(lastSyncedDocument)
                 .localVersion(localVersion)
                 .build();
         assertTrue(dao.updateSyncInformation(syncInformation));
@@ -294,7 +294,7 @@ class ShadowManagerDAOImplTest {
 
     @ParameterizedTest
     @MethodSource("validUpdateSyncInformationTests")
-    void GIVEN_valid_sync_information_WHEN_update_delete_and_get_THEN_successfully_updates_and_deletes_sync_information(byte[] cloudDocument, long cloudVersion, boolean cloudDeleted, long localVersion) {
+    void GIVEN_valid_sync_information_WHEN_update_delete_and_get_THEN_successfully_updates_and_deletes_sync_information(byte[] lastSyncedDocument, long cloudVersion, boolean cloudDeleted, long localVersion) {
         long epochMinus60Seconds = Instant.now().minusSeconds(60).getEpochSecond();
         SyncInformation syncInformation = SyncInformation.builder()
                 .thingName(THING_NAME)
@@ -302,7 +302,7 @@ class ShadowManagerDAOImplTest {
                 .cloudDeleted(cloudDeleted)
                 .cloudVersion(cloudVersion)
                 .cloudUpdateTime(epochMinus60Seconds)
-                .cloudDocument(cloudDocument)
+                .lastSyncedDocument(lastSyncedDocument)
                 .localVersion(localVersion)
                 .build();
         assertTrue(dao.updateSyncInformation(syncInformation));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -158,7 +158,7 @@ class ShadowManagerTest extends GGServiceTestUtil {
                     .cloudDeleted(false)
                     .cloudVersion(1)
                     .cloudUpdateTime(epochMinus60Seconds)
-                    .cloudDocument(BASE_DOCUMENT)
+                    .lastSyncedDocument(BASE_DOCUMENT)
                     .build();
             assertTrue(impl.updateSyncInformation(syncInformation));
         }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
@@ -152,13 +152,13 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
      */
     @Override
     public boolean updateSyncInformation(final SyncInformation request) {
-        return execute("MERGE INTO sync(thingName, shadowName, cloudDocument, cloudVersion, cloudDeleted, "
+        return execute("MERGE INTO sync(thingName, shadowName, lastSyncedDocument, cloudVersion, cloudDeleted, "
                         + "cloudUpdateTime, lastSyncTime, localVersion) KEY (thingName, shadowName) "
                         + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 preparedStatement -> {
                     preparedStatement.setString(1, request.getThingName());
                     preparedStatement.setString(2, request.getShadowName());
-                    preparedStatement.setBytes(3, request.getCloudDocument());
+                    preparedStatement.setBytes(3, request.getLastSyncedDocument());
                     preparedStatement.setLong(4, request.getCloudVersion());
                     preparedStatement.setBoolean(5, request.isCloudDeleted());
                     preparedStatement.setLong(6, request.getCloudUpdateTime());
@@ -178,7 +178,7 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
      */
     @Override
     public Optional<SyncInformation> getShadowSyncInformation(String thingName, String shadowName) {
-        return execute("SELECT cloudDocument, cloudVersion, cloudUpdateTime, lastSyncTime, cloudDeleted, "
+        return execute("SELECT lastSyncedDocument, cloudVersion, cloudUpdateTime, lastSyncTime, cloudDeleted, "
                         + "localVersion FROM sync WHERE thingName = ? AND shadowName = ?",
                 preparedStatement -> {
                     preparedStatement.setString(1, thingName);
@@ -186,7 +186,7 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
                     try (ResultSet resultSet = preparedStatement.executeQuery()) {
                         if (resultSet.next()) {
                             return Optional.ofNullable(SyncInformation.builder()
-                                    .cloudDocument(resultSet.getBytes(1))
+                                    .lastSyncedDocument(resultSet.getBytes(1))
                                     .cloudVersion(resultSet.getLong(2))
                                     .cloudUpdateTime(resultSet.getLong(3))
                                     .lastSyncTime(resultSet.getLong(4))

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/dao/SyncInformation.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/dao/SyncInformation.java
@@ -17,7 +17,7 @@ import java.time.Instant;
 public class SyncInformation {
     private String thingName;
     private String shadowName;
-    private byte[] cloudDocument;
+    private byte[] lastSyncedDocument;
     private long localVersion;
     private long cloudVersion;
     private long cloudUpdateTime;

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
@@ -86,7 +86,7 @@ public class CloudDeleteSyncRequest extends BaseSyncRequest {
         Optional<SyncInformation> syncInformation = this.dao.getShadowSyncInformation(getThingName(), getShadowName());
         try {
             this.dao.updateSyncInformation(SyncInformation.builder()
-                    .cloudDocument(null)
+                    .lastSyncedDocument(null)
                     .cloudVersion(syncInformation.map(SyncInformation::getCloudVersion).orElse(0L))
                     .cloudDeleted(true)
                     .shadowName(getShadowName())

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
@@ -112,7 +112,7 @@ public class CloudUpdateSyncRequest extends BaseSyncRequest {
 
         try {
             this.dao.updateSyncInformation(SyncInformation.builder()
-                    .cloudDocument(JsonUtil.getPayloadBytes(shadowDocument.get().toJson(false)))
+                    .lastSyncedDocument(JsonUtil.getPayloadBytes(shadowDocument.get().toJson(false)))
                     .cloudVersion(cloudVersion + 1)
                     .cloudDeleted(false)
                     .shadowName(getShadowName())

--- a/src/main/resources/db/migration/V1__InitialRelease.sql
+++ b/src/main/resources/db/migration/V1__InitialRelease.sql
@@ -11,7 +11,7 @@ CREATE TABLE documents (
 CREATE TABLE sync (
     thingName VARCHAR(255) NOT NULL,
     shadowName VARCHAR(255) NOT NULL,
-    cloudDocument TEXT,
+    lastSyncedDocument TEXT,
     localVersion NUMBER,
     cloudVersion NUMBER,
     cloudDeleted BIT,

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
@@ -365,7 +365,7 @@ class ShadowManagerDAOImplTest {
                 .shadowName(SHADOW_NAME)
                 .cloudUpdateTime(Instant.now().minusSeconds(60).getEpochSecond())
                 .cloudVersion(2)
-                .cloudDocument(BASE_DOCUMENT)
+                .lastSyncedDocument(BASE_DOCUMENT)
                 .localVersion(5)
                 .build()));
 
@@ -385,7 +385,7 @@ class ShadowManagerDAOImplTest {
                 .cloudUpdateTime(Instant.now().minusSeconds(60).getEpochSecond())
                 .cloudVersion(2)
                 .localVersion(5)
-                .cloudDocument(BASE_DOCUMENT)
+                .lastSyncedDocument(BASE_DOCUMENT)
                 .build()));
 
         assertUpdateShadowSyncStatementMocks(epochNow);
@@ -403,7 +403,7 @@ class ShadowManagerDAOImplTest {
                 .shadowName(SHADOW_NAME)
                 .cloudUpdateTime(Instant.now().minusSeconds(60).getEpochSecond())
                 .cloudVersion(2)
-                .cloudDocument(BASE_DOCUMENT)
+                .lastSyncedDocument(BASE_DOCUMENT)
                 .localVersion(5)
                 .build()));
         assertUpdateShadowSyncStatementMocks(epochNow);
@@ -427,7 +427,7 @@ class ShadowManagerDAOImplTest {
         Optional<SyncInformation> shadowSyncInformation = impl.getShadowSyncInformation(THING_NAME, SHADOW_NAME);
 
         assertThat(shadowSyncInformation, is(notNullValue()));
-        assertThat(shadowSyncInformation.get().getCloudDocument(), is(BASE_DOCUMENT));
+        assertThat(shadowSyncInformation.get().getLastSyncedDocument(), is(BASE_DOCUMENT));
         assertThat(shadowSyncInformation.get().getCloudUpdateTime(), is(epochMinus60Seconds));
         assertThat(shadowSyncInformation.get().getLastSyncTime(), is(epochNow));
         assertThat(shadowSyncInformation.get().getCloudVersion(), is(2L));
@@ -461,7 +461,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_existing_shadow_WHEN_deleteCloudDocumentInformationInSync_THEN_deletes_shadow_document() throws SQLException {
+    void GIVEN_existing_shadow_WHEN_deleteSyncInformation_THEN_deletes_shadow_document() throws SQLException {
         setupDeleteShadowSyncMocks();
 
         when(mockPreparedStatement.executeUpdate()).thenReturn(1);
@@ -472,7 +472,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_existing_shadow_WHEN_deleteCloudDocumentInformationInSync_and_h2_returns_0_rows_deleted_THEN_returns_empty_optional() throws SQLException {
+    void GIVEN_existing_shadow_WHEN_deleteSyncInformation_and_h2_returns_0_rows_deleted_THEN_returns_empty_optional() throws SQLException {
         setupDeleteShadowSyncMocks();
 
         when(mockPreparedStatement.executeUpdate()).thenReturn(0);
@@ -483,7 +483,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_existing_shadow_WHEN_deleteCloudDocumentInformationInSync_and_h2_throws_SQL_exception_THEN_ShadowManagerDataException_is_thrown() throws SQLException {
+    void GIVEN_existing_shadow_WHEN_deleteSyncInformation_and_h2_throws_SQL_exception_THEN_ShadowManagerDataException_is_thrown() throws SQLException {
         setupDeleteShadowSyncMocks();
 
         when(mockPreparedStatement.executeUpdate()).thenThrow(SQLException.class);

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequestTest.java
@@ -83,7 +83,7 @@ class CloudDeleteSyncRequestTest {
                 .thingName(THING_NAME)
                 .shadowName(SHADOW_NAME)
                 .cloudDeleted(false)
-                .cloudDocument(BASE_DOCUMENT)
+                .lastSyncedDocument(BASE_DOCUMENT)
                 .cloudVersion(1L)
                 .lastSyncTime(epochSecondsMinus60)
                 .build()));
@@ -97,7 +97,7 @@ class CloudDeleteSyncRequestTest {
         verify(mockIotDataPlaneClient, times(1)).deleteThingShadow(any(DeleteThingShadowRequest.class));
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudDocument(), is(nullValue()));
+        assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
         assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
@@ -120,7 +120,7 @@ class CloudDeleteSyncRequestTest {
         verify(mockIotDataPlaneClient, times(1)).deleteThingShadow(any(DeleteThingShadowRequest.class));
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudDocument(), is(nullValue()));
+        assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
         assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(0L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequestTest.java
@@ -89,7 +89,7 @@ class CloudUpdateSyncRequestTest {
                 .thingName(THING_NAME)
                 .shadowName(SHADOW_NAME)
                 .cloudDeleted(false)
-                .cloudDocument(BASE_DOCUMENT)
+                .lastSyncedDocument(BASE_DOCUMENT)
                 .cloudVersion(5L)
                 .lastSyncTime(epochSecondsMinus60)
                 .build()));
@@ -104,7 +104,7 @@ class CloudUpdateSyncRequestTest {
         verify(mockIotDataPlaneClient, times(1)).updateThingShadow(any(UpdateThingShadowRequest.class));
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudDocument(), is(JsonUtil.getPayloadBytes(shadowDocument.toJson(false))));
+        assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(JsonUtil.getPayloadBytes(shadowDocument.toJson(false))));
         assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(6L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));


### PR DESCRIPTION
**Issue #, if available:**
Shadow-2

**Description of changes:**
Rename `cloudDocument` to `lastSyncedDocument` in the sync table since that is column refers to the last time a sync was successful for that shadow. So at that point both the cloud document and the local document must have the same state (though versions might be different).

**Why is this change necessary:**
This document will be used as the base document when resolving any conflicts during a full sync.

**How was this change tested:**
all tests are passing after the refactor.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
