### PR TITLE
chore: relocate H2 reference to avoid conflicts of versions in Moqette.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,13 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <relocations>
+                                <!-- Relocate all of H2 into a namespace just for shadow manager, so nothing conflicts -->
+                                <relocation>
+                                    <pattern>org.h2</pattern>
+                                    <shadedPattern>com.aws.greengrass.shadowmanager.lib.org.h2</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Relocate all of h2 into a `` namespace for Shadow Manager in order to avoid conflict with the [H2 version in the Moquette broker](https://github.com/moquette-io/moquette/blob/f6f3f6eedbb6b50128a25cb9c031662dd5ad043d/broker/pom.xml#L21)

**Why is this change necessary:**
Without this, the deployment would fail for Shadow Manager when Moquette was already installed on the core due to the version mismatch.

**How was this change tested:**
Current tests are working as expected.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
