### PR TITLE
fix: ignore delta field after getting the cloud document.

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.shadowmanager.sync.model;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.ShadowRequest;
@@ -81,7 +82,7 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
         try {
             ShadowDocument document = new ShadowDocument(payload);
             return Optional.of(document.getVersion());
-        } catch (IOException e) {
+        } catch (InvalidRequestParametersException | IOException e) {
             logger.atDebug()
                     .kv(LOG_THING_NAME_KEY, getThingName())
                     .kv(LOG_SHADOW_NAME_KEY, getShadowName())

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.shadowmanager.sync.model;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.ShadowManager;
+import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
@@ -371,7 +372,7 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
             throws SkipSyncRequestException {
         try {
             return new ShadowDocument(syncInformation.getLastSyncedDocument());
-        } catch (IOException e) {
+        } catch (InvalidRequestParametersException | IOException e) {
             logger.atError()
                     .kv(LOG_THING_NAME_KEY, getThingName())
                     .kv(LOG_SHADOW_NAME_KEY, getShadowName())
@@ -470,7 +471,7 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
                     .kv(LOG_SHADOW_NAME_KEY, getShadowName())
                     .log("Could not execute cloud shadow get request");
             throw new RetryableException(e);
-        } catch (SdkServiceException | SdkClientException | IOException e) {
+        } catch (SdkServiceException | SdkClientException | InvalidRequestParametersException | IOException e) {
             logger.atError()
                     .kv(LOG_THING_NAME_KEY, getThingName())
                     .kv(LOG_SHADOW_NAME_KEY, getShadowName())

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.shadowmanager.sync.model;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
@@ -83,7 +84,7 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
         ShadowDocument shadowDocument;
         try {
             shadowDocument = new ShadowDocument(updateDocument);
-        } catch (IOException e) {
+        } catch (IOException | InvalidRequestParametersException e) {
             throw new SkipSyncRequestException(e);
         }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.shadowmanager;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Pair;
 import org.h2.jdbcx.JdbcConnectionPool;
@@ -218,10 +219,11 @@ class ShadowManagerDAOImplTest {
     }
 
     @BeforeEach
-    void setup() throws SQLException {
+    void setup() throws SQLException, IOException {
         when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
         when(mockDatabase.getPool()).thenReturn(mockPool);
         when(mockPool.getConnection()).thenReturn(mockConnection);
+        JsonUtil.loadSchema();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandlerTest.java
@@ -94,8 +94,9 @@ class DeleteThingShadowRequestHandlerTest {
     ArgumentCaptor<PubSubRequest> pubSubRequestCaptor;
 
     @BeforeEach
-    void setup() {
+    void setup() throws IOException {
         lenient().when(mockSynchronizeHelper.getThingShadowLock(any())).thenReturn(Object.class);
+        JsonUtil.loadSchema();
     }
 
     @ParameterizedTest

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/GetThingShadowRequestHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/GetThingShadowRequestHandlerTest.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.shadowmanager.util.JsonUtil;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -85,6 +86,10 @@ class GetThingShadowRequestHandlerTest {
     @Captor
     ArgumentCaptor<PubSubRequest> pubSubRequestCaptor;
 
+    @BeforeEach
+    void setup() throws IOException {
+        JsonUtil.loadSchema();
+    }
 
     @ParameterizedTest
     @NullAndEmptySource

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.shadowmanager.sync.model;
 
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
+import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
@@ -904,7 +905,7 @@ class FullShadowSyncRequestTest {
 
         FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
         SkipSyncRequestException thrown = assertThrows(SkipSyncRequestException.class, () -> fullShadowSyncRequest.execute(syncContext));
-        assertThat(thrown.getCause(), is(instanceOf(IOException.class)));
+        assertThat(thrown.getCause(), is(instanceOf(InvalidRequestParametersException.class)));
 
         verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
         verify(mockDao, times(1)).updateSyncInformation(any());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently if there was a difference between the reported and desired nodes in the cloud shadow document, the shadow manager reported an error. This will fix that issue by ignoring the delta node in the cloud shadow document. 

**Why is this change necessary:**
Since delta is just a computed field, we do not need to serialize it.

**How was this change tested:**
Added unit test

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
