### PR TITLE
fix: update integration test for sync to include full shadow doc

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -27,7 +27,6 @@ import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.exceptions.base.MockitoException;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest;
 import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest;
@@ -40,10 +39,8 @@ import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRespo
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -74,14 +71,21 @@ class SyncTest extends NucleusLaunchUtils {
     public static final String MOCK_THING_NAME = "Thing1";
     public static final String CLASSIC_SHADOW = "";
     public static final String RANDOM_SHADOW = "badShadowName";
-    private static final String cloudShadowContentV10 = "{\"version\":10,\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
+
+    private static final String cloudShadowContentV10 = "{ \"state\": { \"desired\": { \"SomeKey\": \"foo\" }, "
+            + "\"reported\": { \"SomeKey\": \"bar\", \"OtherKey\": 1}, \"delta\": { \"SomeKey\": \"foo\" } }, "
+            + "\"metadata\": { \"desired\": { \"SomeKey\": { \"timestamp\": 1624980501 } }, "
+            + "\"reported\": { \"SomeKey\": { \"timestamp\": 1624980501 } } },"
+            + " \"version\": 10, \"timestamp\": 1624986665 }";
+
     private static final String cloudShadowContentV1 = "{\"version\":1,\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
-    private static final String localShadowContentV1 = "{\"state\":{\"reported\":{\"SomeKey\":\"foo\", "
-            + "\"OtherKey\": 1}}}";
-    private static final String localShadowContentV2 = "{\"state\":{\"reported\":{\"OtherKey\":2, \"AnotherKey\": "
-            + "\"foobar\"}}}";
-    private static final String mergedLocalShadowContentV2 = "{\"state\":{\"reported\":{\"SomeKey\":\"foo\","
-            + "\"OtherKey\":2, \"AnotherKey\": \"foobar\"}}, \"version\":10}";
+    private static final String localShadowContentV1 = "{\"state\":{ \"desired\": { \"SomeKey\": \"foo\"}, "
+            + "\"reported\":{\"SomeKey\":\"bar\",\"OtherKey\": 1}}}";
+
+    private static final String localUpdate1 = "{\"state\":{\"reported\":{\"SomeKey\":\"foo\", \"OtherKey\": 1}}}";
+    private static final String localUpdate2 = "{\"state\":{\"reported\":{\"OtherKey\":2, \"AnotherKey\":\"foobar\"}}}";
+    private static final String mergedLocalShadowContentV2 =
+            "{\"state\":{\"reported\":{\"SomeKey\":\"foo\",\"OtherKey\":2,\"AnotherKey\":\"foobar\"}},\"version\":10}";
 
     @Mock
     UpdateThingShadowResponse mockUpdateThingShadowResponse;
@@ -93,9 +97,16 @@ class SyncTest extends NucleusLaunchUtils {
     @Captor
     private ArgumentCaptor<software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest> cloudDeleteThingShadowRequestCaptor;
 
+    private Supplier<Optional<SyncInformation>> syncInfo;
+    private Supplier<Optional<ShadowDocument>> localShadow;
+
     @BeforeEach
     void setup() {
         kernel = new Kernel();
+        syncInfo = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowSyncInformation(MOCK_THING_NAME,
+                CLASSIC_SHADOW);
+        localShadow = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowThing(MOCK_THING_NAME,
+                CLASSIC_SHADOW);
     }
 
     @AfterEach
@@ -103,23 +114,9 @@ class SyncTest extends NucleusLaunchUtils {
         kernel.shutdown();
     }
 
-    boolean eventually(Supplier<Void> supplier, long timeout, ChronoUnit unit) throws InterruptedException {
-        Instant expire = Instant.now().plus(Duration.of(timeout, unit));
-        while (expire.isAfter(Instant.now())) {
-            try {
-                supplier.get();
-                return true;
-            } catch (MockitoException | AssertionError e) {
-                // ignore
-            }
-            TimeUnit.MILLISECONDS.sleep(500);
-        }
-        return false;
-    }
-
-
     @Test
-    void GIVEN_sync_config_and_no_local_WHEN_startup_THEN_local_version_updated_via_full_sync(ExtensionContext context) throws Exception {
+    void GIVEN_sync_config_and_no_local_WHEN_startup_THEN_local_version_updated_via_full_sync(ExtensionContext context)
+            throws IOException, InterruptedException {
         ignoreExceptionOfType(context, InterruptedException.class);
 
         GetThingShadowResponse shadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
@@ -128,33 +125,28 @@ class SyncTest extends NucleusLaunchUtils {
         // existing document
         when(iotDataPlaneClientFactory.getIotDataPlaneClient()
                 .getThingShadow(any(GetThingShadowRequest.class))).thenReturn(shadowResponse);
+
         startNucleusWithConfig("sync.yaml", true, false);
 
-        ShadowManagerDAO dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(10L)));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
 
-        JsonNode v1 = JsonUtil.getPayloadJson(localShadowContentV1.getBytes(UTF_8)).get();
-        eventually(() -> {
-            Optional<SyncInformation> syncInformation =
-                    dao.getShadowSyncInformation(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("sync info exists", syncInformation.isPresent(), is(true));
-            assertThat(syncInformation.get().getCloudVersion(), is(10L));
-            assertThat(syncInformation.get().getLocalVersion(), is(1L));
+        assertThat("local shadow exists", localShadow.get().isPresent(), is(true));
+        ShadowDocument shadowDocument = localShadow.get().get();
 
-            Optional<ShadowDocument> shadow = dao.getShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("local shadow exists", shadow.isPresent(), is(true));
-            ShadowDocument shadowDocument = shadow.get();
-            // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
-            shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
-            assertThat(shadowDocument.toJson(false), is(v1));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
+        JsonNode v1 = new ShadowDocument(localShadowContentV1.getBytes(UTF_8)).toJson(false);
+        // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
+        shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
+        assertThat(shadowDocument.toJson(false), is(equalTo(v1)));
 
         verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), never()).updateThingShadow(
                 any(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest.class));
     }
 
     @Test
-    void GIVEN_sync_config_and_no_cloud_WHEN_startup_THEN_cloud_version_updated_via_full_sync(ExtensionContext context) throws InterruptedException, IOException {
+    void GIVEN_sync_config_and_no_cloud_WHEN_startup_THEN_cloud_version_updated_via_full_sync(ExtensionContext context)
+            throws IOException, InterruptedException {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
@@ -181,19 +173,16 @@ class SyncTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig("sync.yaml", true, true);
 
-        eventually(() -> {
-            assertThat(cloudUpdateThingShadowRequestCaptor.getValue(), is(notNullValue()));
-            assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
+        assertThat(() -> cloudUpdateThingShadowRequestCaptor.getValue(), eventuallyEval(is(notNullValue())));
+        assertThat(() -> syncInformationCaptor.getValue(), eventuallyEval(is(notNullValue())));
 
-            assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
-            assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(1L));
-            assertThat(syncInformationCaptor.getValue().getThingName(), is(MOCK_THING_NAME));
-            assertThat(syncInformationCaptor.getValue().getShadowName(), is(CLASSIC_SHADOW));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getThingName(), is(MOCK_THING_NAME));
+        assertThat(syncInformationCaptor.getValue().getShadowName(), is(CLASSIC_SHADOW));
 
-            assertThat(cloudUpdateThingShadowRequestCaptor.getValue().thingName(), is(MOCK_THING_NAME));
-            assertThat(cloudUpdateThingShadowRequestCaptor.getValue().shadowName(), is(CLASSIC_SHADOW));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
+        assertThat(cloudUpdateThingShadowRequestCaptor.getValue().thingName(), is(MOCK_THING_NAME));
+        assertThat(cloudUpdateThingShadowRequestCaptor.getValue().shadowName(), is(CLASSIC_SHADOW));
 
         verify(dao, never()).updateShadowThing(anyString(), anyString(), any(byte[].class), anyLong());
         verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), times(1)).updateThingShadow(
@@ -201,43 +190,45 @@ class SyncTest extends NucleusLaunchUtils {
     }
 
     @Test
-    void GIVEN_synced_shadow_WHEN_local_update_THEN_cloud_updates(ExtensionContext context) throws InterruptedException, IOException {
+    void GIVEN_synced_shadow_WHEN_local_update_THEN_cloud_updates(ExtensionContext context) throws IOException,
+            InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
 
-        when(mockUpdateThingShadowResponse.payload()).thenReturn(SdkBytes.fromString("{\"version\": 1}", UTF_8));
-        when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
-                .thenReturn(mockUpdateThingShadowResponse);
+        // no shadow exists in cloud
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
                 .thenThrow(ResourceNotFoundException.class);
 
-        startNucleusWithConfig("sync.yaml", true, false);
+        // mock response to update cloud
+        when(mockUpdateThingShadowResponse.payload()).thenReturn(SdkBytes.fromString("{\"version\": 1}", UTF_8));
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
+                .thenReturn(mockUpdateThingShadowResponse);
 
-        ShadowManagerDAO dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
+        startNucleusWithConfig("sync.yaml", true, false);
 
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
 
-        JsonNode v1 = JsonUtil.getPayloadJson(localShadowContentV1.getBytes(UTF_8)).get();
+        // update local shadow
         UpdateThingShadowRequest request = new UpdateThingShadowRequest();
         request.setThingName(MOCK_THING_NAME);
         request.setShadowName(CLASSIC_SHADOW);
         request.setPayload(localShadowContentV1.getBytes(UTF_8));
-        updateHandler.handleRequest(request, "DoAll");
-        eventually(() -> {
-            Optional<SyncInformation> syncInformation =
-                    dao.getShadowSyncInformation(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("sync info exists", syncInformation.isPresent(), is(true));
-            assertThat(syncInformation.get().getCloudVersion(), is(1L));
-            assertThat(syncInformation.get().getLocalVersion(), is(1L));
 
-            Optional<ShadowDocument> shadow = dao.getShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("local shadow exists", shadow.isPresent(), is(true));
-            ShadowDocument shadowDocument = shadow.get();
-            // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
-            shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
-            assertThat(shadowDocument.toJson(false), is(v1));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
+        updateHandler.handleRequest(request, "DoAll");
+        assertEmptySyncQueue(kernel.getContext().get(SyncHandler.class));
+
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(1L)));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+
+        assertThat("local shadow exists", localShadow.get().isPresent(), is(true));
+        ShadowDocument shadowDocument = localShadow.get().get();
+        // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
+        shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
+        JsonNode v1 = new ShadowDocument(localShadowContentV1.getBytes(UTF_8)).toJson(false);
+        assertThat(shadowDocument.toJson(false), is(v1));
+
         verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), times(1)).updateThingShadow(
                 any(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest.class));
     }
@@ -255,29 +246,24 @@ class SyncTest extends NucleusLaunchUtils {
         JsonNode cloudDocument = JsonUtil.getPayloadJson(cloudShadowContentV1.getBytes(UTF_8)).get();
 
         startNucleusWithConfig("sync.yaml", true, false);
-        ShadowManagerDAO dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
+
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
         syncHandler.pushLocalUpdateSyncRequest(MOCK_THING_NAME, CLASSIC_SHADOW, JsonUtil.getPayloadBytes(cloudDocument));
+        assertEmptySyncQueue(syncHandler);
 
-        eventually(() -> {
-            Optional<SyncInformation> syncInformation =
-                    dao.getShadowSyncInformation(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("sync info exists", syncInformation.isPresent(), is(true));
-            assertThat(syncInformation.get().getCloudVersion(), is(1L));
-            assertThat(syncInformation.get().getLocalVersion(), is(1L));
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
 
-            Optional<ShadowDocument> shadow = dao.getShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("local shadow exists", shadow.isPresent(), is(true));
-            ShadowDocument shadowDocument = shadow.get();
-            // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
-            shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
-            assertThat(shadowDocument.toJson(false).get(SHADOW_DOCUMENT_STATE), is(cloudDocument.get(SHADOW_DOCUMENT_STATE)));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(1L)));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+
+        assertThat("local shadow exists", localShadow.get().isPresent(), is(true));
+        ShadowDocument shadowDocument = localShadow.get().get();
+        // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
+        shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
+        assertThat(shadowDocument.toJson(false).get(SHADOW_DOCUMENT_STATE), is(cloudDocument.get(SHADOW_DOCUMENT_STATE)));
 
         verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), never()).updateThingShadow(
                 any(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest.class));
-
     }
 
     @Test
@@ -287,104 +273,84 @@ class SyncTest extends NucleusLaunchUtils {
 
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().deleteThingShadow(cloudDeleteThingShadowRequestCaptor.capture()))
                 .thenReturn(mock(software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowResponse.class));
-        when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
-                .thenThrow(ResourceNotFoundException.class);
+
+        GetThingShadowResponse shadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(shadowResponse.payload().asByteArray()).thenReturn(cloudShadowContentV10.getBytes(UTF_8));
+
+        // return existing doc for full sync
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()
+                .getThingShadow(any(GetThingShadowRequest.class))).thenReturn(shadowResponse);
 
         startNucleusWithConfig("sync.yaml", true, false);
 
-        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
-        eventually(() -> {
-            assertThat(syncHandler.getSyncQueue().size(), is(0));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
-
-        ShadowManagerDAO dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
-        dao.updateSyncInformation(SyncInformation.builder()
-                .localVersion(1L)
-                .cloudVersion(1L)
-                .lastSyncedDocument(localShadowContentV1.getBytes(UTF_8))
-                .cloudUpdateTime(Instant.now().getEpochSecond())
-                .cloudDeleted(false)
-                .lastSyncTime(Instant.now().getEpochSecond())
-                .shadowName(CLASSIC_SHADOW)
-                .thingName(MOCK_THING_NAME)
-                .build());
-        dao.updateShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW, localShadowContentV1.getBytes(UTF_8), 1L);
+        // we have a local shadow from the initial full sync
+        assertThat("local shadow exists", () -> localShadow.get().isPresent(), eventuallyEval(is(true)));
 
         DeleteThingShadowRequestHandler deleteHandler = shadowManager.getDeleteThingShadowRequestHandler();
-
         DeleteThingShadowRequest request = new DeleteThingShadowRequest();
         request.setThingName(MOCK_THING_NAME);
         request.setShadowName(CLASSIC_SHADOW);
         deleteHandler.handleRequest(request, "DoAll");
-        eventually(() -> {
-            Optional<SyncInformation> syncInformation =
-                    dao.getShadowSyncInformation(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("sync info exists", syncInformation.isPresent(), is(true));
-            assertThat(syncInformation.get().getCloudVersion(), is(1L));
-            assertThat(syncInformation.get().getLocalVersion(), is(1L));
-            assertThat(syncInformation.get().getLastSyncedDocument(), is(nullValue()));
-            assertThat(syncInformation.get().isCloudDeleted(), is(true));
 
-            Optional<ShadowDocument> shadow = dao.getShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("local shadow should not exist", shadow.isPresent(), is(false));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("cloud deleted", () -> syncInfo.get().get().isCloudDeleted(), eventuallyEval(is(true)));
+        assertThat("cloud version", syncInfo.get().get().getCloudVersion(), is(10L));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+        assertThat("sync doc", syncInfo.get().get().getLastSyncedDocument(), is(nullValue()));
+
+        assertThat("local shadow should not exist", localShadow.get().isPresent(), is(false));
+
         verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), times(1)).deleteThingShadow(
                 any(software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest.class));
     }
 
+    private void assertEmptySyncQueue(SyncHandler syncHandler) {
+        assertThat(() -> syncHandler.getSyncQueue().size(), eventuallyEval(is(0)));
+    }
+
     @Test
-    void GIVEN_synced_shadow_WHEN_cloud_delete_THEN_local_deletes(ExtensionContext context) throws IOException, InterruptedException {
+    void GIVEN_synced_shadow_WHEN_cloud_delete_THEN_local_deletes(ExtensionContext context) throws InterruptedException {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().deleteThingShadow(cloudDeleteThingShadowRequestCaptor.capture()))
                 .thenReturn(mock(software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowResponse.class));
-        when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
-                .thenThrow(ResourceNotFoundException.class);
+
+        GetThingShadowResponse shadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(shadowResponse.payload().asByteArray()).thenReturn(cloudShadowContentV10.getBytes(UTF_8));
+
+        // return existing doc for full sync
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()
+                .getThingShadow(any(GetThingShadowRequest.class))).thenReturn(shadowResponse);
 
         startNucleusWithConfig("sync.yaml", true, false);
 
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
-        eventually(() -> {
-            assertThat(syncHandler.getSyncQueue().size(), is(0));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
 
-        ShadowManagerDAO dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
-        dao.updateSyncInformation(SyncInformation.builder()
-                .localVersion(1L)
-                .cloudVersion(1L)
-                .lastSyncedDocument(localShadowContentV1.getBytes(UTF_8))
-                .cloudUpdateTime(Instant.now().getEpochSecond())
-                .cloudDeleted(false)
-                .lastSyncTime(Instant.now().getEpochSecond())
-                .shadowName(CLASSIC_SHADOW)
-                .thingName(MOCK_THING_NAME)
-                .build());
-        dao.updateShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW, localShadowContentV1.getBytes(UTF_8), 1L);
+        // we have a local shadow from the initial full sync
+        assertThat("local shadow exists", () -> localShadow.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("local shadow version",localShadow.get().get().getVersion(), is(1L));
 
-        syncHandler.pushLocalDeleteSyncRequest(MOCK_THING_NAME, CLASSIC_SHADOW, "{\"version\": 1}".getBytes(UTF_8));
-        eventually(() -> {
-            Optional<SyncInformation> syncInformation =
-                    dao.getShadowSyncInformation(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("sync info exists", syncInformation.isPresent(), is(true));
-            assertThat(syncInformation.get().getCloudVersion(), is(1L));
-            assertThat(syncInformation.get().getLocalVersion(), is(1L));
-            assertThat(syncInformation.get().getLastSyncedDocument(), is(nullValue()));
-            assertThat(syncInformation.get().isCloudDeleted(), is(true));
+        syncHandler.pushLocalDeleteSyncRequest(MOCK_THING_NAME, CLASSIC_SHADOW, "{\"version\": 10}".getBytes(UTF_8));
 
-            Optional<ShadowDocument> shadow = dao.getShadowThing(MOCK_THING_NAME, CLASSIC_SHADOW);
-            assertThat("local shadow should not exist", shadow.isPresent(), is(false));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
+        // wait for it to process
+        assertEmptySyncQueue(syncHandler);
+
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("cloud deleted", () -> syncInfo.get().get().isCloudDeleted(), eventuallyEval(is(true)));
+
+        assertThat("cloud version", syncInfo.get().get().getCloudVersion(), is(10L));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+        assertThat("sync doc", syncInfo.get().get().getLastSyncedDocument(), is(nullValue()));
+
+        assertThat("local shadow should not exist", localShadow.get().isPresent(), is(false));
+
         verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), never()).deleteThingShadow(
                 any(software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest.class));
     }
 
     @Test
-    void GIVEN_unsynced_shadow_WHEN_local_deletes_THEN_no_cloud_delete(ExtensionContext context) throws IOException, InterruptedException {
+    void GIVEN_unsynced_shadow_WHEN_local_deletes_THEN_no_cloud_delete(ExtensionContext context) throws InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
 
@@ -394,12 +360,8 @@ class SyncTest extends NucleusLaunchUtils {
                 .thenThrow(ResourceNotFoundException.class);
 
         startNucleusWithConfig("sync.yaml", true, false);
-        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
 
-        eventually(() -> {
-            assertThat(syncHandler.getSyncQueue().size(), is(0));
-            return null;
-        }, 10, ChronoUnit.SECONDS);
+        assertEmptySyncQueue(kernel.getContext().get(SyncHandler.class));
 
         ShadowManagerDAO dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
         dao.updateSyncInformation(SyncInformation.builder()
@@ -421,6 +383,7 @@ class SyncTest extends NucleusLaunchUtils {
         request.setShadowName(RANDOM_SHADOW);
 
         deleteHandler.handleRequest(request, "DoAll");
+
         verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), after(Duration.ofSeconds(10).toMillis()).never()).deleteThingShadow(
                 any(software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest.class));
     }
@@ -463,12 +426,12 @@ class SyncTest extends NucleusLaunchUtils {
         UpdateThingShadowRequest request1 = new UpdateThingShadowRequest();
         request1.setThingName(MOCK_THING_NAME);
         request1.setShadowName(CLASSIC_SHADOW);
-        request1.setPayload(localShadowContentV1.getBytes(UTF_8));
+        request1.setPayload(localUpdate1.getBytes(UTF_8));
 
         UpdateThingShadowRequest request2 = new UpdateThingShadowRequest();
         request2.setThingName(MOCK_THING_NAME);
         request2.setShadowName(CLASSIC_SHADOW);
-        request2.setPayload(localShadowContentV2.getBytes(UTF_8));
+        request2.setPayload(localUpdate2.getBytes(UTF_8));
 
         // on startup a full sync is executed. mock a cloud response
         GetThingShadowResponse shadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
@@ -480,12 +443,7 @@ class SyncTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig("sync.yaml", true, false);
 
-        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
-        ShadowManagerDAOImpl dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
-
         // wait for full sync to finish
-        Supplier<Optional<SyncInformation>> syncInfo = () -> dao.getShadowSyncInformation(MOCK_THING_NAME,
-                CLASSIC_SHADOW);
         assertThat("full sync finished with version 10",
                 () -> syncInfo.get().map(SyncInformation::getCloudVersion).orElse(0L),
                 eventuallyEval(is(10L), Duration.ofSeconds(10)));
@@ -515,7 +473,7 @@ class SyncTest extends NucleusLaunchUtils {
         updateHandler.handleRequest(request1, "DoAll");
 
         assertThat("update thing shadow called", updateThingShadowCalled::get, eventuallyEval(is(2)));
-        assertThat("sync queue is empty", () -> syncHandler.getSyncQueue().isEmpty(), eventuallyEval(is(true)));
+        assertEmptySyncQueue(kernel.getContext().get(SyncHandler.class));
         assertThat("dao cloud version updated", () -> syncInfo.get()
                         .map(SyncInformation::getCloudVersion).orElse(0L), eventuallyEval(is(11L)));
         assertThat("dao local version updated", () -> syncInfo.get()

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync.yaml
@@ -16,9 +16,8 @@ services:
       - DoAll
   DoAll:
     lifecycle:
-      all:
-        run:
-          echo "Running"
+      startup: echo "Running"
+      shutdown: echo "Stopping"
     dependencies:
       - aws.greengrass.ShadowManager
     configuration:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Integration tests are also updated to more properly simulate real behavior. A full shadow document with delta and metadata is returned from the cloud

Added use of Eventually matcher library to clean up test cases

**Why is this change necessary:**
To clean up test cases and add more realistic usage

**How was this change tested:**
`mvn verify`

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
