### PR TITLE
feat: get version from the response objects after updating shadows.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.shadowmanager.AuthorizationHandlerWrapper;
+import com.aws.greengrass.shadowmanager.ShadowManager;
+import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
+import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
+import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
+import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.mockito.Mock;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+public class NucleusLaunchUtils extends GGServiceTestUtil {
+    private static final long TEST_TIME_OUT_SEC = 30L;
+
+    public Kernel kernel;
+    public ShadowManager shadowManager;
+    GlobalStateChangeListener listener;
+    @TempDir
+    Path rootDir;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    IotDataPlaneClientFactory iotDataPlaneClientFactory;
+    @Mock
+    MqttClient mqttClient;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    ShadowManagerDAOImpl dao;
+    @Mock
+    AuthorizationHandlerWrapper mockAuthorizationHandlerWrapper;
+    @Mock
+    ShadowManagerDatabase mockShadowManagerDatabase;
+
+    public void startNucleusWithConfig(String configFile) throws InterruptedException {
+        startNucleusWithConfig(configFile, State.RUNNING, false, false, false);
+    }
+
+    void startNucleusWithConfig(String configFile, boolean mockCloud, boolean mockDao) throws InterruptedException {
+        startNucleusWithConfig(configFile, State.RUNNING, false, mockCloud, mockDao);
+    }
+
+    void startNucleusWithConfig(String configFile, State expectedState, boolean mockDatabase) throws InterruptedException {
+        startNucleusWithConfig(configFile, expectedState, mockDatabase, false, true);
+    }
+
+    void startNucleusWithConfig(String configFile, State expectedState, boolean mockDatabase, boolean mockCloud,
+                                boolean mockDao) throws InterruptedException {
+        CountDownLatch shadowManagerRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+                getClass().getResource(configFile).toString());
+        listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(ShadowManager.SERVICE_NAME) && service.getState().equals(expectedState)) {
+                shadowManagerRunning.countDown();
+                shadowManager = (ShadowManager) service;
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.getContext().put(MqttClient.class, mqttClient);
+        // assume we are always connected
+        lenient().when(mqttClient.connected()).thenReturn(true);
+
+        if (mockDatabase) {
+            kernel.getContext().put(ShadowManagerDatabase.class, mockShadowManagerDatabase);
+            kernel.getContext().put(AuthorizationHandlerWrapper.class, mockAuthorizationHandlerWrapper);
+        }
+        if (mockCloud) {
+            kernel.getContext().put(IotDataPlaneClientFactory.class, iotDataPlaneClientFactory);
+        }
+        if (mockDao) {
+            kernel.getContext().put(ShadowManagerDAOImpl.class, dao);
+        }
+        kernel.launch();
+
+        assertTrue(shadowManagerRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
@@ -5,16 +5,9 @@
 
 package com.aws.greengrass.integrationtests;
 
-import com.aws.greengrass.dependency.State;
-import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
-import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
-import com.aws.greengrass.mqttclient.MqttClient;
-import com.aws.greengrass.shadowmanager.ShadowManager;
-import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
-import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -24,51 +17,32 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.iotdataplane.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowResponse;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static com.aws.greengrass.shadowmanager.model.Constants.CLASSIC_SHADOW_IDENTIFIER;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class RateLimiterTest {
-    private static final long TEST_TIME_OUT_SEC = 30L;
-
+class RateLimiterTest extends NucleusLaunchUtils {
     private static final String localShadowContentV1 = "{\"version\":1,\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
     private static final String lastSyncedDocument = "{\"state\":{\"desired\":{\"SomeKey\":\"boo\"}},\"metadata\":{}}";
 
-    Kernel kernel;
-    ShadowManager shadowManager;
-    GlobalStateChangeListener listener;
-
-    @TempDir
-    Path rootDir;
-
     @Mock
-    MqttClient mqttClient;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    IotDataPlaneClientFactory iotDataPlaneClientFactory;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    ShadowManagerDAOImpl dao;
+    UpdateThingShadowResponse mockUpdateThingShadowResponse;
 
     @BeforeEach
     void setup() {
@@ -80,37 +54,15 @@ public class RateLimiterTest {
         kernel.shutdown();
     }
 
-    private void startNucleusWithConfig(String configFile) throws InterruptedException {
-        CountDownLatch shadowManagerRunning = new CountDownLatch(1);
-        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
-                getClass().getResource(configFile).toString());
-        listener = (GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(ShadowManager.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
-                shadowManagerRunning.countDown();
-                shadowManager = (ShadowManager) service;
-            }
-        };
-        kernel.getContext().addGlobalStateChangeListener(listener);
-
-        kernel.getContext().put(MqttClient.class, mqttClient);
-        // assume we are always connected
-        lenient().when(mqttClient.connected()).thenReturn(true);
-        kernel.getContext().put(IotDataPlaneClientFactory.class, iotDataPlaneClientFactory);
-        kernel.getContext().put(ShadowManagerDAOImpl.class, dao);
-
-        kernel.launch();
-
-        assertTrue(shadowManagerRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
-    }
-
     @Test
     void GIVEN_throttled_cloud_update_requests_WHEN_cloud_updates_THEN_cloud_updates_eventually(ExtensionContext context) throws IOException, InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
 
         // mock actual calls to the cloud
+        when(mockUpdateThingShadowResponse.payload()).thenReturn(SdkBytes.fromString("{\"version\": 1}", UTF_8));
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(any(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest.class)))
-                .thenReturn(mock(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowResponse.class));
+                .thenReturn(mockUpdateThingShadowResponse);
 
         // mock dao calls in cloud update
         when(dao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(new ShadowDocument(localShadowContentV1.getBytes())));
@@ -120,7 +72,7 @@ public class RateLimiterTest {
                         .cloudVersion(0).build()));
         lenient().when(dao.updateSyncInformation(any(SyncInformation.class))).thenReturn(true);
 
-        startNucleusWithConfig("rateLimits.yaml");
+        startNucleusWithConfig("rateLimits.yaml", true, true);
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
         JsonNode updateDocument = JsonUtil.getPayloadJson(localShadowContentV1.getBytes()).get();
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/UnhappyUpdateIPCTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/UnhappyUpdateIPCTest.java
@@ -5,38 +5,26 @@
 
 package com.aws.greengrass.integrationtests.ipc;
 
-import com.aws.greengrass.dependency.State;
-import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
-import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.integrationtests.NucleusLaunchUtils;
 import com.aws.greengrass.lifecyclemanager.Kernel;
-import com.aws.greengrass.mqttclient.MqttClient;
-import com.aws.greengrass.shadowmanager.ShadowManager;
 import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.model.ErrorMessage;
-import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import com.aws.greengrass.util.Coerce;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Answers;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest;
 
-import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
@@ -48,28 +36,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.lenient;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-class UnhappyUpdateIPCTest extends GGServiceTestUtil {
-    private static final long TEST_TIME_OUT_SEC = 30L;
+class UnhappyUpdateIPCTest extends NucleusLaunchUtils {
     public static final String MOCK_THING_NAME = "Thing1";
     public static final String CLASSIC_SHADOW = "";
     private static final String shadowContentFormat = "{\"state\":{\"desired\":{\"SomeKey\":\"%s\"}},\"metadata\":{}}";
-
-    Kernel kernel;
-    ShadowManager shadowManager;
-    GlobalStateChangeListener listener;
-
-    @TempDir
-    Path rootDir;
-
-    @Mock
-    MqttClient mqttClient;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    IotDataPlaneClientFactory iotDataPlaneClientFactory;
 
     @BeforeEach
     void setup() {
@@ -79,28 +51,6 @@ class UnhappyUpdateIPCTest extends GGServiceTestUtil {
     @AfterEach
     void cleanup() {
         kernel.shutdown();
-    }
-
-    private void startNucleusWithConfig(String configFile) throws InterruptedException {
-        CountDownLatch shadowManagerRunning = new CountDownLatch(1);
-        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
-                getClass().getResource(configFile).toString());
-        listener = (GreengrassService service, State was, State newState) -> {
-            if (service.getName().equals(ShadowManager.SERVICE_NAME) && service.getState().equals(State.RUNNING)) {
-                shadowManagerRunning.countDown();
-                shadowManager = (ShadowManager) service;
-            }
-        };
-        kernel.getContext().addGlobalStateChangeListener(listener);
-
-        kernel.getContext().put(MqttClient.class, mqttClient);
-        // assume we are always connected
-        lenient().when(mqttClient.connected()).thenReturn(true);
-        kernel.getContext().put(IotDataPlaneClientFactory.class, iotDataPlaneClientFactory);
-
-        kernel.launch();
-
-        assertTrue(shadowManagerRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
     }
 
     private String getStringWithLengthAndFilledWithCharacter(int length, char charToFill) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -92,17 +92,18 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
                 request.setShadowName(getShadowName());
                 request.setPayload(JsonUtil.getPayloadBytes(shadowDocument.toJson(false)));
 
-                UpdateThingShadowHandlerResponse updateThingShadowHandlerResponse =
+                UpdateThingShadowHandlerResponse response =
                         context.getUpdateHandler().handleRequest(request, SHADOW_MANAGER_NAME);
 
-                byte[] updatedDocument = updateThingShadowHandlerResponse.getCurrentDocument();
+                byte[] updatedDocument = response.getCurrentDocument();
                 long updateTime = Instant.now().getEpochSecond();
                 context.getDao().updateSyncInformation(SyncInformation.builder()
                         .thingName(getThingName())
                         .shadowName(getShadowName())
                         .lastSyncedDocument(updatedDocument)
                         .cloudUpdateTime(updateTime)
-                        .localVersion(currentLocalVersion + 1)
+                        .localVersion(getUpdatedVersion(response.getUpdateThingShadowResponse().getPayload())
+                                .orElse(currentLocalVersion + 1))
                         .cloudVersion(cloudUpdateVersion)
                         .lastSyncTime(updateTime)
                         .cloudDeleted(false)

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequestTest.java
@@ -25,6 +25,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.iotdataplane.model.ConflictException;
 import software.amazon.awssdk.services.iotdataplane.model.InternalFailureException;
@@ -35,6 +36,7 @@ import software.amazon.awssdk.services.iotdataplane.model.ServiceUnavailableExce
 import software.amazon.awssdk.services.iotdataplane.model.ThrottlingException;
 import software.amazon.awssdk.services.iotdataplane.model.UnauthorizedException;
 import software.amazon.awssdk.services.iotdataplane.model.UnsupportedDocumentEncodingException;
+import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowResponse;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -44,6 +46,7 @@ import static com.aws.greengrass.shadowmanager.TestUtils.SAMPLE_EXCEPTION_MESSAG
 import static com.aws.greengrass.shadowmanager.TestUtils.SHADOW_NAME;
 import static com.aws.greengrass.shadowmanager.TestUtils.THING_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -102,6 +105,8 @@ class CloudUpdateSyncRequestTest {
                 .cloudVersion(5L)
                 .lastSyncTime(epochSecondsMinus60)
                 .build()));
+        when(mockIotDataPlaneClientWrapper.updateThingShadow(anyString(), anyString(), any(byte[].class)))
+                .thenReturn(UpdateThingShadowResponse.builder().payload(SdkBytes.fromString("{\"version\": 6}", UTF_8)).build());
 
         CloudUpdateSyncRequest request = new CloudUpdateSyncRequest(THING_NAME, SHADOW_NAME, baseDocumentJson);
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -60,6 +61,7 @@ import static com.aws.greengrass.shadowmanager.TestUtils.THING_NAME;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_METADATA;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_VERSION;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -87,6 +89,8 @@ class FullShadowSyncRequestTest {
 
     @Mock
     private ShadowManagerDAO mockDao;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private UpdateThingShadowHandlerResponse mockUpdateThingShadowHandlerResponse;
     @Mock
     private IotDataPlaneClientWrapper mockIotDataPlaneClientWrapper;
     @Mock
@@ -137,10 +141,11 @@ class FullShadowSyncRequestTest {
                 .localVersion(1L)
                 .lastSyncTime(epochSecondsMinus60)
                 .build()));
+        when(mockUpdateThingShadowHandlerResponse.getUpdateThingShadowResponse().getPayload()).thenReturn("{\"version\": 11, \"state\": {}}".getBytes(UTF_8));
         when(mockUpdateThingShadowRequestHandler.handleRequest(localUpdateThingShadowRequestCaptor.capture(), anyString())).
-                thenReturn(mock(UpdateThingShadowHandlerResponse.class));
+                thenReturn(mockUpdateThingShadowHandlerResponse);
         when(mockIotDataPlaneClientWrapper.updateThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture(), payloadCaptor.capture()))
-                .thenReturn(UpdateThingShadowResponse.builder().build());
+                .thenReturn(UpdateThingShadowResponse.builder().payload(SdkBytes.fromString("{\"version\": 6, \"state\": {}}", UTF_8)).build());
 
         FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
         fullShadowSyncRequest.execute(syncContext);
@@ -318,8 +323,9 @@ class FullShadowSyncRequestTest {
                 .localVersion(0L)
                 .lastSyncTime(Instant.EPOCH.getEpochSecond())
                 .build()));
+        when(mockUpdateThingShadowHandlerResponse.getUpdateThingShadowResponse().getPayload()).thenReturn("{\"version\": 1, \"state\": {}}".getBytes(UTF_8));
         when(mockUpdateThingShadowRequestHandler.handleRequest(localUpdateThingShadowRequestCaptor.capture(), anyString())).
-                thenReturn(mock(UpdateThingShadowHandlerResponse.class));
+                thenReturn(mockUpdateThingShadowHandlerResponse);
 
         FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
         fullShadowSyncRequest.execute(syncContext);
@@ -372,7 +378,7 @@ class FullShadowSyncRequestTest {
                 .lastSyncTime(Instant.EPOCH.getEpochSecond())
                 .build()));
         when(mockIotDataPlaneClientWrapper.updateThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture(), payloadCaptor.capture()))
-                .thenReturn(UpdateThingShadowResponse.builder().build());
+                .thenReturn(UpdateThingShadowResponse.builder().payload(SdkBytes.fromString("{\"version\": 1, \"state\": {}}", UTF_8)).build());
 
         FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
         fullShadowSyncRequest.execute(syncContext);
@@ -657,8 +663,9 @@ class FullShadowSyncRequestTest {
                 .localVersion(1L)
                 .lastSyncTime(epochSecondsMinus60)
                 .build()));
+        when(mockUpdateThingShadowHandlerResponse.getUpdateThingShadowResponse().getPayload()).thenReturn("{\"version\": 11, \"state\": {}}".getBytes(UTF_8));
         when(mockUpdateThingShadowRequestHandler.handleRequest(localUpdateThingShadowRequestCaptor.capture(), anyString())).
-                thenReturn(mock(UpdateThingShadowHandlerResponse.class));
+                thenReturn(mockUpdateThingShadowHandlerResponse);
         doThrow(clazz).when(mockIotDataPlaneClientWrapper).updateThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture(), payloadCaptor.capture());
 
         FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
@@ -707,8 +714,10 @@ class FullShadowSyncRequestTest {
                 .localVersion(1L)
                 .lastSyncTime(epochSecondsMinus60)
                 .build()));
+        when(mockUpdateThingShadowHandlerResponse.getUpdateThingShadowResponse().getPayload()).thenReturn("{\"version\": 1, \"state\": {}}".getBytes(UTF_8));
         when(mockUpdateThingShadowRequestHandler.handleRequest(localUpdateThingShadowRequestCaptor.capture(), anyString())).
-                thenReturn(mock(UpdateThingShadowHandlerResponse.class));
+                thenReturn(mockUpdateThingShadowHandlerResponse);
+
         doThrow(ConflictException.class).when(mockIotDataPlaneClientWrapper).updateThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture(), payloadCaptor.capture());
 
         FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
@@ -799,8 +808,10 @@ class FullShadowSyncRequestTest {
                 .localVersion(1L)
                 .lastSyncTime(epochSecondsMinus60)
                 .build()));
+        when(mockUpdateThingShadowHandlerResponse.getUpdateThingShadowResponse().getPayload()).thenReturn("{\"version\": 11, \"state\": {}}".getBytes(UTF_8));
         when(mockUpdateThingShadowRequestHandler.handleRequest(localUpdateThingShadowRequestCaptor.capture(), anyString())).
-                thenReturn(mock(UpdateThingShadowHandlerResponse.class));
+                thenReturn(mockUpdateThingShadowHandlerResponse);
+
         doThrow(clazz).when(mockIotDataPlaneClientWrapper).updateThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture(), payloadCaptor.capture());
 
         FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
@@ -43,6 +43,7 @@ import static com.aws.greengrass.shadowmanager.TestUtils.SAMPLE_EXCEPTION_MESSAG
 import static com.aws.greengrass.shadowmanager.TestUtils.SHADOW_NAME;
 import static com.aws.greengrass.shadowmanager.TestUtils.THING_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -97,8 +98,10 @@ public class LocalUpdateSyncRequestTest {
                 .cloudVersion(5L)
                 .lastSyncTime(epochSeconds)
                 .build()));
+        UpdateThingShadowResponse response = new UpdateThingShadowResponse();
+        response.setPayload("{\"version\": 1}".getBytes(UTF_8));
         when(mockUpdateThingShadowRequestHandler.handleRequest(any(UpdateThingShadowRequest.class), anyString()))
-                .thenReturn(new UpdateThingShadowHandlerResponse(new UpdateThingShadowResponse(), UPDATE_DOCUMENT));
+                .thenReturn(new UpdateThingShadowHandlerResponse(response, UPDATE_DOCUMENT));
 
         LocalUpdateSyncRequest request = new LocalUpdateSyncRequest(THING_NAME, SHADOW_NAME, UPDATE_DOCUMENT);
         request.execute(syncContext);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Get the version from the update response instead of incrementing the current version for both local and cloud update.

Also added a `NucleusLaucnhUtils` class to start the nucleus with the proper config to avoid code duplication.

**Why is this change necessary:**
Removes code duplication.
Gets the updated version from the source of truth.

**How was this change tested:**
Updated unit and integration tests.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
