### PR TITLE
fix: Default to empty collection for shadow names to avoid null pointer

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ThingShadowSyncConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ThingShadowSyncConfiguration.java
@@ -31,6 +31,7 @@ public class ThingShadowSyncConfiguration {
     @Builder.Default
     private boolean syncClassicShadow = true;
     @JsonProperty(CONFIGURATION_NAMED_SHADOWS_TOPIC)
+    @Builder.Default
     private List<String> syncNamedShadows = Collections.emptyList();
     @Builder.Default
     private boolean isNucleusThing = false;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Sets the collection to an empty list by default

**Why is this change necessary:**
If named shadows are not specified, this will default to `null` and cause NPE

**How was this change tested:**
integration test (in progress) without named shadows

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
