### PR TITLE
fix: increment shadow version on shadow delete.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -69,7 +69,8 @@ class ShadowManagerDAOImplTest {
     }
 
     @BeforeEach
-    public void before() throws SQLException {
+    public void before() throws IOException {
+        JsonUtil.loadSchema();
         kernel = new Kernel();
         // Might need to start the Nucleus here
         kernel.parseArgs("-r", rootDir.toAbsolutePath().toString());
@@ -117,7 +118,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_no_shadow_WHEN_get_shadow_thing_THEN_return_nothing() throws Exception {
+    void GIVEN_no_shadow_WHEN_get_shadow_thing_THEN_return_nothing() {
         Optional<ShadowDocument> result = dao.getShadowThing(MISSING_THING_NAME, SHADOW_NAME);
         assertThat("No shadow found", result.isPresent(), is(false));
     }
@@ -136,7 +137,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_no_shadow_WHEN_delete_shadow_thing_THEN_return_nothing() throws Exception {
+    void GIVEN_no_shadow_WHEN_delete_shadow_thing_THEN_return_nothing() {
         Optional<ShadowDocument> result = dao.deleteShadowThing(THING_NAME, SHADOW_NAME);
         assertThat("No shadow found", result.isPresent(), is(false));
     }
@@ -170,14 +171,14 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_no_shadow_WHEN_update_shadow_thing_THEN_shadow_created() throws Exception {
+    void GIVEN_no_shadow_WHEN_update_shadow_thing_THEN_shadow_created() {
         Optional<byte[]> result = dao.updateShadowThing(THING_NAME, SHADOW_NAME, UPDATED_DOCUMENT, 1);
         assertThat("Shadow created", result.isPresent(), is(true));
         assertThat(result.get(), is(equalTo(UPDATED_DOCUMENT)));
     }
 
     @Test
-    void GIVEN_multiple_named_shadows_for_thing_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_list() throws Exception {
+    void GIVEN_multiple_named_shadows_for_thing_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_list() {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -189,7 +190,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_classic_and_named_shadows_WHEN_list_named_shadows_for_thing_THEN_return_list_does_not_include_classic_shadow() throws Exception {
+    void GIVEN_classic_and_named_shadows_WHEN_list_named_shadows_for_thing_THEN_return_list_does_not_include_classic_shadow() {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -203,7 +204,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_offset_and_limit_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_subset() throws Exception {
+    void GIVEN_offset_and_limit_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_subset() {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -248,7 +249,7 @@ class ShadowManagerDAOImplTest {
 
     @ParameterizedTest
     @MethodSource("validListTestParameters")
-    void GIVEN_valid_edge_inputs_WHEN_list_named_shadows_for_thing_THEN_return_valid_results(String thingName, int offset, int pageSize) throws Exception {
+    void GIVEN_valid_edge_inputs_WHEN_list_named_shadows_for_thing_THEN_return_valid_results(String thingName, int offset, int pageSize) {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -381,4 +382,28 @@ class ShadowManagerDAOImplTest {
         assertThat(shadowSyncInformation, is(not(Optional.empty())));
         assertThat(shadowSyncInformation.get(), is(initialSyncInformation));
     }
+
+    @ParameterizedTest
+    @MethodSource("classicAndNamedShadow")
+    void GIVEN_named_and_classic_shadow_WHEN_delete_shadow_and_get_deleted_version_THEN_gets_shadow_deleted_version(String shadowName, byte[] expectedPayload) throws Exception {
+        createNamedShadow();
+        createClassicShadow();
+
+        // Before deleting the shadow, we should not get the shadow version.
+        Optional<Long> deletedShadowVersion = dao.getDeletedShadowVersion(THING_NAME, shadowName);
+        assertThat(deletedShadowVersion, is(Optional.empty()));
+
+        Optional<ShadowDocument> result = dao.deleteShadowThing(THING_NAME, shadowName); //NOPMD
+        assertThat("Correct payload returned", result.isPresent(), is(true));
+        assertThat(result.get().toJson(true), is(equalTo(new ShadowDocument(expectedPayload).toJson(true))));
+
+        Optional<ShadowDocument> getResults = dao.getShadowThing(THING_NAME, shadowName);
+        assertThat("Should not get the shadow document.", getResults.isPresent(), is(false));
+
+        // After the shadow has been deleted, we should get the correct deleted shadow version.
+        deletedShadowVersion = dao.getDeletedShadowVersion(THING_NAME, shadowName);
+        assertThat(deletedShadowVersion, is(not(Optional.empty())));
+        assertThat(deletedShadowVersion.get(), is(2L));
+    }
+
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -365,8 +365,8 @@ class SyncTest extends NucleusLaunchUtils {
 
         assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
         assertThat("cloud deleted", () -> syncInfo.get().get().isCloudDeleted(), eventuallyEval(is(true)));
-        assertThat("cloud version", syncInfo.get().get().getCloudVersion(), is(10L));
-        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+        assertThat("cloud version", syncInfo.get().get().getCloudVersion(), is(11L));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(2L));
         assertThat("sync doc", syncInfo.get().get().getLastSyncedDocument(), is(nullValue()));
 
         assertThat("local shadow should not exist", localShadow.get().isPresent(), is(false));
@@ -414,8 +414,8 @@ class SyncTest extends NucleusLaunchUtils {
         assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
         assertThat("cloud deleted", () -> syncInfo.get().get().isCloudDeleted(), eventuallyEval(is(true)));
 
-        assertThat("cloud version", syncInfo.get().get().getCloudVersion(), is(10L));
-        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+        assertThat("cloud version", syncInfo.get().get().getCloudVersion(), is(11L));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(2L));
         assertThat("sync doc", syncInfo.get().get().getLastSyncedDocument(), is(nullValue()));
 
         assertThat("local shadow should not exist", localShadow.get().isPresent(), is(false));

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
@@ -77,6 +77,15 @@ public interface ShadowManagerDAO {
     List<Pair<String, String>> listSyncedShadows();
 
     /**
+     * Get the shadow document version of a deleted shadow.
+     *
+     * @param thingName  Name of the Thing for the shadow topic prefix.
+     * @param shadowName Name of shadow topic prefix for thing.
+     * @return The deleted shadow version if it was deleted or exists; Else an empty optional
+     */
+    Optional<Long> getDeletedShadowVersion(String thingName, String shadowName);
+
+    /**
      * Attempts to delete the cloud shadow document in the sync table.
      *
      * @param thingName  Name of the Thing for the shadow topic prefix.
@@ -88,8 +97,8 @@ public interface ShadowManagerDAO {
     /**
      * Attempts to get the shadow document version.
      *
-     * @param thingName       Name of the Thing for the shadow topic prefix.
-     * @param shadowName      Name of shadow topic prefix for thing.
+     * @param thingName  Name of the Thing for the shadow topic prefix.
+     * @param shadowName Name of shadow topic prefix for thing.
      * @return Optional containing the new shadow document version if document exists; Else an empty optional
      */
     Optional<Long> getShadowDocumentVersion(String thingName, String shadowName);

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
@@ -79,10 +79,15 @@ public class CloudDeleteSyncRequest extends BaseSyncRequest {
         }
 
         try {
+            // Since the local shadow has been deleted, we need get the deleted shadow version from the DAO.
+            long localShadowVersion = context.getDao().getDeletedShadowVersion(getThingName(), getShadowName())
+                    .orElse(syncInformation.map(SyncInformation::getLocalVersion).orElse(0L) + 1);
             context.getDao().updateSyncInformation(SyncInformation.builder()
                     .lastSyncedDocument(null)
-                    .cloudVersion(syncInformation.map(SyncInformation::getCloudVersion).orElse(0L))
-                    .localVersion(syncInformation.map(SyncInformation::getLocalVersion).orElse(0L))
+                    // After the cloud shadow has been deleted, the version on cloud gets incremented. So we have to
+                    // increment the synced cloud shadow version.
+                    .cloudVersion(syncInformation.map(SyncInformation::getCloudVersion).orElse(0L) + 1)
+                    .localVersion(localShadowVersion)
                     .cloudDeleted(true)
                     .shadowName(getShadowName())
                     .thingName(getThingName())

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequestTest.java
@@ -97,7 +97,8 @@ class CloudDeleteSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(2L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -116,10 +116,11 @@ class FullShadowSyncRequestTest {
     private SyncContext syncContext;
 
     @BeforeEach
-    void setup() {
+    void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
                 mockIotDataPlaneClientWrapper);
+        JsonUtil.loadSchema();
     }
 
     @Test
@@ -192,6 +193,7 @@ class FullShadowSyncRequestTest {
                 .build();
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenReturn(response);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.empty());
+        when(mockDao.getDeletedShadowVersion(anyString(), anyString())).thenReturn(Optional.of(5L));
         when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
                 .cloudUpdateTime(epochSecondsMinus60)
                 .thingName(THING_NAME)
@@ -219,8 +221,8 @@ class FullShadowSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(5L));
-        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(6L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(5L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
@@ -266,6 +268,7 @@ class FullShadowSyncRequestTest {
         ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT);
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(shadowDocument));
+        when(mockDao.getDeletedShadowVersion(anyString(), anyString())).thenReturn(Optional.of(11L));
         when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
                 .cloudUpdateTime(epochSecondsMinus60)
                 .thingName(THING_NAME)
@@ -295,8 +298,8 @@ class FullShadowSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
-        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(10L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(2L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(11L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSecondsMinus60)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class LocalDeleteSyncRequestTest {
+class LocalDeleteSyncRequestTest {
 
     private static final byte[] CLOUD_DELETE_PAYLOAD = "{\"version\": 6}".getBytes();
 
@@ -109,7 +109,8 @@ public class LocalDeleteSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(deletedVersion));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(6L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(deletedVersion + 1));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(syncTime)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(syncTime)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.shadowmanager.sync.strategy;
 
+import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
@@ -24,6 +25,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.event.Level;
 import software.amazon.awssdk.aws.greengrass.model.ConflictError;
 import software.amazon.awssdk.services.iotdataplane.model.ConflictException;
 
@@ -68,6 +70,7 @@ class RealTimeSyncStrategyTest {
 
     @BeforeEach
     void setup() {
+        LogConfig.getRootLogConfig().setLevel(Level.ERROR);
         executorService = Executors.newCachedThreadPool();
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update the shadow version after a local shadow has been deleted. Also update the last synced local and cloud shadow version after either of them have been deleted and synced with each other.

**Why is this change necessary:**
IoT Device service increments the version of the shadow on a delete. GG needs to make sure that happens in the local shadow service as well.

**How was this change tested:**
Added unit tests and updates existing unit and integration tests.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
