### PR TITLE
fix: Check local and cloud to determine if update is actually necessary

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.shadowmanager.ShadowManager;
+import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
+import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
+import com.aws.greengrass.shadowmanager.model.ShadowDocument;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowRequest;
+import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowResponse;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class SyncTest extends GGServiceTestUtil  {
+    private static final long TEST_TIME_OUT_SEC = 30L;
+    public static final String MOCK_THING_NAME = "Thing1";
+    public static final String CLASSIC_SHADOW = "";
+    private static final String cloudShadowContentV10 = "{\"version\":10,\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
+    private static final String localShadowContentV1 = "{\"state\":{\"desired\":{\"SomeKey\":\"foo\"}},\"metadata\":{}}";
+
+    Kernel kernel;
+    ShadowManager shadowManager;
+    GlobalStateChangeListener listener;
+
+    @TempDir
+    Path rootDir;
+
+    @Mock
+    MqttClient mqttClient;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    IotDataPlaneClientFactory iotDataPlaneClientFactory;
+
+    @BeforeEach
+    void setup() {
+        kernel = new Kernel();
+    }
+
+    @AfterEach
+    void cleanup() {
+        kernel.shutdown();
+    }
+
+    private void startNucleusWithConfig(String configFile) throws InterruptedException {
+        CountDownLatch shadowManagerRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+                getClass().getResource(configFile).toString());
+        listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(ShadowManager.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
+                shadowManagerRunning.countDown();
+                shadowManager = (ShadowManager) service;
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+
+        kernel.getContext().put(MqttClient.class, mqttClient);
+        // assume we are always connected
+        lenient().when(mqttClient.connected()).thenReturn(true);
+
+        kernel.getContext().put(IotDataPlaneClientFactory.class, iotDataPlaneClientFactory);
+        kernel.launch();
+
+        assertTrue(shadowManagerRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void GIVEN_sync_config_and_no_local_WHEN_startup_THEN_local_version_updated_via_full_sync(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, InterruptedException.class);
+
+        GetThingShadowResponse shadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(shadowResponse.payload().asByteArray()).thenReturn(cloudShadowContentV10.getBytes(UTF_8));
+
+        // existing document
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()
+                .getThingShadow(any(GetThingShadowRequest.class))).thenReturn(shadowResponse);
+        startNucleusWithConfig("sync.yaml");
+
+        ShadowManagerDAO dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
+
+        JsonNode v1 = JsonUtil.getPayloadJson(localShadowContentV1.getBytes(UTF_8)).get();
+        eventually(() -> {
+            Optional<SyncInformation> syncInformation =
+                    dao.getShadowSyncInformation(MOCK_THING_NAME, CLASSIC_SHADOW);
+            assertThat("sync info exists", syncInformation.isPresent(), is(true));
+            assertThat(syncInformation.get().getCloudVersion(), is(10L));
+            assertThat(syncInformation.get().getLocalVersion(), is(1L));
+
+            Optional<ShadowDocument> shadow = dao.getShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW);
+            assertThat("local shadow exists", shadow.isPresent(), is(true));
+            ShadowDocument shadowDocument = shadow.get();
+            // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
+            shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
+            assertThat(shadowDocument.toJson(false), is(v1));
+            return null;
+        }, 10, ChronoUnit.SECONDS);
+
+        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), never()).updateThingShadow(
+                any(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest.class));
+    }
+
+    void eventually(Supplier<Void> supplier, long timeout, ChronoUnit unit) throws InterruptedException {
+        Instant expire = Instant.now().plus(Duration.of(timeout, unit));
+        while (expire.isAfter(Instant.now())) {
+            try {
+                supplier.get();
+                return;
+            } catch (AssertionError e) {
+                // ignore
+            }
+            Thread.sleep(500);
+        }
+        supplier.get();
+    }
+
+    @Disabled
+    @Test
+    void GIVEN_sync_config_and_no_cloud_WHEN_startup_THEN_cloud_version_updated_via_full_sync() {
+
+    }
+
+    @Disabled
+    @Test
+    void GIVEN_synced_shadow_WHEN_local_update_THEN_cloud_updates() {
+
+    }
+
+    @Disabled
+    @Test
+    void GIVEN_synced_shadow_WHEN_cloud_update_THEN_local_updates() {
+
+    }
+
+    @Disabled
+    @Test
+    void GIVEN_synced_shadow_WHEN_local_delete_THEN_cloud_deletes() {
+
+    }
+
+    @Disabled
+    @Test
+    void GIVEN_synced_shadow_WHEN_cloud_delete_THEN_local_deletes() {
+
+    }
+
+    @Disabled
+    @Test
+    void GIVEN_unsynced_shadow_WHEN_cloud_updates_THEN_no_local_update() {
+
+    }
+    @Disabled
+    @Test
+    void GIVEN_unsynced_shadow_WHEN_local_updates_THEN_no_cloud_update() {
+
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync.yaml
@@ -1,0 +1,47 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.ShadowManager:
+    configuration:
+      synchronize:
+        shadowDocuments:
+          - thingName: Thing1
+            classic: true
+
+  main:
+    dependencies:
+      - DoAll
+  DoAll:
+    lifecycle:
+      all:
+        run:
+          echo "Running"
+    dependencies:
+      - aws.greengrass.ShadowManager
+    configuration:
+      accessControl:
+        aws.greengrass.ShadowManager:
+          policyId1:
+            policyDescription: access to CRUD shadow operations
+            operations:
+              - 'aws.greengrass#GetThingShadow'
+              - 'aws.greengrass#UpdateThingShadow'
+              - 'aws.greengrass#DeleteThingShadow'
+            resources:
+              - '*'
+          policyId2:
+            policyDescription: access to list named shadows
+            operations:
+              - 'aws.greengrass#ListNamedShadowsForThing'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId3:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+            resources:
+              - '*'

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
@@ -5,7 +5,14 @@
 
 package com.aws.greengrass.shadowmanager.sync.model;
 
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.model.ShadowRequest;
+import com.aws.greengrass.shadowmanager.util.JsonMerger;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Base class for all sync requests.
@@ -21,5 +28,38 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
     public BaseSyncRequest(String thingName,
                            String shadowName) {
         super(thingName, shadowName);
+    }
+
+    /**
+     * Answer whether the update is already part of the shadow.
+     *
+     * @param baseDocument the shadow to compare against
+     * @param update the partial update to check
+     * @return true if an update to the shadow is needed, otherwise false
+     */
+    protected boolean isUpdateNecessary(JsonNode baseDocument, JsonNode update) {
+        JsonNode merged = baseDocument.deepCopy();
+        JsonMerger.merge(merged, update);
+        return !baseDocument.equals(merged);
+    }
+
+    /**
+     * Answer whether the update is already part of the shadow.
+     *
+     * @param baseDocument the shadow to compare against
+     * @param update the partial update to check
+     * @return true if an update to the shadow is needed, otherwise false
+     * @throws SkipSyncRequestException if an error occurs parsing the shadow documents
+     */
+    protected boolean isUpdateNecessary(byte[] baseDocument, JsonNode update) throws SkipSyncRequestException {
+        // if the base document is empty, then we need to update
+        Optional<JsonNode> existing = null;
+        try {
+            existing = JsonUtil.getPayloadJson(baseDocument);
+        } catch (IOException e) {
+            throw new SkipSyncRequestException(e);
+        }
+
+        return existing.map(base -> isUpdateNecessary(base, update)).orElse(true);
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -247,6 +247,7 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
                 .kv(LOG_SHADOW_NAME_KEY, getShadowName())
                 .kv(LOG_CLOUD_VERSION_KEY, cloudShadowDocument.getVersion())
                 .log("Syncing local shadow for the first time");
+
         ObjectNode updateDocument = (ObjectNode) cloudShadowDocument.toJson(false);
         long localDocumentVersion = updateLocalDocumentAndGetUpdatedVersion(updateDocument, Optional.empty());
         updateSyncInformation(updateDocument, localDocumentVersion, cloudShadowDocument.getVersion());

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
@@ -54,6 +55,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -319,5 +321,16 @@ public class LocalUpdateSyncRequestTest {
         verify(mockDao, times(0)).updateSyncInformation(any());
     }
 
+    @Test
+    void GIVEN_no_change_WHEN_execute_THEN_does_not_update_local_shadow_and_sync_information() throws IOException {
+        ShadowDocument shadowDocument = new ShadowDocument(UPDATE_DOCUMENT);
+        when(mockDao.getShadowThing(any(), any())).thenReturn(Optional.of(shadowDocument));
 
+        LocalUpdateSyncRequest request = new LocalUpdateSyncRequest(THING_NAME, SHADOW_NAME, UPDATE_DOCUMENT);
+
+        assertDoesNotThrow(() -> request.execute(syncContext));
+
+        verify(mockDao, never()).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(), any());
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**
Shadow-2

**Description of changes:**
Update request objects to check if the update will actually make a change before executing.

**Why is this change necessary:**
When a local update is made, a sync request is created to update the cloud. When
the cloud update occurs, a notification is received that there was a cloud
update. This triggers a local update for the same content.

In order to break the cycle, when executing the request, a check is made of the
local or last synced cloud to determine if the change needs to actually occur.


**How was this change tested:**
Unit + integ test

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
