### PR TITLE
feat: initialize sync info on successful config processing.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -171,7 +171,20 @@ class ShadowManagerTest extends GGServiceTestUtil {
         createThingShadowSyncInfo(impl, THING_NAME);
         createThingShadowSyncInfo(impl, THING_NAME2);
 
-        List<Map<String, Object>> shadowDocumentsList = new ArrayList<>();
+        List<Pair<String, String>> allSyncedShadowNames = impl.listSyncedShadows();
+        assertThat(allSyncedShadowNames, containsInAnyOrder(
+                new Pair<>(THING_NAME, "Shadow-0"),
+                new Pair<>(THING_NAME, "Shadow-1"),
+                new Pair<>(THING_NAME, "Shadow-2"),
+                new Pair<>(THING_NAME, "Shadow-3"),
+                new Pair<>(THING_NAME, "Shadow-4"),
+                new Pair<>(THING_NAME2, "Shadow-0"),
+                new Pair<>(THING_NAME2, "Shadow-1"),
+                new Pair<>(THING_NAME2, "Shadow-2"),
+                new Pair<>(THING_NAME2, "Shadow-3"),
+                new Pair<>(THING_NAME2, "Shadow-4")));
+
+    List<Map<String, Object>> shadowDocumentsList = new ArrayList<>();
         Map<String, Object> thingAMap = new HashMap<>();
         thingAMap.put(CONFIGURATION_THING_NAME_TOPIC, THING_NAME);
         thingAMap.put(CONFIGURATION_CLASSIC_SHADOW_TOPIC, false);
@@ -184,10 +197,12 @@ class ShadowManagerTest extends GGServiceTestUtil {
         shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY).lookupTopics(CONFIGURATION_SYNCHRONIZATION_TOPIC)
                 .replaceAndWait(Collections.singletonMap(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC, shadowDocumentsList));
 
-        List<Pair<String, String>> allSyncedShadowNames = impl.listSyncedShadows();
+        allSyncedShadowNames = impl.listSyncedShadows();
         assertThat(allSyncedShadowNames, containsInAnyOrder(
                 new Pair<>(THING_NAME, "Shadow-0"),
                 new Pair<>(THING_NAME, "Shadow-1"),
-                new Pair<>(THING_NAME2, "Shadow-0")));
+                new Pair<>(THING_NAME2, ""),
+                new Pair<>(THING_NAME2, "Shadow-0"),
+                new Pair<>(THING_NAME2, "Shadow-5")));
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
@@ -79,9 +79,17 @@ public interface ShadowManagerDAO {
     /**
      * Attempts to delete the cloud shadow document in the sync table.
      *
-     * @param thingName       Name of the Thing for the shadow topic prefix.
-     * @param shadowName      Name of shadow topic prefix for thing.
+     * @param thingName  Name of the Thing for the shadow topic prefix.
+     * @param shadowName Name of shadow topic prefix for thing.
      * @return true if the cloud document (soft) delete was successful or not.
      */
     boolean deleteSyncInformation(String thingName, String shadowName);
+
+    /**
+     * Attempts to insert a new sync information row for a thing's shadow if it does not exist.
+     *
+     * @param request The update shadow sync information request containing the necessary information to update.
+     * @return true if the insert is successful; Else false.
+     */
+    boolean insertSyncInfoIfNotExists(SyncInformation request);
 }

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.shadowmanager.exception.InvalidConfigurationException;
 import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.ipc.PubSubClientWrapper;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
 import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import com.aws.greengrass.shadowmanager.util.Validator;
@@ -111,6 +112,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowManager.install();
         assertFalse(shadowManager.isErrored());
         verify(mockDatabase, times(1)).setMaxDiskUtilization(intObjectCaptor.capture());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
         assertThat(intObjectCaptor.getValue(), is(notNullValue()));
         assertThat(intObjectCaptor.getValue(), is(maxDiskUtilizationMB));
     }
@@ -130,6 +132,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @ParameterizedTest
@@ -148,6 +151,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
 
         assertFalse(shadowManager.isErrored());
         assertThat(Validator.getMaxShadowDocumentSize(), is(maxDocSize));
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @ParameterizedTest
@@ -165,6 +169,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @Test
@@ -218,6 +223,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         });
         assertThat(shadowManager.getSyncConfiguration().getMaxOutboundSyncUpdatesPerSecond(), is(500));
         assertThat(shadowManager.getSyncConfiguration().isProvideSyncStatus(), is(true));
+        verify(mockDao, times(6)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @Test
@@ -271,6 +277,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         });
         assertThat(shadowManager.getSyncConfiguration().getMaxOutboundSyncUpdatesPerSecond(), is(500));
         assertThat(shadowManager.getSyncConfiguration().isProvideSyncStatus(), is(true));
+        verify(mockDao, times(6)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @Test
@@ -318,6 +325,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
                 fail("Encountered unknown thing in sync configurations list: " + thingShadowSyncConfiguration.getThingName());
             }
         });
+        verify(mockDao, times(2)).insertSyncInfoIfNotExists(any(SyncInformation.class));
 
     }
 
@@ -346,6 +354,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @Test
@@ -373,6 +382,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @Test
@@ -396,6 +406,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @Test
@@ -417,6 +428,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @ParameterizedTest
@@ -453,6 +465,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
     @ParameterizedTest
@@ -491,5 +504,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper, mockPubSubClientWrapper, mockDeviceConfiguration, mockSynchronizeHelper, mockClientFactory);
         shadowManager.install();
         assertTrue(shadowManager.isErrored());
+        verify(mockDao, times(0)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Shadow-2

**Description of changes:**
After a successful configuration has been processed, go ahead and insert a default sync info row in the `sync` table.
This insert a new row for sync info if there isn't already one in the DB.

**Why is this change necessary:**
This will be useful in the full sync situation where there needs to be a sync info to properly gauge whats the proper approach.

**How was this change tested:**
Add unit tests and integration tests.

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
