### PR TITLE
fix: shadow manager sync bug for recreated shadows.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -69,7 +69,8 @@ class ShadowManagerDAOImplTest {
     }
 
     @BeforeEach
-    public void before() throws SQLException {
+    public void before() throws IOException {
+        JsonUtil.loadSchema();
         kernel = new Kernel();
         // Might need to start the Nucleus here
         kernel.parseArgs("-r", rootDir.toAbsolutePath().toString());
@@ -117,7 +118,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_no_shadow_WHEN_get_shadow_thing_THEN_return_nothing() throws Exception {
+    void GIVEN_no_shadow_WHEN_get_shadow_thing_THEN_return_nothing() {
         Optional<ShadowDocument> result = dao.getShadowThing(MISSING_THING_NAME, SHADOW_NAME);
         assertThat("No shadow found", result.isPresent(), is(false));
     }
@@ -136,7 +137,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_no_shadow_WHEN_delete_shadow_thing_THEN_return_nothing() throws Exception {
+    void GIVEN_no_shadow_WHEN_delete_shadow_thing_THEN_return_nothing() {
         Optional<ShadowDocument> result = dao.deleteShadowThing(THING_NAME, SHADOW_NAME);
         assertThat("No shadow found", result.isPresent(), is(false));
     }
@@ -170,14 +171,14 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_no_shadow_WHEN_update_shadow_thing_THEN_shadow_created() throws Exception {
+    void GIVEN_no_shadow_WHEN_update_shadow_thing_THEN_shadow_created() {
         Optional<byte[]> result = dao.updateShadowThing(THING_NAME, SHADOW_NAME, UPDATED_DOCUMENT, 1);
         assertThat("Shadow created", result.isPresent(), is(true));
         assertThat(result.get(), is(equalTo(UPDATED_DOCUMENT)));
     }
 
     @Test
-    void GIVEN_multiple_named_shadows_for_thing_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_list() throws Exception {
+    void GIVEN_multiple_named_shadows_for_thing_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_list() {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -189,7 +190,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_classic_and_named_shadows_WHEN_list_named_shadows_for_thing_THEN_return_list_does_not_include_classic_shadow() throws Exception {
+    void GIVEN_classic_and_named_shadows_WHEN_list_named_shadows_for_thing_THEN_return_list_does_not_include_classic_shadow() {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -203,7 +204,7 @@ class ShadowManagerDAOImplTest {
     }
 
     @Test
-    void GIVEN_offset_and_limit_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_subset() throws Exception {
+    void GIVEN_offset_and_limit_WHEN_list_named_shadows_for_thing_THEN_return_named_shadow_subset() {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -248,7 +249,7 @@ class ShadowManagerDAOImplTest {
 
     @ParameterizedTest
     @MethodSource("validListTestParameters")
-    void GIVEN_valid_edge_inputs_WHEN_list_named_shadows_for_thing_THEN_return_valid_results(String thingName, int offset, int pageSize) throws Exception {
+    void GIVEN_valid_edge_inputs_WHEN_list_named_shadows_for_thing_THEN_return_valid_results(String thingName, int offset, int pageSize) {
         for (String shadowName : SHADOW_NAME_LIST) {
             dao.updateShadowThing(THING_NAME, shadowName, UPDATED_DOCUMENT, 1);
         }
@@ -381,4 +382,28 @@ class ShadowManagerDAOImplTest {
         assertThat(shadowSyncInformation, is(not(Optional.empty())));
         assertThat(shadowSyncInformation.get(), is(initialSyncInformation));
     }
+
+    @ParameterizedTest
+    @MethodSource("classicAndNamedShadow")
+    void GIVEN_named_and_classic_shadow_WHEN_delete_shadow_and_get_deleted_version_THEN_gets_shadow_deleted_version(String shadowName, byte[] expectedPayload) throws Exception {
+        createNamedShadow();
+        createClassicShadow();
+
+        // Before deleting the shadow, we should not get the shadow version.
+        Optional<Long> deletedShadowVersion = dao.getDeletedShadowVersion(THING_NAME, shadowName);
+        assertThat(deletedShadowVersion, is(Optional.empty()));
+
+        Optional<ShadowDocument> result = dao.deleteShadowThing(THING_NAME, shadowName); //NOPMD
+        assertThat("Correct payload returned", result.isPresent(), is(true));
+        assertThat(result.get().toJson(true), is(equalTo(new ShadowDocument(expectedPayload).toJson(true))));
+
+        Optional<ShadowDocument> getResults = dao.getShadowThing(THING_NAME, shadowName);
+        assertThat("Should not get the shadow document.", getResults.isPresent(), is(false));
+
+        // After the shadow has been deleted, we should get the correct deleted shadow version.
+        deletedShadowVersion = dao.getDeletedShadowVersion(THING_NAME, shadowName);
+        assertThat(deletedShadowVersion, is(not(Optional.empty())));
+        assertThat(deletedShadowVersion.get(), is(2L));
+    }
+
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.shadowmanager.util.JsonUtil;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Pair;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_METADATA;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_STATE;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
@@ -529,6 +531,8 @@ class SyncTest extends NucleusLaunchUtils {
 
         JsonNode actualNode = JsonUtil.getPayloadJson(actualRequest.payload().asByteArray()).get();
         JsonNode expectedNode = JsonUtil.getPayloadJson(mergedLocalShadowContentV2.getBytes(UTF_8)).get();
+        ((ObjectNode) actualNode).remove(SHADOW_DOCUMENT_METADATA);
+        ((ObjectNode) expectedNode).remove(SHADOW_DOCUMENT_METADATA);
 
         // check that it is request 2 merged on top of request 1 and *not* request 1 merged on top of request 2
         assertThat(actualNode, is(equalTo(expectedNode)));

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAO.java
@@ -77,6 +77,15 @@ public interface ShadowManagerDAO {
     List<Pair<String, String>> listSyncedShadows();
 
     /**
+     * Get the shadow document version of a deleted shadow.
+     *
+     * @param thingName  Name of the Thing for the shadow topic prefix.
+     * @param shadowName Name of shadow topic prefix for thing.
+     * @return The deleted shadow version if it was deleted or exists; Else an empty optional
+     */
+    Optional<Long> getDeletedShadowVersion(String thingName, String shadowName);
+
+    /**
      * Attempts to delete the cloud shadow document in the sync table.
      *
      * @param thingName  Name of the Thing for the shadow topic prefix.
@@ -88,8 +97,8 @@ public interface ShadowManagerDAO {
     /**
      * Attempts to get the shadow document version.
      *
-     * @param thingName       Name of the Thing for the shadow topic prefix.
-     * @param shadowName      Name of shadow topic prefix for thing.
+     * @param thingName  Name of the Thing for the shadow topic prefix.
+     * @param shadowName Name of shadow topic prefix for thing.
      * @return Optional containing the new shadow document version if document exists; Else an empty optional
      */
     Optional<Long> getShadowDocumentVersion(String thingName, String shadowName);

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowDocument.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowDocument.java
@@ -56,6 +56,19 @@ public class ShadowDocument {
      * @throws InvalidRequestParametersException if there was a validation issue while deserializing the shadow doc.
      */
     public ShadowDocument(byte[] documentBytes) throws IOException, InvalidRequestParametersException {
+        this(documentBytes, true);
+    }
+
+    /**
+     * Constructor to create a new shadow document from a byte array.
+     *
+     * @param documentBytes the byte array containing the shadow information.
+     * @param validate      whether to validate the payload or not.
+     * @throws IOException                       if there was an issue while deserializing the shadow byte array.
+     * @throws InvalidRequestParametersException if there was a validation issue while deserializing the shadow doc.
+     */
+    public ShadowDocument(byte[] documentBytes, boolean validate)
+            throws IOException, InvalidRequestParametersException {
         if (documentBytes == null || documentBytes.length == 0) {
             setFields(null, null, null);
             return;
@@ -65,8 +78,10 @@ public class ShadowDocument {
                 .orElseThrow(() ->
                         new InvalidRequestParametersException(ErrorMessage
                                 .createInvalidPayloadJsonMessage("")));
-        // Validate the payload schema
-        JsonUtil.validatePayloadSchema(documentJson);
+        if (validate) {
+            // Validate the payload schema
+            JsonUtil.validatePayloadSchema(documentJson);
+        }
 
         ShadowDocument shadowDocument = SerializerFactory.getFailSafeJsonObjectMapper()
                 .convertValue(documentJson, ShadowDocument.class);

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
@@ -80,7 +80,7 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
      */
     protected Optional<Long> getUpdatedVersion(byte[] payload) {
         try {
-            ShadowDocument document = new ShadowDocument(payload);
+            ShadowDocument document = new ShadowDocument(payload, false);
             return Optional.of(document.getVersion());
         } catch (InvalidRequestParametersException | IOException e) {
             logger.atDebug()

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
@@ -79,10 +79,15 @@ public class CloudDeleteSyncRequest extends BaseSyncRequest {
         }
 
         try {
+            // Since the local shadow has been deleted, we need get the deleted shadow version from the DAO.
+            long localShadowVersion = context.getDao().getDeletedShadowVersion(getThingName(), getShadowName())
+                    .orElse(syncInformation.map(SyncInformation::getLocalVersion).orElse(0L) + 1);
             context.getDao().updateSyncInformation(SyncInformation.builder()
                     .lastSyncedDocument(null)
-                    .cloudVersion(syncInformation.map(SyncInformation::getCloudVersion).orElse(0L))
-                    .localVersion(syncInformation.map(SyncInformation::getLocalVersion).orElse(0L))
+                    // After the cloud shadow has been deleted, the version on cloud gets incremented. So we have to
+                    // increment the synced cloud shadow version.
+                    .cloudVersion(syncInformation.map(SyncInformation::getCloudVersion).orElse(0L) + 1)
+                    .localVersion(localShadowVersion)
                     .cloudDeleted(true)
                     .shadowName(getShadowName())
                     .thingName(getThingName())

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequestTest.java
@@ -97,7 +97,8 @@ class CloudDeleteSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(2L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -79,11 +79,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("PMD.CouplingBetweenObjects")
+@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.ExcessiveClassLength"})
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class FullShadowSyncRequestTest {
     private static final byte[] LOCAL_DOCUMENT = "{\"version\": 10, \"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Pink Floyd\", \"SomethingNew\": true}}}".getBytes();
+    private static final byte[] LOCAL_DOCUMENT_WITH_METADATA = "{\"version\": 10, \"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Pink Floyd\", \"SomethingNew\": true}}, \"metadata\": {\"reported\": {\"name\": {\"timestamp\": 100}, \"NewField\": {\"timestamp\": 100}}, \"desired\": {\"name\": {\"timestamp\": 100}, \"SomethingNew\": {\"timestamp\": 100}}}}".getBytes();
     private static final byte[] CLOUD_DOCUMENT = "{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomeOtherThingNew\": 100}}}".getBytes();
+    private static final byte[] CLOUD_DOCUMENT_WITH_METADATA = "{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomeOtherThingNew\": 100}}, \"metadata\": {\"reported\": {\"name\": {\"timestamp\": 100}, \"OldField\": {\"timestamp\": 100}}, \"desired\": {\"name\": {\"timestamp\": 100}, \"SomeOtherThingNew\": {\"timestamp\": 100}}}}".getBytes();
     private static final byte[] CLOUD_DOCUMENT_WITH_DELTA = "{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomeOtherThingNew\": 100}, \"delta\": {\"name\": \"The Beatles\", \"OldField\": true}}}".getBytes();
     private static final byte[] BASE_DOCUMENT = "{\"version\": 1, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"The Beatles\"}}}".getBytes();
     private static final byte[] MERGED_DOCUMENT = "{\"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomethingNew\": true, \"SomeOtherThingNew\": 100}}}".getBytes();
@@ -116,10 +118,11 @@ class FullShadowSyncRequestTest {
     private SyncContext syncContext;
 
     @BeforeEach
-    void setup() {
+    void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
                 mockIotDataPlaneClientWrapper);
+        JsonUtil.loadSchema();
     }
 
     @Test
@@ -188,10 +191,11 @@ class FullShadowSyncRequestTest {
         long epochSeconds = Instant.now().getEpochSecond();
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         GetThingShadowResponse response = GetThingShadowResponse.builder()
-                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT))
+                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT_WITH_METADATA))
                 .build();
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenReturn(response);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.empty());
+        when(mockDao.getDeletedShadowVersion(anyString(), anyString())).thenReturn(Optional.of(5L));
         when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
                 .cloudUpdateTime(epochSecondsMinus60)
                 .thingName(THING_NAME)
@@ -219,8 +223,8 @@ class FullShadowSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(5L));
-        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(6L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(5L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
@@ -263,9 +267,10 @@ class FullShadowSyncRequestTest {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         long epochSeconds = Instant.now().getEpochSecond();
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
-        ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT);
+        ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT_WITH_METADATA);
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(shadowDocument));
+        when(mockDao.getDeletedShadowVersion(anyString(), anyString())).thenReturn(Optional.of(11L));
         when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
                 .cloudUpdateTime(epochSecondsMinus60)
                 .thingName(THING_NAME)
@@ -295,8 +300,8 @@ class FullShadowSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
-        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(10L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(2L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(11L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSecondsMinus60)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
@@ -413,9 +418,8 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_non_existent_cloud_document_and_existent_local_document_WHEN_execute_THEN_updates_sync_info_only(ExtensionContext context) throws RetryableException, SkipSyncRequestException {
+    void GIVEN_non_existent_cloud_document_and_non_existent_local_document_WHEN_execute_THEN_updates_sync_info_only(ExtensionContext context) throws RetryableException, SkipSyncRequestException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
-        long epochSeconds = Instant.now().getEpochSecond();
 
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.empty());
@@ -445,8 +449,8 @@ class FullShadowSyncRequestTest {
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
         assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(5L));
         assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(10L));
-        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
-        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(Instant.EPOCH.getEpochSecond()));
+        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(Instant.EPOCH.getEpochSecond()));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
         assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
         assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
@@ -476,7 +480,7 @@ class FullShadowSyncRequestTest {
         ignoreExceptionOfType(context, clazz);
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         GetThingShadowResponse response = GetThingShadowResponse.builder()
-                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT))
+                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT_WITH_METADATA))
                 .build();
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenReturn(response);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.empty());
@@ -514,7 +518,7 @@ class FullShadowSyncRequestTest {
         ignoreExceptionOfType(context, clazz);
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         GetThingShadowResponse response = GetThingShadowResponse.builder()
-                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT))
+                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT_WITH_METADATA))
                 .build();
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenReturn(response);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.empty());
@@ -551,7 +555,7 @@ class FullShadowSyncRequestTest {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, clazz);
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
-        ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT);
+        ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT_WITH_METADATA);
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
         when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(shadowDocument));
         when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
@@ -968,6 +972,127 @@ class FullShadowSyncRequestTest {
         assertThat(JsonUtil.getPayloadJson(syncInformationCaptor.getValue().getLastSyncedDocument()).get(), is(expectedMergedDocument));
         assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(6L));
         assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(11L));
+        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
+        assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+    }
+
+    @Test
+    void GIVEN_updated_local_after_delete_WHEN_execute_THEN_updates_cloud_document(ExtensionContext context) throws RetryableException, SkipSyncRequestException, IOException {
+        ignoreExceptionOfType(context, ResourceNotFoundException.class);
+
+        long epochSeconds = Instant.now().getEpochSecond();
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        final byte[] LOCAL_DOCUMENT = ("{\"version\": 10, \"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Pink Floyd\", \"SomethingNew\": true}}, "
+                + "\"metadata\": {\"reported\": {\"name\": {\"timestamp\": " + epochSeconds + "}, \"NewField\": {\"timestamp\": " + epochSeconds + "}}, "
+                + "\"desired\": {\"name\": {\"timestamp\": " + epochSeconds + "}, \"SomethingNew\": {\"timestamp\": " + epochSeconds + "}}}}").getBytes();
+        JsonNode expectedMergedDocument = JsonUtil.getPayloadJson(LOCAL_DOCUMENT).get();
+        ((ObjectNode)expectedMergedDocument).remove(SHADOW_DOCUMENT_VERSION);
+        ((ObjectNode)expectedMergedDocument).remove(SHADOW_DOCUMENT_METADATA);
+
+        ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT);
+        when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(shadowDocument));
+        when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
+        when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(shadowDocument));
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(Instant.EPOCH.getEpochSecond())
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(false)
+                .lastSyncedDocument(null)
+                .cloudVersion(2L)
+                .localVersion(4L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+        when(mockIotDataPlaneClientWrapper.updateThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture(), payloadCaptor.capture()))
+                .thenReturn(UpdateThingShadowResponse.builder().payload(SdkBytes.fromString("{\"version\": 1, \"state\": {}}", UTF_8)).build());
+
+        FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
+        fullShadowSyncRequest.execute(syncContext);
+
+        verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
+        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, times(0)).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockDeleteThingShadowRequestHandler, times(0)).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, times(1)).getThingShadow(anyString(), anyString());
+        verify(mockIotDataPlaneClientWrapper, times(1)).updateThingShadow(anyString(), anyString(), any(byte[].class));
+        verify(mockIotDataPlaneClientWrapper, times(0)).deleteThingShadow(anyString(), anyString());
+
+        assertThat(thingNameCaptor.getValue(), is(THING_NAME));
+        assertThat(shadowNameCaptor.getValue(), is(SHADOW_NAME));
+        JsonNode actualCloudUpdateDocument = JsonUtil.getPayloadJson(payloadCaptor.getValue()).get();
+        ((ObjectNode)actualCloudUpdateDocument).remove(SHADOW_DOCUMENT_METADATA);
+        assertThat(actualCloudUpdateDocument, is(expectedMergedDocument));
+
+        assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
+        JsonNode lastSyncedDocument = JsonUtil.getPayloadJson(syncInformationCaptor.getValue().getLastSyncedDocument()).get();
+        ((ObjectNode)lastSyncedDocument).remove(SHADOW_DOCUMENT_METADATA);
+
+        assertThat(lastSyncedDocument, is(expectedMergedDocument));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(1L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(10L));
+        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
+        assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+    }
+
+    @Test
+    void GIVEN_updated_cloud_document_after_delete_WHEN_execute_THEN_updates_local_document() throws RetryableException, SkipSyncRequestException, IOException {
+        long epochSeconds = Instant.now().getEpochSecond();
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        final byte[] CLOUD_DOCUMENT = ("{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Pink Floyd\", \"SomethingNew\": true}}, "
+                + "\"metadata\": {\"reported\": {\"name\": {\"timestamp\": " + epochSeconds + "}, \"NewField\": {\"timestamp\": " + epochSeconds + "}}, "
+                + "\"desired\": {\"name\": {\"timestamp\": " + epochSeconds + "}, \"SomethingNew\": {\"timestamp\": " + epochSeconds + "}}}}").getBytes();
+
+        JsonNode expectedMergedDocument = JsonUtil.getPayloadJson(CLOUD_DOCUMENT).get();
+        ((ObjectNode)expectedMergedDocument).remove(SHADOW_DOCUMENT_VERSION);
+        ((ObjectNode)expectedMergedDocument).remove(SHADOW_DOCUMENT_METADATA);
+
+        when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.empty());
+        GetThingShadowResponse response = GetThingShadowResponse.builder()
+                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT))
+                .build();
+        when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenReturn(response);
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(Instant.EPOCH.getEpochSecond())
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(true)
+                .lastSyncedDocument(null)
+                .cloudVersion(1L)
+                .localVersion(2L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+        when(mockUpdateThingShadowHandlerResponse.getUpdateThingShadowResponse().getPayload()).thenReturn("{\"version\": 3, \"state\": {}}".getBytes(UTF_8));
+        when(mockUpdateThingShadowRequestHandler.handleRequest(localUpdateThingShadowRequestCaptor.capture(), anyString())).
+                thenReturn(mockUpdateThingShadowHandlerResponse);
+
+        FullShadowSyncRequest fullShadowSyncRequest = new FullShadowSyncRequest(THING_NAME, SHADOW_NAME);
+        fullShadowSyncRequest.execute(syncContext);
+
+        verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
+        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, times(1)).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, times(0)).updateThingShadow(anyString(), anyString(), any(byte[].class));
+
+        software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest localDocumentUpdateRequest = localUpdateThingShadowRequestCaptor.getValue();
+        assertThat(localDocumentUpdateRequest.getShadowName(), is(SHADOW_NAME));
+        assertThat(localDocumentUpdateRequest.getThingName(), is(THING_NAME));
+        JsonNode actualLocalUpdateDocument = JsonUtil.getPayloadJson(localDocumentUpdateRequest.getPayload()).get();
+        ((ObjectNode)actualLocalUpdateDocument).remove(SHADOW_DOCUMENT_METADATA);
+        assertThat(actualLocalUpdateDocument, is(expectedMergedDocument));
+
+        assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
+        JsonNode lastSyncedDocument = JsonUtil.getPayloadJson(syncInformationCaptor.getValue().getLastSyncedDocument()).get();
+        ((ObjectNode)lastSyncedDocument).remove(SHADOW_DOCUMENT_METADATA);
+
+        assertThat(lastSyncedDocument, is(expectedMergedDocument));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(5L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(3L));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-public class LocalDeleteSyncRequestTest {
+class LocalDeleteSyncRequestTest {
 
     private static final byte[] CLOUD_DELETE_PAYLOAD = "{\"version\": 6}".getBytes();
 
@@ -109,7 +109,8 @@ public class LocalDeleteSyncRequestTest {
 
         assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
         assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
-        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(deletedVersion));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(6L));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(deletedVersion + 1));
         assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(syncTime)));
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(syncTime)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-shadow-manager/issues/98

**Description of changes:**
Pull latest code from main into release pipeline.

fix: increment shadow version on shadow delete. (#97)
fix: Do a full sync of shadow after shadow has been deleted before. (#96)

**Why is this change necessary:**
To have the latest changes into the release pipeline for testing.

**How was this change tested:**


**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
