### PR TITLE
feat: add new `synchronize:shadowDocumentsMap` configuration type to accept a map object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ Manifests:
             - "bar"
           # Explicit config for "other" IoT Things
           shadowDocuments:
-          - thingName: "MyThing"
-            classic: false
-            namedShadows:
-            - "foo"
-            - "bar"
-          - thingName: "OtherThing"
-          - thingName: "YetAnotherThing"
+            <thingName>:
+              classic: false
+              namedShadows:
+              - "foo"
+              - "bar"
+            <thingName>:
+              classic: true
+            <thingName>:
+              classic: false
 
         rateLimits:
           # number of outgoing sync updates per second (useful to constrain bandwidth)
@@ -54,20 +56,18 @@ Manifests:
         "bar"
       ]
     },
-    "shadowDocuments":[
-      {
-        "thingName":"MyThing",
+    "shadowDocuments":{
+      "MyThing": {
         "classic":false,
         "namedShadows":[
           "foo",
           "bar"
         ]
       },
-      {
-        "thingName":"OtherThing",
+      "OtherThing": {
         "classic":true,
         "namedShadows":[
-          
+          "foo2"
         ]
       }
     ],
@@ -80,6 +80,11 @@ Manifests:
   "shadowDocumentSizeLimitBytes":8192
 }
 ```
+
+### Notes
+- For Shadow manager 2.1 synchronize configuration supports both data types for syncing shadows. The sync configuration
+can either be a `map` or a `list`. The map approach is preferred since this allows the customers to use the deployment 
+`merge` command to add in new shadows to sync.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Manifests:
             - "bar"
           # Explicit config for "other" IoT Things
           shadowDocuments:
+          - thingName: "MyThing"
+            classic: false
+            namedShadows:
+            - "foo"
+            - "bar"
+          - thingName: "OtherThing"
+          - thingName: "YetAnotherThing"
+          shadowDocumentsMap:
             <thingName>:
               classic: false
               namedShadows:
@@ -56,7 +64,7 @@ Manifests:
         "bar"
       ]
     },
-    "shadowDocuments":{
+    "shadowDocumentsMap":{
       "MyThing": {
         "classic":false,
         "namedShadows":[
@@ -70,7 +78,24 @@ Manifests:
           "foo2"
         ]
       }
-    ],
+    },
+    "shadowDocuments":[
+      {
+        "thingName":"MyThing",
+        "classic":false,
+        "namedShadows":[
+          "foo",
+          "bar"
+        ]
+      },
+      {
+        "thingName":"OtherThing",
+        "classic":true,
+        "namedShadows":[
+          
+        ]
+      }
+    ]
   },
   "rateLimits": {
     "maxOutboundSyncUpdatesPerSecond":50,
@@ -83,8 +108,8 @@ Manifests:
 
 ### Notes
 - For Shadow manager 2.1 synchronize configuration supports both data types for syncing shadows. The sync configuration
-can either be a `map` or a `list`. The map approach is preferred since this allows the customers to use the deployment 
-`merge` command to add in new shadows to sync.
+can either be a `map` or a `list`. Both the `map` and `list` thing shadow configurations will be merged. The map 
+approach is preferred since this allows the customers to use the deployment `merge` command to add in new shadows to sync.
 
 ## Security
 

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_map.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_map.yaml
@@ -1,0 +1,50 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.ShadowManager:
+    configuration:
+      synchronize:
+        shadowDocuments:
+          Thing1:
+            classic: true
+          Thing2:
+            namedShadows:
+              - "foo"
+              - "bar"
+
+  main:
+    dependencies:
+      - DoAll
+  DoAll:
+    lifecycle:
+      startup: echo "Running"
+      shutdown: echo "Stopping"
+    dependencies:
+      - aws.greengrass.ShadowManager
+    configuration:
+      accessControl:
+        aws.greengrass.ShadowManager:
+          policyId1:
+            policyDescription: access to CRUD shadow operations
+            operations:
+              - 'aws.greengrass#GetThingShadow'
+              - 'aws.greengrass#UpdateThingShadow'
+              - 'aws.greengrass#DeleteThingShadow'
+            resources:
+              - '*'
+          policyId2:
+            policyDescription: access to list named shadows
+            operations:
+              - 'aws.greengrass#ListNamedShadowsForThing'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId3:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+            resources:
+              - '*'

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_map.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_map.yaml
@@ -7,7 +7,7 @@ services:
   aws.greengrass.ShadowManager:
     configuration:
       synchronize:
-        shadowDocuments:
+        shadowDocumentsMap:
           Thing1:
             classic: true
           Thing2:

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -106,7 +106,7 @@ public class ShadowManager extends PluginService {
     };
     private final CallbackEventManager.OnConnectCallback onConnect = callbacks::onConnectionResumed;
 
-    @Getter(AccessLevel.PACKAGE)
+    @Getter(AccessLevel.PUBLIC)
     @Setter(AccessLevel.PACKAGE)
     private ShadowSyncConfiguration syncConfiguration;
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
@@ -61,6 +61,7 @@ public final class Constants {
     public static final String CONFIGURATION_CLASSIC_SHADOW_TOPIC = "classic";
     public static final String CONFIGURATION_NAMED_SHADOWS_TOPIC = "namedShadows";
     public static final String CONFIGURATION_SHADOW_DOCUMENTS_TOPIC = "shadowDocuments";
+    public static final String CONFIGURATION_SHADOW_DOCUMENTS_MAP_TOPIC = "shadowDocumentsMap";
     public static final String CONFIGURATION_THING_NAME_TOPIC = "thingName";
     public static final String CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC = "shadowDocumentSizeLimitBytes";
     public static final String CONFIGURATION_RATE_LIMITS_TOPIC = "rateLimits";


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added a new  `synchronize:shadowDocumentsMap` configuration to support map based shadow documents approach.
Thing Name is used as the key in the map and has been removed from the configuration object fields.

**Why is this change necessary:**
To allow for `synchronize:shadowDocumentsMap` to be merged from any deployment

**How was this change tested:**
Added new unit test and integration test.

**Any additional information or context required to review the change:**
This change will allow the customers to use the old `list` approach. We will document that the map approach is preferred since a list gets overwritten with each deployment merge. Both the `map` and `list` shadow documents configuration topic will be merged into one list of shadow documents to be synced.

**Checklist:**
 - [X] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
