### PR TITLE
chore: remove unimplemented config variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Manifests:
             - "bar"
           - thingName: "OtherThing"
           - thingName: "YetAnotherThing"
-          # include sync status in response messages
-          provideSyncStatus: true
 
         rateLimits:
           # number of outgoing sync updates per second (useful to constrain bandwidth)
@@ -74,7 +72,6 @@ Manifests:
         ]
       }
     ],
-    "provideSyncStatus":true,
     "maxOutboundSyncUpdatesPerSecond":50
   },
   "rateLimits": {

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
@@ -37,7 +37,6 @@ public final class Constants {
     // https://docs.aws.amazon.com/general/latest/gr/iot-core.html#device-shadow-limits
     // 400 is max TPS for some regions (account level), others are 4000
     public static final int DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS = 100;
-    public static final boolean DEFAULT_PROVIDE_SYNC_STATUS = false;
     public static final int DEFAULT_DISK_UTILIZATION_SIZE_B = 16 * 1024 * 1024;
     public static final int DEFAULT_LOCAL_REQUESTS_RATE = 20;
     public static final int DEFAULT_TOTAL_LOCAL_REQUESTS_RATE = 200;
@@ -64,7 +63,6 @@ public final class Constants {
     public static final String CONFIGURATION_NAMED_SHADOWS_TOPIC = "namedShadows";
     public static final String CONFIGURATION_SHADOW_DOCUMENTS_TOPIC = "shadowDocuments";
     public static final String CONFIGURATION_THING_NAME_TOPIC = "thingName";
-    public static final String CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC = "provideSyncStatus";
     public static final String CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC = "shadowDocumentSizeLimitBytes";
     public static final String CONFIGURATION_MAX_DISK_UTILIZATION_MB_TOPIC = "maxDiskUtilizationMegaBytes";
     public static final String CONFIGURATION_RATE_LIMITS_TOPIC = "rateLimits";

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ShadowSyncConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ShadowSyncConfiguration.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.shadowmanager.util.Validator;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Pair;
 import com.aws.greengrass.util.Utils;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,7 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -29,10 +27,8 @@ import static com.aws.greengrass.shadowmanager.model.Constants.CLASSIC_SHADOW_ID
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_CLASSIC_SHADOW_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NAMED_SHADOWS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NUCLEUS_THING_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SHADOW_DOCUMENTS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_THING_NAME_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_PROVIDE_SYNC_STATUS;
 import static com.aws.greengrass.shadowmanager.model.Constants.UNEXPECTED_TYPE_FORMAT;
 import static com.aws.greengrass.shadowmanager.model.Constants.UNEXPECTED_VALUE_FORMAT;
 
@@ -40,8 +36,6 @@ import static com.aws.greengrass.shadowmanager.model.Constants.UNEXPECTED_VALUE_
 @Getter
 public class ShadowSyncConfiguration {
     private final Set<ThingShadowSyncConfiguration> syncConfigurations;
-    @JsonProperty(CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC)
-    private final boolean provideSyncStatus;
 
     @Override
     public boolean equals(Object o) {
@@ -58,8 +52,7 @@ public class ShadowSyncConfiguration {
         ShadowSyncConfiguration newConfiguration = (ShadowSyncConfiguration) o;
 
         // Compare the data members and return accordingly
-        return Objects.equals(this.provideSyncStatus, newConfiguration.provideSyncStatus)
-                && Objects.equals(this.syncConfigurations, newConfiguration.syncConfigurations);
+        return Objects.equals(this.syncConfigurations, newConfiguration.syncConfigurations);
     }
 
     @SuppressWarnings("PMD.UselessOverridingMethod")
@@ -85,14 +78,8 @@ public class ShadowSyncConfiguration {
             throw new InvalidConfigurationException(e);
         }
 
-        final boolean provideSyncStatus = Optional.ofNullable(
-                configTopicsPojo.get(CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC))
-                .map(Coerce::toBoolean)
-                .orElse(DEFAULT_PROVIDE_SYNC_STATUS);
-
         return ShadowSyncConfiguration.builder()
                 .syncConfigurations(syncConfigurationSet)
-                .provideSyncStatus(provideSyncStatus)
                 .build();
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -64,7 +64,6 @@ import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NAMED_SHADOWS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NUCLEUS_THING_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_RATE_LIMITS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SHADOW_DOCUMENTS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNCHRONIZATION_TOPIC;
@@ -323,7 +322,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowDocumentsList.add(thingAMap);
         shadowDocumentsList.add(thingBMap);
         configTopics.createLeafChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC).withValueChecked(shadowDocumentsList);
-        configTopics.createLeafChild(CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC).withValueChecked(true);
         Topics systemConfigTopics = configTopics.createInteriorChild(CONFIGURATION_NUCLEUS_THING_TOPIC);
         systemConfigTopics.createLeafChild(CONFIGURATION_CLASSIC_SHADOW_TOPIC).withValue("true");
         systemConfigTopics.createLeafChild(CONFIGURATION_NAMED_SHADOWS_TOPIC).withValue(Collections.singletonList("boo2"));
@@ -346,7 +344,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
                         ThingShadowSyncConfiguration.builder().thingName(THING_NAME_A).shadowName("bar").build(),
                         ThingShadowSyncConfiguration.builder().thingName(THING_NAME_B).shadowName("").build(),
                         ThingShadowSyncConfiguration.builder().thingName(THING_NAME_B).shadowName("foo2").build()));
-        assertThat(shadowManager.getSyncConfiguration().isProvideSyncStatus(), is(true));
         verify(mockDao, times(6)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
@@ -365,7 +362,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowDocumentsList.add(thingAMap);
         shadowDocumentsList.add(thingBMap);
         configTopics.createLeafChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC).withValueChecked(shadowDocumentsList);
-        configTopics.createLeafChild(CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC).withValueChecked(true);
 
         when(thingNameTopic.getOnce()).thenReturn(KERNEL_THING);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
@@ -382,7 +378,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
                         ThingShadowSyncConfiguration.builder().thingName(THING_NAME_A).shadowName("bar").build(),
                         ThingShadowSyncConfiguration.builder().thingName(THING_NAME_B).shadowName("").build(),
                         ThingShadowSyncConfiguration.builder().thingName(THING_NAME_B).shadowName("foo2").build()));
-        assertThat(shadowManager.getSyncConfiguration().isProvideSyncStatus(), is(true));
         verify(mockDao, times(4)).insertSyncInfoIfNotExists(any(SyncInformation.class));
     }
 
@@ -390,7 +385,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
     void GIVEN_good_sync_configuration_with_only_nucleus_thing_config_WHEN_thing_name_changes_THEN_updates_nucleus_configuration_correctly() throws UnsupportedInputTypeException {
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, KERNEL_THING);
         Topics configTopics = Topics.of(context, CONFIGURATION_SYNCHRONIZATION_TOPIC, null);
-        configTopics.createLeafChild(CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC).withValueChecked(true);
         Topics systemConfigTopics = configTopics.createInteriorChild(CONFIGURATION_NUCLEUS_THING_TOPIC);
         systemConfigTopics.createLeafChild(CONFIGURATION_CLASSIC_SHADOW_TOPIC).withValue("true");
         systemConfigTopics.createLeafChild(CONFIGURATION_NAMED_SHADOWS_TOPIC).withValue(Collections.singletonList("boo2"));
@@ -501,7 +495,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowDocumentsList.add(thingAMap);
         shadowDocumentsList.add(thingBMap);
         configTopics.createLeafChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC).withValueChecked(shadowDocumentsList);
-        configTopics.createLeafChild(CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC).withValueChecked(true);
 
         when(thingNameTopic.getOnce()).thenReturn(KERNEL_THING);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
@@ -531,7 +524,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowDocumentsList.add(thingAMap);
         shadowDocumentsList.add(thingBMap);
         configTopics.createLeafChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC).withValueChecked(shadowDocumentsList);
-        configTopics.createLeafChild(CONFIGURATION_PROVIDE_SYNC_STATUS_TOPIC).withValueChecked(true);
 
         when(thingNameTopic.getOnce()).thenReturn(KERNEL_THING);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The `provideSyncStatus` is not implemented. So removing it for now. We will add this in a later PR.

**Why is this change necessary:**
We do not want to have code for a feature which is not implemented.

**How was this change tested:**
Current tests pass

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
