### PR TITLE
chore: rename nucleusThing config to coreThing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Manifests:
       Configuration:
         synchronize:
           # explicit config for Nucleus
-          nucleusThing:
+          coreThing:
             classic: true // default is true
             namedShadows:
             - "foo"
@@ -48,7 +48,7 @@ Manifests:
 ```
 {
   "synchronize":{
-    "nucleusThing":{
+    "coreThing":{
       "classic":true,
       "namedShadows":[
         "foo",
@@ -72,7 +72,6 @@ Manifests:
         ]
       }
     ],
-    "maxOutboundSyncUpdatesPerSecond":50
   },
   "rateLimits": {
     "maxOutboundSyncUpdatesPerSecond":50,

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -196,7 +196,7 @@ public class ShadowManager extends PluginService {
             // First time.
             return;
         }
-        getNucleusThingShadowSyncConfiguration(oldThingName).ifPresent(thingShadowSyncConfiguration ->
+        getCoreThingShadowSyncConfiguration(oldThingName).ifPresent(thingShadowSyncConfiguration ->
                 thingShadowSyncConfiguration.setThingName(thingName));
     }
 
@@ -227,9 +227,9 @@ public class ShadowManager extends PluginService {
                 this.syncHandler.setSyncConfiguration(this.syncConfiguration.getSyncConfigurations());
 
                 // Subscribe to the thing name topic if the Nucleus thing shadows have been synced.
-                Optional<ThingShadowSyncConfiguration> nucleusThingConfig =
-                        getNucleusThingShadowSyncConfiguration(thingName);
-                if (nucleusThingConfig.isPresent()) {
+                Optional<ThingShadowSyncConfiguration> coreThingConfig =
+                        getCoreThingShadowSyncConfiguration(thingName);
+                if (coreThingConfig.isPresent()) {
                     thingNameTopic.subscribeGeneric(this.deviceThingNameWatcher);
                 } else {
                     thingNameTopic.remove(this.deviceThingNameWatcher);
@@ -322,7 +322,7 @@ public class ShadowManager extends PluginService {
                 .build());
     }
 
-    private Optional<ThingShadowSyncConfiguration> getNucleusThingShadowSyncConfiguration(String thingName) {
+    private Optional<ThingShadowSyncConfiguration> getCoreThingShadowSyncConfiguration(String thingName) {
         return syncConfiguration.getSyncConfigurations()
                 .stream()
                 .filter(thingShadowSyncConfiguration -> thingName.equals(thingShadowSyncConfiguration.getThingName()))

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
@@ -57,7 +57,7 @@ public final class Constants {
     public static final int PBE_KEY_ITERATION_COUNT = 65_536;
     public static final int PBE_KEY_LENGTH = 256;
     public static final String CONFIGURATION_SYNCHRONIZATION_TOPIC = "synchronize";
-    public static final String CONFIGURATION_NUCLEUS_THING_TOPIC = "nucleusThing";
+    public static final String CONFIGURATION_CORE_THING_TOPIC = "coreThing";
     public static final String CONFIGURATION_CLASSIC_SHADOW_TOPIC = "classic";
     public static final String CONFIGURATION_NAMED_SHADOWS_TOPIC = "namedShadows";
     public static final String CONFIGURATION_SHADOW_DOCUMENTS_TOPIC = "shadowDocuments";

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ShadowSyncConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ShadowSyncConfiguration.java
@@ -24,8 +24,8 @@ import java.util.stream.Collectors;
 
 import static com.aws.greengrass.shadowmanager.model.Constants.CLASSIC_SHADOW_IDENTIFIER;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_CLASSIC_SHADOW_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_CORE_THING_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NAMED_SHADOWS_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NUCLEUS_THING_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SHADOW_DOCUMENTS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_THING_NAME_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.UNEXPECTED_TYPE_FORMAT;
@@ -71,7 +71,7 @@ public class ShadowSyncConfiguration {
     public static ShadowSyncConfiguration processConfiguration(Map<String, Object> configTopicsPojo, String thingName) {
         Set<ThingShadowSyncConfiguration> syncConfigurationSet = new HashSet<>();
         try {
-            processNucleusThingConfiguration(configTopicsPojo, thingName, syncConfigurationSet);
+            processCoreThingConfiguration(configTopicsPojo, thingName, syncConfigurationSet);
             processOtherThingConfigurations(configTopicsPojo, thingName, syncConfigurationSet);
         } catch (InvalidRequestParametersException e) {
             throw new InvalidConfigurationException(e);
@@ -113,19 +113,19 @@ public class ShadowSyncConfiguration {
      * @param syncConfigurationSet the sync configuration list to add the nucleus thing configuration to.
      * @throws InvalidRequestParametersException if the named shadow validation fails.
      */
-    private static void processNucleusThingConfiguration(Map<String, Object> configTopicsPojo, String thingName,
-                                                         Set<ThingShadowSyncConfiguration> syncConfigurationSet) {
-        configTopicsPojo.computeIfPresent(CONFIGURATION_NUCLEUS_THING_TOPIC, (ignored, nucleusThingConfigObject) -> {
-            processThingConfiguration(nucleusThingConfigObject, thingName, syncConfigurationSet);
-            return nucleusThingConfigObject;
+    private static void processCoreThingConfiguration(Map<String, Object> configTopicsPojo, String thingName,
+                                                      Set<ThingShadowSyncConfiguration> syncConfigurationSet) {
+        configTopicsPojo.computeIfPresent(CONFIGURATION_CORE_THING_TOPIC, (ignored, coreThingConfigObject) -> {
+            processThingConfiguration(coreThingConfigObject, thingName, syncConfigurationSet);
+            return coreThingConfigObject;
         });
     }
 
-    private static void processThingConfiguration(Object thingConfigObject, String nucleusThingName,
+    private static void processThingConfiguration(Object thingConfigObject, String coreThingName,
                                                   Set<ThingShadowSyncConfiguration> syncConfigurationSet) {
         if (thingConfigObject instanceof Map) {
             Map<String, Object> thingConfig = (Map) thingConfigObject;
-            AtomicReference<String> thingName = new AtomicReference<>(nucleusThingName);
+            AtomicReference<String> thingName = new AtomicReference<>(coreThingName);
             if (thingConfig.containsKey(CONFIGURATION_THING_NAME_TOPIC)) {
                 Object name = thingConfig.get(CONFIGURATION_THING_NAME_TOPIC);
                 if (name instanceof String) {

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -67,7 +67,7 @@ import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NAMED_SHADOWS_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NUCLEUS_THING_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_CORE_THING_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_RATE_LIMITS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SHADOW_DOCUMENTS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNCHRONIZATION_TOPIC;
@@ -298,7 +298,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowDocumentsList.add(thingAMap);
         shadowDocumentsList.add(thingBMap);
         configTopics.createLeafChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC).withValueChecked(shadowDocumentsList);
-        Topics systemConfigTopics = configTopics.createInteriorChild(CONFIGURATION_NUCLEUS_THING_TOPIC);
+        Topics systemConfigTopics = configTopics.createInteriorChild(CONFIGURATION_CORE_THING_TOPIC);
         systemConfigTopics.createLeafChild(CONFIGURATION_CLASSIC_SHADOW_TOPIC).withValue("true");
         systemConfigTopics.createLeafChild(CONFIGURATION_NAMED_SHADOWS_TOPIC).withValue(Collections.singletonList("boo2"));
 
@@ -359,7 +359,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
     void GIVEN_good_sync_configuration_with_only_nucleus_thing_config_WHEN_thing_name_changes_THEN_updates_nucleus_configuration_correctly() throws UnsupportedInputTypeException {
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, KERNEL_THING);
         Topics configTopics = Topics.of(context, CONFIGURATION_SYNCHRONIZATION_TOPIC, null);
-        Topics systemConfigTopics = configTopics.createInteriorChild(CONFIGURATION_NUCLEUS_THING_TOPIC);
+        Topics systemConfigTopics = configTopics.createInteriorChild(CONFIGURATION_CORE_THING_TOPIC);
         systemConfigTopics.createLeafChild(CONFIGURATION_CLASSIC_SHADOW_TOPIC).withValue("true");
         systemConfigTopics.createLeafChild(CONFIGURATION_NAMED_SHADOWS_TOPIC).withValue(Collections.singletonList("boo2"));
 
@@ -385,7 +385,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         thingAMap.put(CONFIGURATION_CLASSIC_SHADOW_TOPIC, false);
         thingAMap.put(CONFIGURATION_NAMED_SHADOWS_TOPIC, Arrays.asList("foo", "bar"));
         shadowDocumentsList.add(thingAMap);
-        configTopics.createLeafChild(CONFIGURATION_NUCLEUS_THING_TOPIC).withValueChecked(shadowDocumentsList);
+        configTopics.createLeafChild(CONFIGURATION_CORE_THING_TOPIC).withValueChecked(shadowDocumentsList);
         configTopics.createLeafChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC).withValueChecked(null);
 
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
@@ -401,7 +401,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         Topic maxDocSizeTopic = Topic.of(context, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC, DEFAULT_DOCUMENT_SIZE);
         Topics configTopics = Topics.of(context, CONFIGURATION_SYNCHRONIZATION_TOPIC, null);
-        configTopics.createLeafChild(CONFIGURATION_NUCLEUS_THING_TOPIC).withValueChecked(null);
+        configTopics.createLeafChild(CONFIGURATION_CORE_THING_TOPIC).withValueChecked(null);
         List<Map<String, Object>> shadowDocumentsList = new ArrayList<>();
         Map<String, Object> thingAMap = new HashMap<>();
         thingAMap.put(CONFIGURATION_THING_NAME_TOPIC, THING_NAME_A);
@@ -425,7 +425,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         Topic maxDocSizeTopic = Topic.of(context, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC, DEFAULT_DOCUMENT_SIZE);
         Topics configTopics = Topics.of(context, CONFIGURATION_SYNCHRONIZATION_TOPIC, null);
-        configTopics.createLeafChild(CONFIGURATION_NUCLEUS_THING_TOPIC).withValueChecked(null);
+        configTopics.createLeafChild(CONFIGURATION_CORE_THING_TOPIC).withValueChecked(null);
         Topics shadowDocumentsTopics = configTopics.createInteriorChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC);
         shadowDocumentsTopics.createLeafChild(CONFIGURATION_CLASSIC_SHADOW_TOPIC).withValue("true");
         shadowDocumentsTopics.createLeafChild(CONFIGURATION_NAMED_SHADOWS_TOPIC).withValue(Collections.singletonList("boo2"));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update the `nucleusThing` config field to `coreThing`.

**Why is this change necessary:**
This is a better name for the configuration variable.

**How was this change tested:**
Updated the tests.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
