### PR TITLE
fix: do not start syncing until shadow manager is RUNNING

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -109,6 +109,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
         kernel.launch();
 
         assertTrue(shadowManagerRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+        realTimeSyncStrategy.stop();
 
         RetryUtils.RetryConfig retryConfig = RetryUtils.RetryConfig.builder()
                 .maxAttempt(1)
@@ -126,7 +127,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
         }
         syncHandler.setOverallSyncStrategy(syncStrategy);
         isSyncMocked.set(true);
-        shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().updateCloudSubscriptions(true).build());
+        shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().build());
 
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -145,7 +145,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
     public void stop() {
         synchronized (lifecycleLock) {
             if (syncing.compareAndSet(true, false)) {
-                logger.atInfo(SYNC_EVENT_TYPE).log("Stop real time syncing");
+                logger.atInfo(SYNC_EVENT_TYPE).log("Stop syncing");
                 syncing.set(false);
 
                 doStop();
@@ -196,6 +196,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
             logger.atDebug(SYNC_EVENT_TYPE)
                     .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
                     .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                    .addKeyValue("type", request.getClass())
                     .log("Adding new sync request");
 
             syncQueue.put(request);

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -699,16 +699,19 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         strategyTopics.createLeafChild("type").withValue(strategyType);
         strategyTopics.createLeafChild("delay").withValue(interval);
 
+        ShadowManager s = spy(shadowManager);
+
+        doReturn(true).when(s).inState(eq(State.RUNNING));
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC)).thenReturn(strategyTopics);
         doNothing().when(shadowManager.getSyncHandler()).setSyncStrategy(strategyCaptor.capture());
-        shadowManager.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
+        s.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
         ThingShadowSyncConfiguration config = mock(ThingShadowSyncConfiguration.class);
-        shadowManager.getSyncConfiguration().getSyncConfigurations().add(config);
+        s.getSyncConfiguration().getSyncConfigurations().add(config);
 
         when(mockMqttClient.connected()).thenReturn(true);
-        shadowManager.install();
+        s.install();
 
-        assertFalse(shadowManager.isErrored());
+        assertFalse(s.isErrored());
         assertThat(strategyCaptor.getValue(), is(notNullValue()));
         if (STRATEGY_TYPE_REAL_TIME.equals(strategyType)) {
             assertThat(strategyCaptor.getValue().getType(), is(StrategyType.REALTIME));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Only start syncing shadows if Shadow Manager is in `RUNNING` state.

**Why is this change necessary:**
Since we are now processing config which will start syncing shadows in the `install` step, we need to add this additional check so that we are not actually syncing any shadow until Shadow Manager is actually running. In `startup`, Shadow Manager will start syncing these shadows (if required)

**How was this change tested:**
Current tests pass.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
