### PR TITLE
fix: Allow ShadowManager to update any shadow

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/AuthorizationHandlerWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/AuthorizationHandlerWrapper.java
@@ -66,6 +66,10 @@ public class AuthorizationHandlerWrapper {
      */
     public void doAuthorization(String opCode, String serviceName, String resource)
             throws AuthorizationException {
+        // shadow manager is always authorized to udpate shadows
+        if (serviceName.equals(SHADOW_MANAGER_NAME)) {
+            return;
+        }
         authorizationHandler.isAuthorized(
                 SHADOW_MANAGER_NAME,
                 Permission.builder()

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/AuthorizationHandlerWrapperTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/AuthorizationHandlerWrapperTest.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.shadowmanager.AuthorizationHandlerWrapper;
+import com.aws.greengrass.shadowmanager.ShadowManager;
 import com.aws.greengrass.shadowmanager.model.ShadowRequest;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.Test;
@@ -83,5 +84,15 @@ public class AuthorizationHandlerWrapperTest {
                 () -> authorizationHandlerWrapper.registerComponent(TEST_SERVICE, TEST_OPERATIONS_SET));
 
         assertThat(thrown.getMessage(), is(equalTo(SAMPLE_EXCEPTION_MESSAGE)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {SHADOW_NAME})
+    void GIVEN_shadow_manager_WHEN_perform_action_THEN_authorized(String shadowName)  {
+        AuthorizationHandlerWrapper authorizationHandlerWrapper = new AuthorizationHandlerWrapper(mockAuthorizationHandler);
+        ShadowRequest shadowRequest = new ShadowRequest(THING_NAME, shadowName);
+        assertDoesNotThrow(() -> authorizationHandlerWrapper.doAuthorization(OP_CODE, ShadowManager.SERVICE_NAME,
+                shadowRequest ));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Whitelist ShadowManager to be authorized for shadow updates

**Why is this change necessary:**
To allow ShadowManager to update shadows when reacting to sync events

**How was this change tested:**
Unit tests

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
