### PR TITLE
feat: add sync directionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Manifests:
           type: periodic // default realTime
           delay: 300 // in seconds
         synchronize:
+          direction: BIDIRECTIONAL
           # explicit config for Nucleus
           coreThing:
             classic: true // default is true
@@ -64,6 +65,7 @@ Manifests:
     "delay": 300  // in seconds
   },
   "synchronize":{
+    "direction": "BIDIRECTIONAL"
     "coreThing":{
       "classic":true,
       "namedShadows":[

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Manifests:
           type: periodic // default realTime
           delay: 300 // in seconds
         synchronize:
-          direction: BIDIRECTIONAL
+          direction: betweenDeviceAndCloud
           # explicit config for Nucleus
           coreThing:
             classic: true // default is true
@@ -65,7 +65,7 @@ Manifests:
     "delay": 300  // in seconds
   },
   "synchronize":{
-    "direction": "BIDIRECTIONAL"
+    "direction": "betweenDeviceAndCloud"
     "coreThing":{
       "classic":true,
       "namedShadows":[

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtilsConfig.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtilsConfig.java
@@ -25,4 +25,6 @@ public class NucleusLaunchUtilsConfig {
     boolean mqttConnected = true;
     @Builder.Default
     Class syncClazz = RealTimeSyncStrategy.class;
+    @Builder.Default
+    boolean resetRetryConfig = true;
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
@@ -108,9 +108,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         }
 
         // verify that some requests have been throttled
-        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), after(1000).atLeastOnce()).updateThingShadow(
-                any(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest.class));
-        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), after(1000).atMost(6)).updateThingShadow(
+        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), after(500).atMost(4)).updateThingShadow(
                 any(software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest.class));
 
         // verify that the rest of the requests are eventually handled

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
@@ -77,6 +77,7 @@ class ShadowManagerDAOImplTest {
 
         database = new ShadowManagerDatabase(kernel);
         database.install();
+        JsonUtil.loadSchema();
         database.open();
         dao = new ShadowManagerDAOImpl(database);
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests;
+
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
+import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.model.ShadowDocument;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.sync.SyncHandler;
+import com.aws.greengrass.shadowmanager.sync.strategy.RealTimeSyncStrategy;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.slf4j.event.Level;
+import software.amazon.awssdk.aws.greengrass.model.ResourceNotFoundError;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowRequest;
+import software.amazon.awssdk.services.iotdataplane.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRequest;
+import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowResponse;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_STATE;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+class SyncDirectionalityTest extends NucleusLaunchUtils {
+    public static final String MOCK_THING_NAME_1 = "Thing1";
+    public static final String CLASSIC_SHADOW = "";
+
+    private Supplier<Optional<SyncInformation>> syncInfo;
+    private Supplier<Optional<ShadowDocument>> localShadow;
+    private static final String localShadowContentV1 = "{\"state\":{ \"desired\": { \"SomeKey\": \"foo\"}, "
+            + "\"reported\":{\"SomeKey\":\"bar\",\"OtherKey\": 1}}}";
+    private static final String cloudShadowContentV1 = "{\"version\":1,\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
+
+    @Mock
+    UpdateThingShadowResponse mockUpdateThingShadowResponse;
+
+    @Captor
+    private ArgumentCaptor<UpdateThingShadowRequest> cloudUpdateThingShadowRequestCaptor;
+
+    @BeforeEach
+    void setup() {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
+        kernel = new Kernel();
+        syncInfo = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowSyncInformation(MOCK_THING_NAME_1,
+                CLASSIC_SHADOW);
+        localShadow = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowThing(MOCK_THING_NAME_1,
+                CLASSIC_SHADOW);
+        reset(iotDataPlaneClientFactory);
+    }
+
+    @AfterEach
+    void cleanup() {
+        kernel.shutdown();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"sync_directionality_bidirectional.yaml", "sync_directionality_fromdeviceonly.yaml"})
+    void GIVEN_cloud_sync_enabled_WHEN_local_update_THEN_syncs_shadow_to_cloud(String configFileName, ExtensionContext context) throws InterruptedException, IOException {
+        ignoreExceptionOfType(context, InterruptedException.class);
+        ignoreExceptionOfType(context, ResourceNotFoundException.class);
+
+        // no shadow exists in cloud
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
+                .thenThrow(ResourceNotFoundException.class);
+
+        // mock response to update cloud
+        when(mockUpdateThingShadowResponse.payload()).thenReturn(SdkBytes.fromString("{\"version\": 1}", UTF_8));
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
+                .thenReturn(mockUpdateThingShadowResponse);
+
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder()
+                .configFile(configFileName)
+                .mockCloud(true)
+                .resetRetryConfig(false)
+                .build());
+
+        UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
+
+        // update local shadow
+        software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest request = new software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest();
+        request.setThingName(MOCK_THING_NAME_1);
+        request.setShadowName(CLASSIC_SHADOW);
+        request.setPayload(localShadowContentV1.getBytes(UTF_8));
+
+        updateHandler.handleRequest(request, "DoAll");
+        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
+        assertThat(() -> ((RealTimeSyncStrategy) syncHandler.getOverallSyncStrategy()).getSyncQueue().size(), eventuallyEval(is(0)));
+
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(1L)));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+
+        assertThat("local shadow exists", localShadow.get().isPresent(), is(true));
+        ShadowDocument shadowDocument = localShadow.get().get();
+        // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
+        shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
+        JsonNode v1 = new ShadowDocument(localShadowContentV1.getBytes(UTF_8)).toJson(false);
+        assertThat(shadowDocument.toJson(false), is(v1));
+
+        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), times(1)).updateThingShadow(
+                any(UpdateThingShadowRequest.class));
+    }
+
+    @Test
+    void GIVEN_cloud_sync_not_enabled_WHEN_local_update_THEN_does_not_sync_shadow_to_cloud(ExtensionContext context) throws InterruptedException, IOException {
+        ignoreExceptionOfType(context, InterruptedException.class);
+        ignoreExceptionOfType(context, ResourceNotFoundException.class);
+        ignoreExceptionOfType(context, ResourceNotFoundError.class);
+
+        // no shadow exists in cloud
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
+                .thenThrow(ResourceNotFoundException.class);
+
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder()
+                .configFile("sync_directionality_fromcloudonly.yaml")
+                .mockCloud(true)
+                .resetRetryConfig(false)
+                .build());
+        assertThat(() -> kernel.getContext().get(RealTimeSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
+        TimeUnit.SECONDS.sleep(5);
+        UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
+
+        // update local shadow
+        software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest request = new software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest();
+        request.setThingName(MOCK_THING_NAME_1);
+        request.setShadowName(CLASSIC_SHADOW);
+        request.setPayload(localShadowContentV1.getBytes(UTF_8));
+
+        updateHandler.handleRequest(request, "DoAll");
+        assertThat(() -> kernel.getContext().get(RealTimeSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
+
+        assertThat("local shadow exists", localShadow.get().isPresent(), is(true));
+        ShadowDocument shadowDocument = localShadow.get().get();
+        // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
+        shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
+        JsonNode v1 = new ShadowDocument(localShadowContentV1.getBytes(UTF_8)).toJson(false);
+        assertThat(shadowDocument.toJson(false), is(v1));
+
+        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), never()).updateThingShadow(
+                any(UpdateThingShadowRequest.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"sync_directionality_bidirectional.yaml", "sync_directionality_fromcloudonly.yaml"})
+    void GIVEN_device_sync_enabled_WHEN_local_update_THEN_syncs_shadow_to_cloud(String configFileName, ExtensionContext context) throws InterruptedException, IOException {
+        ignoreExceptionOfType(context, InterruptedException.class);
+        ignoreExceptionOfType(context, ResourceNotFoundError.class);
+        ignoreExceptionOfType(context, ResourceNotFoundException.class);
+
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
+                .thenReturn(mockUpdateThingShadowResponse);
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
+                .thenThrow(ResourceNotFoundException.class);
+
+        JsonNode cloudDocument = JsonUtil.getPayloadJson(cloudShadowContentV1.getBytes(UTF_8)).get();
+
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder()
+                .configFile(configFileName)
+                .mockCloud(true)
+                .resetRetryConfig(false)
+                .build());
+        assertThat(() -> kernel.getContext().get(RealTimeSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
+        TimeUnit.SECONDS.sleep(2);
+
+        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
+        syncHandler.pushLocalUpdateSyncRequest(MOCK_THING_NAME_1, CLASSIC_SHADOW, JsonUtil.getPayloadBytes(cloudDocument));
+        assertThat(() -> kernel.getContext().get(RealTimeSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
+
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(1L)));
+        assertThat("local version", syncInfo.get().get().getLocalVersion(), is(1L));
+
+        assertThat("local shadow exists", localShadow.get().isPresent(), is(true));
+        ShadowDocument shadowDocument = localShadow.get().get();
+        // remove metadata node and version (JsonNode version will fail a comparison of long vs int)
+        shadowDocument = new ShadowDocument(shadowDocument.getState(), null, null);
+        assertThat(shadowDocument.toJson(false).get(SHADOW_DOCUMENT_STATE), is(cloudDocument.get(SHADOW_DOCUMENT_STATE)));
+
+        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), never()).updateThingShadow(
+                any(UpdateThingShadowRequest.class));
+    }
+
+    @Test
+    void GIVEN_device_sync_not_enabled_WHEN_local_update_THEN_does_not_sync_shadow_to_cloud() throws InterruptedException, IOException {
+        JsonNode cloudDocument = JsonUtil.getPayloadJson(cloudShadowContentV1.getBytes(UTF_8)).get();
+
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder()
+                .configFile("sync_directionality_fromdeviceonly.yaml")
+                .mockCloud(true)
+                .resetRetryConfig(false)
+                .build());
+        assertThat(() -> kernel.getContext().get(RealTimeSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
+        TimeUnit.SECONDS.sleep(2);
+
+        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
+        syncHandler.pushLocalUpdateSyncRequest(MOCK_THING_NAME_1, CLASSIC_SHADOW, JsonUtil.getPayloadBytes(cloudDocument));
+        assertThat(() -> kernel.getContext().get(RealTimeSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
+
+        TimeUnit.SECONDS.sleep(2);
+
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("local shadow exists", () -> localShadow.get().isPresent(), eventuallyEval(is(false)));
+
+        verify(iotDataPlaneClientFactory.getIotDataPlaneClient(), never()).updateThingShadow(
+                any(UpdateThingShadowRequest.class));
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -16,7 +16,6 @@ import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfiguration;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.strategy.BaseSyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.PeriodicSyncStrategy;
@@ -149,18 +148,6 @@ class SyncTest extends NucleusLaunchUtils {
         } else {
             return "periodic_sync.yaml";
         }
-    }
-
-    private void assertEmptySyncQueue(Class<? extends BaseSyncStrategy> clazz) {
-        BaseSyncStrategy s = kernel.getContext().get(clazz);
-
-        assertThat("syncing has started", s::isSyncing, eventuallyEval(is(true)));
-
-        RequestBlockingQueue q = s.getSyncQueue();
-
-        // queue is eventually empty (full syncs are added and then eventually removed)
-        assertThat("sync queue is eventually empty", () -> q.isEmpty() && !s.isExecuting(),
-                eventuallyEval(is(true), Duration.ofSeconds(10)));
     }
 
     @ParameterizedTest

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_bidirectional.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_bidirectional.yaml
@@ -1,0 +1,51 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.ShadowManager:
+    configuration:
+      synchronize:
+        direction: BIDIRECTIONAL
+        shadowDocumentsMap:
+          Thing1:
+            classic: true
+          Thing2:
+            namedShadows:
+              - "foo"
+              - "bar"
+
+  main:
+    dependencies:
+      - DoAll
+  DoAll:
+    lifecycle:
+      startup: echo "Running"
+      shutdown: echo "Stopping"
+    dependencies:
+      - aws.greengrass.ShadowManager
+    configuration:
+      accessControl:
+        aws.greengrass.ShadowManager:
+          policyId1:
+            policyDescription: access to CRUD shadow operations
+            operations:
+              - 'aws.greengrass#GetThingShadow'
+              - 'aws.greengrass#UpdateThingShadow'
+              - 'aws.greengrass#DeleteThingShadow'
+            resources:
+              - '*'
+          policyId2:
+            policyDescription: access to list named shadows
+            operations:
+              - 'aws.greengrass#ListNamedShadowsForThing'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId3:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+            resources:
+              - '*'

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_bidirectional.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_bidirectional.yaml
@@ -7,7 +7,7 @@ services:
   aws.greengrass.ShadowManager:
     configuration:
       synchronize:
-        direction: BIDIRECTIONAL
+        direction: betweenDeviceAndCloud
         shadowDocumentsMap:
           Thing1:
             classic: true

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromcloudonly.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromcloudonly.yaml
@@ -1,0 +1,51 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.ShadowManager:
+    configuration:
+      synchronize:
+        direction: FROMCLOUDONLY
+        shadowDocumentsMap:
+          Thing1:
+            classic: true
+          Thing2:
+            namedShadows:
+              - "foo"
+              - "bar"
+
+  main:
+    dependencies:
+      - DoAll
+  DoAll:
+    lifecycle:
+      startup: echo "Running"
+      shutdown: echo "Stopping"
+    dependencies:
+      - aws.greengrass.ShadowManager
+    configuration:
+      accessControl:
+        aws.greengrass.ShadowManager:
+          policyId1:
+            policyDescription: access to CRUD shadow operations
+            operations:
+              - 'aws.greengrass#GetThingShadow'
+              - 'aws.greengrass#UpdateThingShadow'
+              - 'aws.greengrass#DeleteThingShadow'
+            resources:
+              - '*'
+          policyId2:
+            policyDescription: access to list named shadows
+            operations:
+              - 'aws.greengrass#ListNamedShadowsForThing'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId3:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+            resources:
+              - '*'

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromcloudonly.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromcloudonly.yaml
@@ -7,7 +7,7 @@ services:
   aws.greengrass.ShadowManager:
     configuration:
       synchronize:
-        direction: FROMCLOUDONLY
+        direction: cloudToDevice
         shadowDocumentsMap:
           Thing1:
             classic: true

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromdeviceonly.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromdeviceonly.yaml
@@ -1,0 +1,51 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.ShadowManager:
+    configuration:
+      synchronize:
+        direction: FROMDEVICEONLY
+        shadowDocumentsMap:
+          Thing1:
+            classic: true
+          Thing2:
+            namedShadows:
+              - "foo"
+              - "bar"
+
+  main:
+    dependencies:
+      - DoAll
+  DoAll:
+    lifecycle:
+      startup: echo "Running"
+      shutdown: echo "Stopping"
+    dependencies:
+      - aws.greengrass.ShadowManager
+    configuration:
+      accessControl:
+        aws.greengrass.ShadowManager:
+          policyId1:
+            policyDescription: access to CRUD shadow operations
+            operations:
+              - 'aws.greengrass#GetThingShadow'
+              - 'aws.greengrass#UpdateThingShadow'
+              - 'aws.greengrass#DeleteThingShadow'
+            resources:
+              - '*'
+          policyId2:
+            policyDescription: access to list named shadows
+            operations:
+              - 'aws.greengrass#ListNamedShadowsForThing'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId3:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+            resources:
+              - '*'

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromdeviceonly.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync_directionality_fromdeviceonly.yaml
@@ -7,7 +7,7 @@ services:
   aws.greengrass.ShadowManager:
     configuration:
       synchronize:
-        direction: FROMDEVICEONLY
+        direction: deviceToCloud
         shadowDocumentsMap:
           Thing1:
             classic: true

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -34,6 +34,7 @@ import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.CloudDataClient;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
+import com.aws.greengrass.shadowmanager.sync.model.Direction;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.Strategy;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
@@ -70,6 +71,7 @@ import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_RATE_LIMITS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_STRATEGY_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNCHRONIZATION_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNC_DIRECTION_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_DOCUMENT_SIZE;
 import static com.aws.greengrass.shadowmanager.sync.strategy.model.Strategy.DEFAULT_STRATEGY;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.DELETE_THING_SHADOW;
@@ -108,7 +110,8 @@ public class ShadowManager extends PluginService {
         @Override
         public void onConnectionResumed(boolean sessionPresent) {
             if (inState(State.RUNNING)) {
-                startSyncingShadows(StartSyncInfo.builder().updateCloudSubscriptions(true).build());
+                startSyncingShadows(StartSyncInfo.builder().startSyncStrategy(true).startSyncStrategy(true)
+                        .updateCloudSubscriptions(true).build());
 
             }
         }
@@ -211,9 +214,22 @@ public class ShadowManager extends PluginService {
 
     @Override
     protected void install() {
+        install(InstallConfig.builder()
+                .configureMaxDocSizeLimitConfig(true)
+                .configureRateLimitsConfig(true)
+                .configureStrategyConfig(true)
+                .configureSyncDirectionConfig(true)
+                .configureSynchronizeConfig(true)
+                .installDatabase(true)
+                .build());
+    }
+
+    protected void install(InstallConfig installConfig) {
         try {
-            database.install();
-            JsonUtil.loadSchema();
+            if (installConfig.installDatabase) {
+                database.install();
+                JsonUtil.loadSchema();
+            }
         } catch (FlywayException | IOException e) {
             serviceErrored(e);
             return;
@@ -221,108 +237,148 @@ public class ShadowManager extends PluginService {
 
         inboundRateLimiter.clear();
 
-        Topics configTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC);
-        configTopics.subscribe((what, newv) -> {
-            Map<String, Object> configTopicsPojo = configTopics.toPOJO();
-            try {
-                Topic thingNameTopic = this.deviceConfiguration.getThingName();
-                String thingName = Coerce.toString(thingNameTopic);
-                ShadowSyncConfiguration newSyncConfiguration =
-                        ShadowSyncConfiguration.processConfiguration(configTopicsPojo, thingName);
-                if (this.syncConfiguration != null && this.syncConfiguration.equals(newSyncConfiguration)) {
-                    return;
-                }
-                this.syncConfiguration = newSyncConfiguration;
-                this.syncHandler.setSyncConfigurations(this.syncConfiguration.getSyncConfigurations());
-
-                // Subscribe to the thing name topic if the Nucleus thing shadows have been synced.
-                Optional<ThingShadowSyncConfiguration> coreThingConfig =
-                        getCoreThingShadowSyncConfiguration(thingName);
-                if (coreThingConfig.isPresent()) {
-                    thingNameTopic.subscribeGeneric(this.deviceThingNameWatcher);
-                } else {
-                    thingNameTopic.remove(this.deviceThingNameWatcher);
-                }
-
-                // only stop / start syncing if we are not in install - it will otherwise be started by lifecycle
-                if (inState(State.RUNNING)) {
-                    stopSyncingShadows(true);
-                    startSyncingShadows(StartSyncInfo.builder().reInitializeSyncInfo(true)
-                            .updateCloudSubscriptions(true).build());
-                }
-            } catch (InvalidConfigurationException e) {
-                serviceErrored(e);
-            }
-        });
-
-        Topics rateLimitTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC);
-        rateLimitTopics.subscribe((what, newv) -> {
-            Map<String, Object> rateLimitsPojo = rateLimitTopics.toPOJO();
-            try {
-                if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC)) {
-                    int maxOutboundSyncUpdatesPerSecond = Coerce.toInt(rateLimitsPojo
-                            .get(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC));
-                    Validator.validateOutboundSyncUpdatesPerSecond(maxOutboundSyncUpdatesPerSecond);
-                    iotDataPlaneClientWrapper.setRate(maxOutboundSyncUpdatesPerSecond);
-                }
-
-                if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE)) {
-                    int maxTotalLocalRequestRate = Coerce.toInt(rateLimitsPojo
-                            .get(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE));
-                    Validator.validateTotalLocalRequestRate(maxTotalLocalRequestRate);
-                    inboundRateLimiter.setTotalRate(maxTotalLocalRequestRate);
-                }
-
-                if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC)) {
-                    int maxLocalShadowUpdatesPerThingPerSecond = Coerce.toInt(rateLimitsPojo
-                            .get(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC));
-                    Validator.validateLocalShadowRequestsPerThingPerSecond(maxLocalShadowUpdatesPerThingPerSecond);
-                    inboundRateLimiter.setRate(maxLocalShadowUpdatesPerThingPerSecond);
-                }
-            } catch (InvalidConfigurationException e) {
-                serviceErrored(e);
-            }
-        });
-
-        config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC)
-                .dflt(DEFAULT_DOCUMENT_SIZE)
-                .subscribe((why, newv) -> {
-                    int newMaxShadowSize;
-                    if (WhatHappened.removed.equals(why)) {
-                        newMaxShadowSize = DEFAULT_DOCUMENT_SIZE;
-                    } else {
-                        newMaxShadowSize = Coerce.toInt(newv);
-                    }
-                    try {
-                        Validator.validateMaxShadowSize(newMaxShadowSize);
-                        Validator.setMaxShadowDocumentSize(newMaxShadowSize);
-                        updateThingShadowRequestHandler.setMaxShadowSize(newMaxShadowSize);
-                    } catch (InvalidConfigurationException e) {
-                        serviceErrored(e);
-                    }
-                });
-
-        Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
-        final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
-
-        strategyTopics.subscribe((why, newv) -> {
-            Strategy strategy;
-            Map<String, Object> strategyPojo = strategyTopics.toPOJO();
-
-            if (WhatHappened.removed.equals(why) || strategyPojo == null || strategyPojo.isEmpty()) {
-                strategy = DEFAULT_STRATEGY;
-            } else {
-                // Get the correct sync strategy configuration from the POJO.
+        if (installConfig.configureSynchronizeConfig) {
+            Topics configTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC);
+            configTopics.subscribe((what, newv) -> {
+                Map<String, Object> configTopicsPojo = configTopics.toPOJO();
                 try {
-                    strategy = Strategy.fromPojo(strategyPojo);
+                    Topic thingNameTopic = this.deviceConfiguration.getThingName();
+                    String thingName = Coerce.toString(thingNameTopic);
+                    ShadowSyncConfiguration newSyncConfiguration =
+                            ShadowSyncConfiguration.processConfiguration(configTopicsPojo, thingName);
+                    if (this.syncConfiguration != null && this.syncConfiguration.equals(newSyncConfiguration)) {
+                        return;
+                    }
+                    this.syncConfiguration = newSyncConfiguration;
+                    this.syncHandler.setSyncConfigurations(this.syncConfiguration.getSyncConfigurations());
+
+                    // Subscribe to the thing name topic if the Nucleus thing shadows have been synced.
+                    Optional<ThingShadowSyncConfiguration> coreThingConfig =
+                            getCoreThingShadowSyncConfiguration(thingName);
+                    if (coreThingConfig.isPresent()) {
+                        thingNameTopic.subscribeGeneric(this.deviceThingNameWatcher);
+                    } else {
+                        thingNameTopic.remove(this.deviceThingNameWatcher);
+                    }
+
+                    // only stop / start syncing if we are not in install - it will otherwise be started by lifecycle
+                    if (inState(State.RUNNING)) {
+                        stopSyncingShadows(true);
+                        startSyncingShadows(StartSyncInfo.builder().reInitializeSyncInfo(true).startSyncStrategy(true)
+                                .updateCloudSubscriptions(true).build());
+                    }
                 } catch (InvalidConfigurationException e) {
                     serviceErrored(e);
-                    return;
                 }
-            }
+            });
+        }
 
-            currentStrategy.set(replaceStrategyIfNecessary(currentStrategy.get(), strategy));
-        });
+        if (installConfig.configureRateLimitsConfig) {
+            Topics rateLimitTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC);
+            rateLimitTopics.subscribe((what, newv) -> {
+                Map<String, Object> rateLimitsPojo = rateLimitTopics.toPOJO();
+                try {
+                    if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC)) {
+                        int maxOutboundSyncUpdatesPerSecond = Coerce.toInt(rateLimitsPojo
+                                .get(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC));
+                        Validator.validateOutboundSyncUpdatesPerSecond(maxOutboundSyncUpdatesPerSecond);
+                        iotDataPlaneClientWrapper.setRate(maxOutboundSyncUpdatesPerSecond);
+                    }
+
+                    if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE)) {
+                        int maxTotalLocalRequestRate = Coerce.toInt(rateLimitsPojo
+                                .get(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE));
+                        Validator.validateTotalLocalRequestRate(maxTotalLocalRequestRate);
+                        inboundRateLimiter.setTotalRate(maxTotalLocalRequestRate);
+                    }
+
+                    if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC)) {
+                        int maxLocalShadowUpdatesPerThingPerSecond = Coerce.toInt(rateLimitsPojo
+                                .get(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC));
+                        Validator.validateLocalShadowRequestsPerThingPerSecond(maxLocalShadowUpdatesPerThingPerSecond);
+                        inboundRateLimiter.setRate(maxLocalShadowUpdatesPerThingPerSecond);
+                    }
+                } catch (InvalidConfigurationException e) {
+                    serviceErrored(e);
+                }
+            });
+        }
+
+
+        if (installConfig.configureMaxDocSizeLimitConfig) {
+            config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC)
+                    .dflt(DEFAULT_DOCUMENT_SIZE)
+                    .subscribe((why, newv) -> {
+                        int newMaxShadowSize;
+                        if (WhatHappened.removed.equals(why)) {
+                            newMaxShadowSize = DEFAULT_DOCUMENT_SIZE;
+                        } else {
+                            newMaxShadowSize = Coerce.toInt(newv);
+                        }
+                        try {
+                            Validator.validateMaxShadowSize(newMaxShadowSize);
+                            Validator.setMaxShadowDocumentSize(newMaxShadowSize);
+                            updateThingShadowRequestHandler.setMaxShadowSize(newMaxShadowSize);
+                        } catch (InvalidConfigurationException e) {
+                            serviceErrored(new InvalidConfigurationException(e));
+                        }
+                    });
+        }
+
+        if (installConfig.configureSyncDirectionConfig) {
+            config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC,
+                    CONFIGURATION_SYNC_DIRECTION_TOPIC)
+                    .dflt(Direction.BIDIRECTIONAL)
+                    .subscribe((why, newv) -> {
+                        Direction newSyncDirection;
+                        if (WhatHappened.removed.equals(why)) {
+                            newSyncDirection = Direction.BIDIRECTIONAL;
+                        } else {
+                            try {
+                                newSyncDirection = Direction.valueOf(Coerce.toString(newv));
+                            } catch (IllegalArgumentException e) {
+                                serviceErrored(e);
+                                return;
+                            }
+                        }
+
+                        Direction currentDirection = syncHandler.getSyncDirection();
+                        // if the sync direction is the same, then just return and do nothing.
+                        if (newSyncDirection.equals(currentDirection)) {
+                            logger.atDebug()
+                                    .log("Not processing sync direction config change since it is the same {}",
+                                            currentDirection);
+                            return;
+                        }
+
+                        setupSync(newSyncDirection, Optional.of(currentDirection));
+                        syncHandler.setSyncDirection(newSyncDirection);
+                    });
+        }
+
+        if (installConfig.configureStrategyConfig) {
+            Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
+            final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
+
+            strategyTopics.subscribe((why, newv) -> {
+                Strategy strategy;
+                Map<String, Object> strategyPojo = strategyTopics.toPOJO();
+
+                if (WhatHappened.removed.equals(why) || strategyPojo == null || strategyPojo.isEmpty()) {
+                    strategy = DEFAULT_STRATEGY;
+                } else {
+                    // Get the correct sync strategy configuration from the POJO.
+                    try {
+                        strategy = Strategy.fromPojo(strategyPojo);
+                    } catch (InvalidConfigurationException e) {
+                        serviceErrored(e);
+                        return;
+                    }
+                }
+
+                currentStrategy.set(replaceStrategyIfNecessary(currentStrategy.get(), strategy));
+            });
+        }
     }
 
     Strategy replaceStrategyIfNecessary(Strategy currentStrategy, Strategy strategy) {
@@ -330,9 +386,51 @@ public class ShadowManager extends PluginService {
             currentStrategy = strategy;
             stopSyncingShadows(false);
             syncHandler.setSyncStrategy(strategy);
-            startSyncingShadows(StartSyncInfo.builder().build());
+            startSyncingShadows(StartSyncInfo.builder().startSyncStrategy(true).build());
         }
         return currentStrategy;
+    }
+
+    private void setupSync(Direction newSyncDirection, Optional<Direction> currentDirection) {
+        if (Direction.FROMDEVICEONLY.equals(newSyncDirection)) {
+            // If we are going to update the cloud after a local shadow has been updated, then stop
+            // the existing sync loop future which is trying to subscribe to shadow topics.
+            // Also unsubscribe all the shadow topics that we have already subscribed to.
+            // Start the sync strategy if the current direction was FROMCLOUDONLY
+            cloudDataClient.stopSubscribing();
+            cloudDataClient.unsubscribeForAllShadowsTopics();
+            startSyncingShadows(StartSyncInfo.builder()
+                    .overrideRunningCheck(!currentDirection.isPresent())
+                    .reInitializeSyncInfo(!currentDirection.isPresent())
+                    .startSyncStrategy(!currentDirection.isPresent())
+                    .build());
+        } else if (Direction.FROMCLOUDONLY.equals(newSyncDirection)) {
+            // If we are only going to get an update after a cloud shadow has been updated, then
+            // update the shadow subscriptions if the current direction was FROMDEVICEONLY (since we
+            // would have unsubscribed from all topics).
+            // Stop the sync strategy loop.
+            // TODO: do we need to clear the sync queue?
+            if (!currentDirection.isPresent() || Direction.FROMDEVICEONLY.equals(currentDirection.get())) {
+                cloudDataClient.updateSubscriptions(syncConfiguration.getSyncShadows());
+            }
+            startSyncingShadows(StartSyncInfo.builder()
+                    .overrideRunningCheck(!currentDirection.isPresent())
+                    .reInitializeSyncInfo(!currentDirection.isPresent())
+                    .startSyncStrategy(!currentDirection.isPresent())
+                    .build());
+        } else {
+            // If we need to do a bidrectional sync, then start the sync strategy loop only if the
+            // current direction was FROMCLOUDONLY (since we would have stopped the loop) and update
+            // all the cloud subscriptions only if the current direction was FROMDEVICEONLY (since we
+            // would have unsubscribed from all topics).
+            startSyncingShadows(StartSyncInfo.builder()
+                    .startSyncStrategy(!currentDirection.isPresent())
+                    .updateCloudSubscriptions(!currentDirection.isPresent()
+                            || Direction.FROMDEVICEONLY.equals(currentDirection.get()))
+                    .reInitializeSyncInfo(!currentDirection.isPresent())
+                    .overrideRunningCheck(!currentDirection.isPresent())
+                    .build());
+        }
     }
 
     private void deleteRemovedSyncInformation() {
@@ -392,9 +490,7 @@ public class ShadowManager extends PluginService {
             database.open();
 
             reportState(State.RUNNING);
-            startSyncingShadows(StartSyncInfo.builder().reInitializeSyncInfo(true).overrideRunningCheck(true)
-                    .updateCloudSubscriptions(true).build());
-
+            setupSync(syncHandler.getSyncDirection(), Optional.empty());
         } catch (Exception e) {
             serviceErrored(e);
         }
@@ -454,10 +550,12 @@ public class ShadowManager extends PluginService {
         }
 
         if (mqttClient.connected() && !syncConfiguration.getSyncConfigurations().isEmpty()) {
-            final SyncContext syncContext = new SyncContext(dao, getUpdateThingShadowRequestHandler(),
-                    getDeleteThingShadowRequestHandler(),
-                    iotDataPlaneClientWrapper);
-            syncHandler.start(syncContext, SyncHandler.DEFAULT_PARALLELISM);
+            if (startSyncInfo.startSyncStrategy) {
+                final SyncContext syncContext = new SyncContext(dao, getUpdateThingShadowRequestHandler(),
+                        getDeleteThingShadowRequestHandler(),
+                        iotDataPlaneClientWrapper);
+                syncHandler.start(syncContext, SyncHandler.DEFAULT_PARALLELISM);
+            }
 
             // Only update the MQTT subscriptions to cloud shadows at startup or reconnection.
             if (startSyncInfo.updateCloudSubscriptions) {
@@ -494,5 +592,49 @@ public class ShadowManager extends PluginService {
          * ONLY supposed to be used in startup.
          */
         boolean overrideRunningCheck;
+
+        /**
+         * Whether or not to start the sync strategy.
+         */
+        boolean startSyncStrategy;
+    }
+
+    /**
+     * Class to handle different configurations on how to install the shadow manager component.
+     *
+     * @implNote This class is only used in tests in order to avoid any unnecessary mocks.
+     */
+    @Builder
+    @Data
+    public static class InstallConfig {
+        /**
+         * Whether or not to install the database and load the JSON schema for validation.
+         */
+        boolean installDatabase;
+
+        /**
+         * Whether or not to subscribe to the synchronize config field.
+         */
+        boolean configureSynchronizeConfig;
+
+        /**
+         * Whether or not to subscribe to the rate limits config field.
+         */
+        boolean configureRateLimitsConfig;
+
+        /**
+         * Whether or not to subscribe to the max doc size config field.
+         */
+        boolean configureMaxDocSizeLimitConfig;
+
+        /**
+         * Whether or not to subscribe to the sync direction config field.
+         */
+        boolean configureSyncDirectionConfig;
+
+        /**
+         * Whether or not to subscribe to the sync strategy config field.
+         */
+        boolean configureStrategyConfig;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
@@ -72,6 +72,7 @@ public final class Constants {
     public static final String CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC =
             "maxLocalRequestsPerSecondPerThing";
     public static final String CONFIGURATION_STRATEGY_TOPIC = "strategy";
+    public static final String CONFIGURATION_SYNC_DIRECTION_TOPIC = "direction";
     public static final String UNEXPECTED_TYPE_FORMAT = "Unexpected type in %s: %s";
     public static final String UNEXPECTED_VALUE_FORMAT = "Unexpected value in %s: %s";
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
@@ -78,7 +78,7 @@ public class SyncHandler {
      */
     @Getter
     @Setter
-    private Direction syncDirection = Direction.BIDIRECTIONAL;
+    private Direction syncDirection = Direction.BETWEEN_DEVICE_AND_CLOUD;
 
     /**
      * The sync strategy factory object to generate.
@@ -162,13 +162,13 @@ public class SyncHandler {
         }
         Stream<BaseSyncRequest> requestStream = null;
         switch (getSyncDirection()) {
-            case BIDIRECTIONAL:
+            case BETWEEN_DEVICE_AND_CLOUD:
                 requestStream = shadows.stream().map(p -> new FullShadowSyncRequest(p.getLeft(), p.getRight()));
                 break;
-            case FROMDEVICEONLY:
+            case DEVICE_TO_CLOUD:
                 requestStream = shadows.stream().map(p -> new OverwriteCloudShadowRequest(p.getLeft(), p.getRight()));
                 break;
-            case FROMCLOUDONLY:
+            case CLOUD_TO_DEVICE:
                 requestStream = shadows.stream().map(p -> new OverwriteLocalShadowRequest(p.getLeft(), p.getRight()));
                 break;
             default:
@@ -224,7 +224,7 @@ public class SyncHandler {
      * @param updateDocument The update shadow request
      */
     public void pushCloudUpdateSyncRequest(String thingName, String shadowName, JsonNode updateDocument) {
-        if (isShadowSynced(thingName, shadowName) && !Direction.FROMCLOUDONLY.equals(syncDirection)) {
+        if (isShadowSynced(thingName, shadowName) && !Direction.CLOUD_TO_DEVICE.equals(syncDirection)) {
             overallSyncStrategy.putSyncRequest(new CloudUpdateSyncRequest(thingName, shadowName, updateDocument));
         }
     }
@@ -238,7 +238,7 @@ public class SyncHandler {
      * @param updateDocument Update document to be applied to local shadow
      */
     public void pushLocalUpdateSyncRequest(String thingName, String shadowName, byte[] updateDocument) {
-        if (isShadowSynced(thingName, shadowName) && !Direction.FROMDEVICEONLY.equals(syncDirection)) {
+        if (isShadowSynced(thingName, shadowName) && !Direction.DEVICE_TO_CLOUD.equals(syncDirection)) {
             overallSyncStrategy.putSyncRequest(new LocalUpdateSyncRequest(thingName, shadowName, updateDocument));
         }
     }
@@ -251,7 +251,7 @@ public class SyncHandler {
      * @param shadowName The shadow name associated with the sync shadow update
      */
     public void pushCloudDeleteSyncRequest(String thingName, String shadowName) {
-        if (isShadowSynced(thingName, shadowName) && !Direction.FROMCLOUDONLY.equals(syncDirection)) {
+        if (isShadowSynced(thingName, shadowName) && !Direction.CLOUD_TO_DEVICE.equals(syncDirection)) {
             overallSyncStrategy.putSyncRequest(new CloudDeleteSyncRequest(thingName, shadowName));
         }
     }
@@ -265,7 +265,7 @@ public class SyncHandler {
      * @param deletePayload Delete response payload containing the deleted shadow version
      */
     public void pushLocalDeleteSyncRequest(String thingName, String shadowName, byte[] deletePayload) {
-        if (isShadowSynced(thingName, shadowName) && !Direction.FROMDEVICEONLY.equals(syncDirection)) {
+        if (isShadowSynced(thingName, shadowName) && !Direction.DEVICE_TO_CLOUD.equals(syncDirection)) {
             overallSyncStrategy.putSyncRequest(new LocalDeleteSyncRequest(thingName, shadowName, deletePayload));
         }
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
@@ -70,7 +70,7 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
      * @param shadowName The shadow name associated with the sync shadow update
      */
     protected BaseSyncRequest(String thingName,
-                           String shadowName) {
+                              String shadowName) {
         super(thingName, shadowName);
     }
 
@@ -153,6 +153,7 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
                 .thingName(getThingName())
                 .cloudUpdateTime(Instant.now().getEpochSecond())
                 .lastSyncedDocument(null)
+                .cloudDeleted(true)
                 .build());
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
@@ -5,22 +5,53 @@
 
 package com.aws.greengrass.shadowmanager.sync.model;
 
+import com.aws.greengrass.logging.api.LogEventBuilder;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.ShadowManager;
 import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
+import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.ShadowRequest;
+import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.util.JsonMerger;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import software.amazon.awssdk.aws.greengrass.model.ConflictError;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.services.iotdataplane.model.ConflictException;
+import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowResponse;
+import software.amazon.awssdk.services.iotdataplane.model.InternalFailureException;
+import software.amazon.awssdk.services.iotdataplane.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.iotdataplane.model.ServiceUnavailableException;
+import software.amazon.awssdk.services.iotdataplane.model.ThrottlingException;
+import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowResponse;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Optional;
 
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_CLOUD_VERSION_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_LOCAL_VERSION_KEY;
 import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
 import static com.aws.greengrass.shadowmanager.model.Constants.LOG_THING_NAME_KEY;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_STATE;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_VERSION;
 
 /**
  * Base class for all sync requests.
@@ -28,13 +59,17 @@ import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_S
 public abstract class BaseSyncRequest extends ShadowRequest implements SyncRequest {
     private static final Logger logger = LogManager.getLogger(BaseSyncRequest.class);
 
+    @Setter(AccessLevel.PROTECTED)
+    @Getter(AccessLevel.PROTECTED)
+    private SyncContext context;
+
     /**
      * Ctr for BaseSyncRequest.
      *
      * @param thingName  The thing name associated with the sync shadow update
      * @param shadowName The shadow name associated with the sync shadow update
      */
-    public BaseSyncRequest(String thingName,
+    protected BaseSyncRequest(String thingName,
                            String shadowName) {
         super(thingName, shadowName);
     }
@@ -90,5 +125,377 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
                     .log("Unable to get the updated version from the payload");
             return Optional.empty();
         }
+    }
+
+    /**
+     * Delete the cloud shadow using the IoT Data plane client and then update the sync information.
+     *
+     * @param syncInformation            The sync information for the thing's shadow.
+     * @param cloudShadowDocumentVersion The current cloud document version.
+     * @throws RetryableException       if the delete request to cloud encountered a retryable exception.
+     * @throws SkipSyncRequestException if the delete request to cloud encountered a skipable exception.
+     * @throws InterruptedException     if the thread is interrupted while syncing shadow with cloud.
+     */
+    void handleCloudDelete(@NonNull Long cloudShadowDocumentVersion,
+                           @NonNull SyncInformation syncInformation)
+            throws RetryableException, SkipSyncRequestException, InterruptedException {
+        deleteCloudShadowDocument();
+        // Since the local shadow has been deleted, we need get the deleted shadow version from the DAO.
+        long localShadowVersion = context.getDao().getDeletedShadowVersion(getThingName(), getShadowName())
+                .orElse(syncInformation.getLocalVersion() + 1);
+        context.getDao().updateSyncInformation(SyncInformation.builder()
+                .localVersion(localShadowVersion)
+                // The version number we get in the MQTT message is the version of the cloud shadow that was
+                // deleted. But the cloud shadow version after the delete has been incremented by 1. So we have
+                // synced that incremented version instead of the deleted cloud shadow version.
+                .cloudVersion(cloudShadowDocumentVersion + 1)
+                .shadowName(getShadowName())
+                .thingName(getThingName())
+                .cloudUpdateTime(Instant.now().getEpochSecond())
+                .lastSyncedDocument(null)
+                .build());
+    }
+
+    /**
+     * Delete the cloud document using the IoT Data plane client.
+     *
+     * @throws RetryableException       if the delete request encountered errors which should be retried.
+     * @throws SkipSyncRequestException if the delete request encountered errors which should be skipped.
+     * @throws InterruptedException     if the thread is interrupted while syncing shadow with cloud.
+     */
+    private void deleteCloudShadowDocument() throws RetryableException, SkipSyncRequestException, InterruptedException {
+        try {
+            logger.atInfo()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Deleting cloud shadow document");
+            context.getIotDataPlaneClientWrapper().deleteThingShadow(getThingName(), getShadowName());
+        } catch (ThrottlingException | ServiceUnavailableException | InternalFailureException e) {
+            logger.atWarn()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Could not execute cloud shadow delete request");
+            throw new RetryableException(e);
+        } catch (AbortedException e) {
+            LogEventBuilder l = logger.atDebug()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName());
+            Throwable cause = e.getCause();
+            if (cause instanceof InterruptedException) {
+                l.log("Interrupted while deleting cloud shadow");
+                throw (InterruptedException) cause;
+            }
+            l.log("Skipping delete for cloud shadow");
+            throw new SkipSyncRequestException(e);
+        } catch (SdkServiceException | SdkClientException e) {
+            logger.atError()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Could not execute cloud shadow delete request");
+            throw new SkipSyncRequestException(e);
+        }
+    }
+
+    /**
+     * Add the version node to the update request payload and then update the cloud shadow document using that request.
+     *
+     * @param updateDocument       The update request payload.
+     * @param cloudDocumentVersion The current cloud document version.
+     * @return the updated local document version.
+     * @throws RetryableException       if the delete request to cloud encountered a retryable exception or if the
+     *                                  serialization of the update request payload failed.
+     * @throws SkipSyncRequestException if the delete request to cloud encountered a skipable exception.
+     */
+    long updateCloudDocumentAndGetUpdatedVersion(ObjectNode updateDocument, Optional<Long> cloudDocumentVersion)
+            throws SkipSyncRequestException, RetryableException, InterruptedException {
+        cloudDocumentVersion.ifPresent(version ->
+                updateDocument.set(SHADOW_DOCUMENT_VERSION, new LongNode(version)));
+        byte[] payloadBytes = getPayloadBytes(updateDocument);
+        Optional<Long> updatedVersion = updateCloudShadowDocument(payloadBytes);
+        return updatedVersion.orElse(cloudDocumentVersion.map(version -> version + 1).orElse(1L));
+    }
+
+    /**
+     * Gets the SDK bytes object from the Object Node.
+     *
+     * @param updateDocument The update request payload.
+     * @return The SDK bytes object for the update request.
+     * @throws SkipSyncRequestException if the serialization of the update request payload failed.
+     */
+    private byte[] getPayloadBytes(ObjectNode updateDocument) throws SkipSyncRequestException {
+        byte[] payloadBytes;
+        try {
+            payloadBytes = JsonUtil.getPayloadBytes(updateDocument);
+        } catch (JsonProcessingException e) {
+            logger.atWarn()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .cause(e).log("Unable to serialize update request");
+            throw new SkipSyncRequestException(e);
+        }
+        return payloadBytes;
+    }
+
+    /**
+     * Update the cloud document using the IoT Data plane client.
+     *
+     * @param updateDocument The update request payload.
+     * @throws ConflictException        if the update request for cloud had a bad version.
+     * @throws RetryableException       if the update request encountered errors which should be retried.
+     * @throws SkipSyncRequestException if the update request encountered errors which should be skipped.
+     * @throws InterruptedException     if the thread is interrupted while syncing shadow with cloud.
+     */
+    private Optional<Long> updateCloudShadowDocument(byte[] updateDocument)
+            throws ConflictException, RetryableException, SkipSyncRequestException, InterruptedException {
+        UpdateThingShadowResponse response;
+        try {
+            logger.atDebug()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Updating cloud shadow document");
+
+            response = context.getIotDataPlaneClientWrapper().updateThingShadow(getThingName(), getShadowName(),
+                    updateDocument);
+        } catch (ConflictException e) {
+            logger.atWarn()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Conflict exception occurred while updating cloud document.");
+            throw e;
+        } catch (ThrottlingException | ServiceUnavailableException | InternalFailureException e) {
+            logger.atWarn()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Could not execute cloud shadow update request");
+            throw new RetryableException(e);
+        } catch (AbortedException e) {
+            LogEventBuilder l = logger.atDebug()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName());
+            Throwable cause = e.getCause();
+            if (cause instanceof InterruptedException) {
+                l.log("Interrupted while updating cloud shadow");
+                throw (InterruptedException) cause;
+            }
+            l.log("Skipping update for cloud shadow");
+            throw new SkipSyncRequestException(e);
+        } catch (SdkServiceException | SdkClientException e) {
+            logger.atError()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Could not execute cloud shadow update request");
+            throw new SkipSyncRequestException(e);
+        }
+        return getUpdatedVersion(response.payload().asByteArray());
+    }
+
+    /**
+     * Update the sync information for the thing's shadow using the update request payload and the current local and
+     * cloud version.
+     *
+     * @param updateDocument       The update request payload.
+     * @param localDocumentVersion The current local document version.
+     * @param cloudDocumentVersion The current cloud document version.
+     * @param cloudUpdateTime      The cloud document latest update time.
+     * @throws SkipSyncRequestException if the serialization of the update request payload failed.
+     */
+    void updateSyncInformation(ObjectNode updateDocument, long localDocumentVersion, long cloudDocumentVersion,
+                               long cloudUpdateTime)
+            throws SkipSyncRequestException {
+        logger.atTrace()
+                .kv(LOG_THING_NAME_KEY, getThingName())
+                .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                .kv(LOG_LOCAL_VERSION_KEY, localDocumentVersion)
+                .kv(LOG_CLOUD_VERSION_KEY, cloudDocumentVersion)
+                .log("Updating sync information");
+
+        updateDocument.remove(SHADOW_DOCUMENT_VERSION);
+        context.getDao().updateSyncInformation(SyncInformation.builder()
+                .localVersion(localDocumentVersion)
+                .cloudVersion(cloudDocumentVersion)
+                .shadowName(getShadowName())
+                .thingName(getThingName())
+                .cloudUpdateTime(cloudUpdateTime)
+                .lastSyncedDocument(getPayloadBytes(updateDocument))
+                .build());
+    }
+
+    /**
+     * Gets the sync information if it exists or throws a SkipSyncRequestException.
+     *
+     * @return the sync information for the thing and shadow.
+     * @throws SkipSyncRequestException if the sync information does not exist.
+     */
+    SyncInformation getSyncInformation() throws SkipSyncRequestException {
+        Optional<SyncInformation> syncInformation = context.getDao().getShadowSyncInformation(getThingName(),
+                getShadowName());
+
+        if (!syncInformation.isPresent()) {
+            // This should never happen since we always add a default sync info entry in the DB.
+            throw new SkipSyncRequestException("Unable to find sync information");
+        }
+
+        return syncInformation.get();
+    }
+
+    /**
+     * Gets the cloud shadow document using the IoT Data plane client.
+     *
+     * @return an optional of the cloud shadow document if it existed.
+     * @throws RetryableException       if the get request encountered errors which should be retried.
+     * @throws SkipSyncRequestException if the get request encountered errors which should be skipped.
+     * @throws InterruptedException     if the thread is interrupted while syncing shadow with cloud.
+     */
+    Optional<ShadowDocument> getCloudShadowDocument() throws RetryableException,
+            SkipSyncRequestException, InterruptedException {
+        logger.atTrace()
+                .kv(LOG_THING_NAME_KEY, getThingName())
+                .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                .log("Getting cloud shadow document");
+        try {
+            GetThingShadowResponse getThingShadowResponse = context.getIotDataPlaneClientWrapper()
+                    .getThingShadow(getThingName(), getShadowName());
+            if (getThingShadowResponse != null && getThingShadowResponse.payload() != null) {
+                return Optional.of(new ShadowDocument(getThingShadowResponse.payload().asByteArray()));
+            }
+        } catch (ResourceNotFoundException e) {
+            logger.atWarn()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .cause(e)
+                    .log("Unable to find cloud shadow");
+        } catch (ThrottlingException | ServiceUnavailableException | InternalFailureException e) {
+            logger.atWarn()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Could not execute cloud shadow get request");
+            throw new RetryableException(e);
+        } catch (AbortedException e) {
+            LogEventBuilder l = logger.atDebug()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName());
+            Throwable cause = e.getCause();
+            if (cause instanceof InterruptedException) {
+                l.log("Interrupted while getting cloud shadow");
+                throw (InterruptedException) cause;
+            }
+            l.log("Skipping get for cloud shadow");
+            throw new SkipSyncRequestException(e);
+        } catch (SdkServiceException | SdkClientException | InvalidRequestParametersException | IOException e) {
+            logger.atError()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Could not execute cloud shadow get request");
+            throw new SkipSyncRequestException(e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Delete the local shadow using the request handlers and then update the sync information.
+     *
+     * @param syncInformation The sync information for the thing's shadow.
+     * @throws SkipSyncRequestException if the delete request encountered a skipable exception.
+     */
+    void handleLocalDelete(@NonNull SyncInformation syncInformation)
+            throws SkipSyncRequestException {
+        deleteLocalShadowDocument();
+        // Since the local shadow has been deleted, we need get the deleted shadow version from the DAO.
+        long localShadowVersion = context.getDao().getDeletedShadowVersion(getThingName(), getShadowName())
+                .orElse(syncInformation.getLocalVersion() + 1);
+        context.getDao().updateSyncInformation(SyncInformation.builder()
+                .localVersion(localShadowVersion)
+                // If the cloud shadow was deleted, then the last synced version might be 1 higher than the last version
+                // that was synced.
+                // If the device was offline for a long time and the cloud shadow was deleted multiple times in that
+                // period, there is no way to get the correct cloud shadow version. We will eventually get the correct
+                // cloud shadow version in the next cloud shadow update.
+                .cloudVersion(syncInformation.getCloudVersion() + 1)
+                .shadowName(getShadowName())
+                .thingName(getThingName())
+                .cloudUpdateTime(syncInformation.getCloudUpdateTime())
+                .lastSyncedDocument(null)
+                .build());
+    }
+
+    /**
+     * Delete the local shadow document using the delete request handler.
+     *
+     * @throws SkipSyncRequestException if the delete request encountered errors which should be skipped.
+     */
+    private void deleteLocalShadowDocument() throws SkipSyncRequestException {
+        logger.atInfo()
+                .kv(LOG_THING_NAME_KEY, getThingName())
+                .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                .log("Deleting local shadow document");
+
+        software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest localRequest =
+                new software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest();
+        localRequest.setShadowName(getShadowName());
+        localRequest.setThingName(getThingName());
+        try {
+            context.getDeleteHandler().handleRequest(localRequest, ShadowManager.SERVICE_NAME);
+        } catch (ShadowManagerDataException | UnauthorizedError | InvalidArgumentsError | ServiceError e) {
+            throw new SkipSyncRequestException(e);
+        }
+    }
+
+    /**
+     * Gets the latest time the cloud shadow document was updated.
+     *
+     * @param cloudShadowDocument the cloud shadow document.
+     * @return the latest time the cloud shadow was updated if the metadata node exists; Else returns the current time
+     */
+    long getCloudUpdateTime(ShadowDocument cloudShadowDocument) {
+        long cloudUpdateTime = Instant.now().getEpochSecond();
+        if (cloudShadowDocument.getMetadata() != null) {
+            cloudUpdateTime = cloudShadowDocument.getMetadata().getLatestUpdatedTimestamp();
+        }
+        return cloudUpdateTime;
+    }
+
+    /**
+     * Add the version node to the update request payload and then update the local shadow document using that request.
+     *
+     * @param updateDocument       The update request payload.
+     * @param localDocumentVersion The current local document version.
+     * @return the updated local document version.
+     * @throws SkipSyncRequestException if the update request encountered a skipable exception.
+     */
+    long updateLocalDocumentAndGetUpdatedVersion(ObjectNode updateDocument, Optional<Long> localDocumentVersion)
+            throws SkipSyncRequestException {
+        localDocumentVersion.ifPresent(version ->
+                updateDocument.set(SHADOW_DOCUMENT_VERSION, new LongNode(version)));
+        byte[] payloadBytes = getPayloadBytes(updateDocument);
+        Optional<Long> updatedVersion = updateLocalShadowDocument(payloadBytes);
+        return updatedVersion.orElse(localDocumentVersion.map(version -> version + 1).orElse(1L));
+    }
+
+    /**
+     * Update the local shadow document using the update request handler.
+     *
+     * @param payloadBytes The update request bytes.
+     * @throws ConflictError            if the update request for local had a bad version.
+     * @throws SkipSyncRequestException if the update request encountered errors which should be skipped.
+     */
+    private Optional<Long> updateLocalShadowDocument(byte[] payloadBytes) throws ConflictError,
+            SkipSyncRequestException {
+        logger.atDebug()
+                .kv(LOG_THING_NAME_KEY, getThingName())
+                .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                .log("Updating local shadow document");
+
+        software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest localRequest =
+                new software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest();
+        localRequest.setPayload(payloadBytes);
+        localRequest.setShadowName(getShadowName());
+        localRequest.setThingName(getThingName());
+        UpdateThingShadowHandlerResponse response;
+        try {
+            response = getContext().getUpdateHandler().handleRequest(localRequest, ShadowManager.SERVICE_NAME);
+        } catch (ShadowManagerDataException | UnauthorizedError | InvalidArgumentsError | ServiceError e) {
+            throw new SkipSyncRequestException(e);
+        }
+        return getUpdatedVersion(response.getUpdateThingShadowResponse().getPayload());
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/Direction.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/Direction.java
@@ -5,11 +5,40 @@
 
 package com.aws.greengrass.shadowmanager.sync.model;
 
+import lombok.Getter;
+
 /**
  * Enum to indicate the shadow sync directionality.
  */
 public enum Direction {
-    BIDIRECTIONAL,
-    FROMDEVICEONLY,
-    FROMCLOUDONLY
+    BETWEEN_DEVICE_AND_CLOUD("betweenDeviceAndCloud"),
+    DEVICE_TO_CLOUD("deviceToCloud"),
+    CLOUD_TO_DEVICE("cloudToDevice");
+
+    /**
+     * Code for the sync strategy type which will be used in the configuration.
+     */
+    @Getter
+    private final String code;
+
+    Direction(String code) {
+        this.code = code;
+    }
+
+    /**
+     * Gets the direction enum from a string literal.
+     *
+     * @param direction the direction string literal.
+     * @return the direction enum
+     * @throws IllegalArgumentException if string is not a valid enum value.
+     */
+    public static Direction getDirection(String direction) throws IllegalArgumentException {
+        for (Direction dir : values()) {
+            if (dir.code.equalsIgnoreCase(direction)) {
+                return dir;
+            }
+        }
+        throw new IllegalArgumentException("Unknown direction value.");
+
+    }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/Direction.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/Direction.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.model;
+
+/**
+ * Enum to indicate the shadow sync directionality.
+ */
+public enum Direction {
+    BIDIRECTIONAL,
+    FROMDEVICEONLY,
+    FROMCLOUDONLY
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.model;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
+import com.aws.greengrass.shadowmanager.model.ShadowDocument;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_LOCAL_VERSION_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_THING_NAME_KEY;
+
+public class OverwriteCloudShadowRequest extends BaseSyncRequest {
+    private static final Logger logger = LogManager.getLogger(OverwriteCloudShadowRequest.class);
+
+    /**
+     * Ctr for BaseSyncRequest.
+     *
+     * @param thingName  The thing name associated with the sync shadow update
+     * @param shadowName The shadow name associated with the sync shadow update
+     */
+    public OverwriteCloudShadowRequest(String thingName, String shadowName) {
+        super(thingName, shadowName);
+    }
+
+    /**
+     * Executes sync request.
+     *
+     * @param context context object containing useful objects for requests to use when executing.
+     * @throws RetryableException       When error occurs in sync operation indicating a request needs to be retried
+     * @throws SkipSyncRequestException When error occurs in sync operation indicating a request needs to be skipped.
+     * @throws InterruptedException     if the thread is interrupted while syncing shadow with cloud.
+     */
+    @Override
+    public void execute(SyncContext context) throws RetryableException, SkipSyncRequestException, InterruptedException {
+        super.setContext(context);
+        SyncInformation syncInformation = getSyncInformation();
+
+        Optional<ShadowDocument> localShadowDocument = context.getDao().getShadowThing(getThingName(), getShadowName());
+
+        if (localShadowDocument.isPresent()) {
+            if (syncInformation.getLocalVersion() == localShadowDocument.get().getVersion()) {
+                logger.atDebug()
+                        .kv(LOG_THING_NAME_KEY, getThingName())
+                        .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                        .kv(LOG_LOCAL_VERSION_KEY, syncInformation.getLocalVersion())
+                        .log("Not updating cloud shadow since the local shadow has not changed since the last sync");
+            } else {
+                // If the local shadow version is not the same as the last synced local shadow version, go ahead and
+                // update the cloud shadow with the entire local shadow,
+                ObjectNode updateDocument = (ObjectNode) localShadowDocument.get().toJson(false);
+                long cloudDocumentVersion = updateCloudDocumentAndGetUpdatedVersion(updateDocument, Optional.empty());
+                updateSyncInformation(updateDocument, localShadowDocument.get().getVersion(), cloudDocumentVersion,
+                        Instant.now().getEpochSecond());
+            }
+        } else {
+            // If the local shadow is not present, then go ahead and delete the cloud shadow.
+            handleCloudDelete(syncInformation.getCloudVersion(), syncInformation);
+        }
+    }
+
+    /**
+     * Check if an update is necessary or not.
+     *
+     * @param context context object containing useful objects for requests to use when executing.
+     * @return true.
+     */
+    @Override
+    public boolean isUpdateNecessary(SyncContext context) {
+        return true;
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.model;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
+import com.aws.greengrass.shadowmanager.model.ShadowDocument;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Optional;
+
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_CLOUD_VERSION_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_THING_NAME_KEY;
+
+public class OverwriteLocalShadowRequest extends BaseSyncRequest {
+    private static final Logger logger = LogManager.getLogger(OverwriteLocalShadowRequest.class);
+
+    /**
+     * Ctr for BaseSyncRequest.
+     *
+     * @param thingName  The thing name associated with the sync shadow update
+     * @param shadowName The shadow name associated with the sync shadow update
+     */
+    public OverwriteLocalShadowRequest(String thingName, String shadowName) {
+        super(thingName, shadowName);
+    }
+
+    /**
+     * Executes sync request.
+     *
+     * @param context context object containing useful objects for requests to use when executing.
+     * @throws RetryableException       When error occurs in sync operation indicating a request needs to be retried
+     * @throws SkipSyncRequestException When error occurs in sync operation indicating a request needs to be skipped.
+     * @throws InterruptedException     if the thread is interrupted while syncing shadow with cloud.
+     */
+    @Override
+    public void execute(SyncContext context) throws RetryableException, SkipSyncRequestException, InterruptedException {
+        super.setContext(context);
+        SyncInformation syncInformation = getSyncInformation();
+
+        Optional<ShadowDocument> cloudShadowDocument = getCloudShadowDocument();
+
+        if (cloudShadowDocument.isPresent()) {
+            if (syncInformation.getCloudVersion() == cloudShadowDocument.get().getVersion()) {
+                logger.atDebug()
+                        .kv(LOG_THING_NAME_KEY, getThingName())
+                        .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                        .kv(LOG_CLOUD_VERSION_KEY, syncInformation.getCloudVersion())
+                        .log("Not updating local shadow since the cloud shadow has not changed since the last sync");
+            } else {
+                // If the cloud shadow version is not the same as the last synced cloud shadow version, go ahead and
+                // update the local shadow with the entire cloud shadow,
+                long cloudUpdateTime = getCloudUpdateTime(cloudShadowDocument.get());
+                ObjectNode updateDocument = (ObjectNode) cloudShadowDocument.get().toJson(false);
+                long localDocumentVersion = updateLocalDocumentAndGetUpdatedVersion(updateDocument, Optional.empty());
+                updateSyncInformation(updateDocument, localDocumentVersion, cloudShadowDocument.get().getVersion(),
+                        cloudUpdateTime);
+            }
+        } else {
+            // If the cloud shadow is not present, then go ahead and delete the local shadow.
+            handleLocalDelete(syncInformation);
+        }
+    }
+
+    /**
+     * Check if an update is necessary or not.
+     *
+     * @param context context object containing useful objects for requests to use when executing.
+     * @return true.
+     */
+    @Override
+    public boolean isUpdateNecessary(SyncContext context) {
+        return true;
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -285,6 +285,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
             logger.atTrace(SYNC_EVENT_TYPE)
                     .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
                     .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                    .addKeyValue("type", request.getClass())
                     .log("Syncing is stopped. Ignoring sync request");
             return;
         }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -138,15 +138,15 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      *
      * @param retryer The retryer object.
      */
-    public BaseSyncStrategy(Retryer retryer) {
+    protected BaseSyncStrategy(Retryer retryer) {
         this(retryer, DEFAULT_RETRY_CONFIG);
     }
 
-    public BaseSyncStrategy(Retryer retryer, RequestBlockingQueue syncQueue) {
+    protected BaseSyncStrategy(Retryer retryer, RequestBlockingQueue syncQueue) {
         this(retryer, DEFAULT_RETRY_CONFIG, syncQueue);
     }
 
-    public BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig) {
+    protected BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig) {
         this(retryer, retryConfig, new RequestBlockingQueue(new RequestMerger()));
     }
 
@@ -157,7 +157,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      * @param retryConfig The config to be used by the retryer.
      * @param syncQueue   A queue to use for sync requests.
      */
-    public BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
+    private BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
         this.retryer = (config, request, context) -> {
             try {
                 executing.set(true);

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -206,29 +206,29 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         SyncStrategy mockSyncStrategy = mock(SyncStrategy.class);
         lenient().when(mockSyncHandler.getOverallSyncStrategy()).thenReturn(mockSyncStrategy);
         when(mockSyncHandler.getSyncDirection()).thenReturn(current);
-        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.BIDIRECTIONAL);
+        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.BETWEEN_DEVICE_AND_CLOUD.getCode());
         when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC, CONFIGURATION_SYNC_DIRECTION_TOPIC))
                 .thenReturn(directionTopic);
         s.install(ShadowManager.InstallConfig.builder().configureSyncDirectionConfig(true).build());
 
         assertFalse(s.isErrored());
 
-        if (Direction.BIDIRECTIONAL.equals(current)) {
+        if (Direction.BETWEEN_DEVICE_AND_CLOUD.equals(current)) {
             verify(mockSyncHandler, never()).start(any(), anyInt());
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
-            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
-        if (Direction.FROMDEVICEONLY.equals(current)) {
+        if (Direction.DEVICE_TO_CLOUD.equals(current)) {
             verify(mockSyncHandler, never()).start(any(), anyInt());
             verify(mockCloudDataClient, times(1)).updateSubscriptions(any());
         } else {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
         }
         verify(mockSyncHandler, never()).stop();
-        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());
@@ -248,18 +248,18 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         SyncStrategy mockSyncStrategy = mock(SyncStrategy.class);
         lenient().when(mockSyncHandler.getOverallSyncStrategy()).thenReturn(mockSyncStrategy);
         when(mockSyncHandler.getSyncDirection()).thenReturn(current);
-        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.FROMDEVICEONLY);
+        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.DEVICE_TO_CLOUD.getCode());
         when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC, CONFIGURATION_SYNC_DIRECTION_TOPIC))
                 .thenReturn(directionTopic);
         s.install(ShadowManager.InstallConfig.builder().configureSyncDirectionConfig(true).build());
 
         assertFalse(s.isErrored());
 
-        if (Direction.FROMDEVICEONLY.equals(current)) {
+        if (Direction.DEVICE_TO_CLOUD.equals(current)) {
             verify(mockSyncHandler, never()).start(any(), anyInt());
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
-            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
@@ -268,7 +268,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         verify(mockCloudDataClient, never()).updateSubscriptions(any());
         verify(mockSyncHandler, never()).stop();
 
-        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.FROMDEVICEONLY));
+        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.DEVICE_TO_CLOUD));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());
@@ -288,22 +288,22 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         SyncStrategy mockSyncStrategy = mock(SyncStrategy.class);
         lenient().when(mockSyncHandler.getOverallSyncStrategy()).thenReturn(mockSyncStrategy);
         when(mockSyncHandler.getSyncDirection()).thenReturn(current);
-        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.FROMCLOUDONLY);
+        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.CLOUD_TO_DEVICE.getCode());
         when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC, CONFIGURATION_SYNC_DIRECTION_TOPIC))
                 .thenReturn(directionTopic);
         s.install(ShadowManager.InstallConfig.builder().configureSyncDirectionConfig(true).build());
 
         assertFalse(s.isErrored());
 
-        if (Direction.FROMCLOUDONLY.equals(current)) {
+        if (Direction.CLOUD_TO_DEVICE.equals(current)) {
             verify(mockSyncHandler, never()).start(any(), anyInt());
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
-            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
-        if (Direction.BIDIRECTIONAL.equals(current)) {
+        if (Direction.BETWEEN_DEVICE_AND_CLOUD.equals(current)) {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
         } else {
             verify(mockCloudDataClient, times(1)).updateSubscriptions(any());
@@ -311,7 +311,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
 
         verify(mockSyncHandler, never()).stop();
         verify(mockSyncHandler, never()).start(any(), anyInt());
-        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.FROMCLOUDONLY));
+        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.CLOUD_TO_DEVICE));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -24,7 +24,9 @@ import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.CloudDataClient;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
+import com.aws.greengrass.shadowmanager.sync.model.Direction;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
+import com.aws.greengrass.shadowmanager.sync.strategy.SyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.Strategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.StrategyType;
 import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
@@ -39,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -77,6 +80,7 @@ import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SHA
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SHADOW_DOCUMENTS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_STRATEGY_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNCHRONIZATION_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNC_DIRECTION_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_THING_NAME_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_DOCUMENT_SIZE;
 import static com.aws.greengrass.shadowmanager.model.Constants.MAX_SHADOW_DOCUMENT_SIZE;
@@ -93,6 +97,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -161,17 +166,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper,
                 mockPubSubClientWrapper, mockInboundRateLimiter, mockDeviceConfiguration, mockSynchronizeHelper,
                 mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient);
-
-        Topic maxDocSizeTopic = Topic.of(context, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC, DEFAULT_DOCUMENT_SIZE);
-
-        lenient().when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))
-                .thenReturn(maxDocSizeTopic);
-        lenient().when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
-                .thenReturn(mock(Topics.class));
-        lenient().when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC))
-                .thenReturn(mock(Topics.class));
-        lenient().when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC))
-                .thenReturn(mock(Topics.class));
     }
 
     @ParameterizedTest
@@ -180,7 +174,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         Topic maxDocSizeTopic = Topic.of(context, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC, maxDocSize);
         when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))
                 .thenReturn(maxDocSizeTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureMaxDocSizeLimitConfig(true).build());
 
         assertFalse(shadowManager.isErrored());
         assertThat(Validator.getMaxShadowDocumentSize(), is(maxDocSize));
@@ -193,8 +187,148 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         Topic maxDocSizeTopic = Topic.of(context, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC, maxDocSize);
         when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))
                 .thenReturn(maxDocSizeTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureMaxDocSizeLimitConfig(true).build());
         assertTrue(shadowManager.isErrored());
+    }
+
+    @ParameterizedTest
+    @EnumSource(Direction.class)
+    void GIVEN_current_direction_WHEN_updated_to_BIDRECTIONAL_THEN_appropriately_handles_the_sync_direction(Direction current) {
+        ShadowManager s = spy(shadowManager);
+
+        lenient().doReturn(true).when(s).inState(eq(State.RUNNING));
+
+        s.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
+        ThingShadowSyncConfiguration syncConfiguration = mock(ThingShadowSyncConfiguration.class);
+        s.getSyncConfiguration().getSyncConfigurations().add(syncConfiguration);
+
+        lenient().when(mockMqttClient.connected()).thenReturn(true);
+        SyncStrategy mockSyncStrategy = mock(SyncStrategy.class);
+        lenient().when(mockSyncHandler.getOverallSyncStrategy()).thenReturn(mockSyncStrategy);
+        when(mockSyncHandler.getSyncDirection()).thenReturn(current);
+        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.BIDIRECTIONAL);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC, CONFIGURATION_SYNC_DIRECTION_TOPIC))
+                .thenReturn(directionTopic);
+        s.install(ShadowManager.InstallConfig.builder().configureSyncDirectionConfig(true).build());
+
+        assertFalse(s.isErrored());
+
+        if (Direction.BIDIRECTIONAL.equals(current)) {
+            verify(mockSyncHandler, never()).start(any(), anyInt());
+            verify(mockCloudDataClient, never()).updateSubscriptions(any());
+            verify(mockSyncHandler, never()).stop();
+            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+            return;
+        }
+
+        if (Direction.FROMDEVICEONLY.equals(current)) {
+            verify(mockSyncHandler, never()).start(any(), anyInt());
+            verify(mockCloudDataClient, times(1)).updateSubscriptions(any());
+        } else {
+            verify(mockCloudDataClient, never()).updateSubscriptions(any());
+        }
+        verify(mockSyncHandler, never()).stop();
+        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+        verify(mockDao, never()).listSyncedShadows();
+        verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
+        verify(mockDao, never()).insertSyncInfoIfNotExists(any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(Direction.class)
+    void GIVEN_current_direction_WHEN_updated_to_FROMDEVICEONLY_THEN_appropriately_handles_the_sync_direction(Direction current) {
+        ShadowManager s = spy(shadowManager);
+
+        lenient().doReturn(true).when(s).inState(eq(State.RUNNING));
+        s.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
+        ThingShadowSyncConfiguration syncConfiguration = mock(ThingShadowSyncConfiguration.class);
+        s.getSyncConfiguration().getSyncConfigurations().add(syncConfiguration);
+
+        lenient().when(mockMqttClient.connected()).thenReturn(true);
+        SyncStrategy mockSyncStrategy = mock(SyncStrategy.class);
+        lenient().when(mockSyncHandler.getOverallSyncStrategy()).thenReturn(mockSyncStrategy);
+        when(mockSyncHandler.getSyncDirection()).thenReturn(current);
+        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.FROMDEVICEONLY);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC, CONFIGURATION_SYNC_DIRECTION_TOPIC))
+                .thenReturn(directionTopic);
+        s.install(ShadowManager.InstallConfig.builder().configureSyncDirectionConfig(true).build());
+
+        assertFalse(s.isErrored());
+
+        if (Direction.FROMDEVICEONLY.equals(current)) {
+            verify(mockSyncHandler, never()).start(any(), anyInt());
+            verify(mockCloudDataClient, never()).updateSubscriptions(any());
+            verify(mockSyncHandler, never()).stop();
+            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+            return;
+        }
+
+        verify(mockCloudDataClient, times(1)).stopSubscribing();
+        verify(mockSyncHandler, never()).start(any(), anyInt());
+        verify(mockCloudDataClient, never()).updateSubscriptions(any());
+        verify(mockSyncHandler, never()).stop();
+
+        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.FROMDEVICEONLY));
+        verify(mockDao, never()).listSyncedShadows();
+        verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
+        verify(mockDao, never()).insertSyncInfoIfNotExists(any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(Direction.class)
+    void GIVEN_current_direction_WHEN_updated_to_FROMCLOUDONLY_THEN_appropriately_handles_the_sync_direction(Direction current) {
+        ShadowManager s = spy(shadowManager);
+
+        lenient().doReturn(true).when(s).inState(eq(State.RUNNING));
+        s.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
+        ThingShadowSyncConfiguration syncConfiguration = mock(ThingShadowSyncConfiguration.class);
+        s.getSyncConfiguration().getSyncConfigurations().add(syncConfiguration);
+
+        lenient().when(mockMqttClient.connected()).thenReturn(true);
+        SyncStrategy mockSyncStrategy = mock(SyncStrategy.class);
+        lenient().when(mockSyncHandler.getOverallSyncStrategy()).thenReturn(mockSyncStrategy);
+        when(mockSyncHandler.getSyncDirection()).thenReturn(current);
+        Topic directionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, Direction.FROMCLOUDONLY);
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC, CONFIGURATION_SYNC_DIRECTION_TOPIC))
+                .thenReturn(directionTopic);
+        s.install(ShadowManager.InstallConfig.builder().configureSyncDirectionConfig(true).build());
+
+        assertFalse(s.isErrored());
+
+        if (Direction.FROMCLOUDONLY.equals(current)) {
+            verify(mockSyncHandler, never()).start(any(), anyInt());
+            verify(mockCloudDataClient, never()).updateSubscriptions(any());
+            verify(mockSyncHandler, never()).stop();
+            verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BIDIRECTIONAL));
+            return;
+        }
+
+        if (Direction.BIDIRECTIONAL.equals(current)) {
+            verify(mockCloudDataClient, never()).updateSubscriptions(any());
+        } else {
+            verify(mockCloudDataClient, times(1)).updateSubscriptions(any());
+        }
+
+        verify(mockSyncHandler, never()).stop();
+        verify(mockSyncHandler, never()).start(any(), anyInt());
+        verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.FROMCLOUDONLY));
+        verify(mockDao, never()).listSyncedShadows();
+        verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
+        verify(mockDao, never()).insertSyncInfoIfNotExists(any());
+    }
+
+    @Test
+    void GIVEN_bad_sync_direction_WHEN_initialize_THEN_throws_exception(ExtensionContext extensionContext) {
+        ignoreExceptionOfType(extensionContext, IllegalArgumentException.class);
+        Topic syncDirectionTopic = Topic.of(context, CONFIGURATION_SYNC_DIRECTION_TOPIC, "badValue");
+        when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC, CONFIGURATION_SYNC_DIRECTION_TOPIC))
+                .thenReturn(syncDirectionTopic);
+        ShadowManager s = spy(shadowManager);
+
+        lenient().doReturn(true).when(s).inState(eq(State.RUNNING));
+
+        s.install(ShadowManager.InstallConfig.builder().configureSyncDirectionConfig(true).build());
+        assertTrue(s.isErrored());
     }
 
     @Test
@@ -204,7 +338,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC))
                 .thenReturn(rateLimitsTopics);
 
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureRateLimitsConfig(true).build());
 
         assertFalse(shadowManager.isErrored());
         verify(mockInboundRateLimiter, times(0)).setRate(anyInt());
@@ -222,7 +356,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC))
                 .thenReturn(rateLimitsTopics);
 
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureRateLimitsConfig(true).build());
 
         assertTrue(shadowManager.isErrored());
         verify(mockInboundRateLimiter, times(0)).setRate(anyInt());
@@ -237,7 +371,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC))
                 .thenReturn(rateLimitsTopics);
 
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureRateLimitsConfig(true).build());
 
         assertFalse(shadowManager.isErrored());
         verify(mockIotDataPlaneClientWrapper, times(0)).setRate(anyInt());
@@ -255,7 +389,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC))
                 .thenReturn(rateLimitsTopics);
 
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureRateLimitsConfig(true).build());
 
         assertTrue(shadowManager.isErrored());
         verify(mockInboundRateLimiter, times(0)).setRate(anyInt());
@@ -270,7 +404,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC))
                 .thenReturn(rateLimitsTopics);
 
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureRateLimitsConfig(true).build());
 
         assertFalse(shadowManager.isErrored());
         verify(mockInboundRateLimiter, times(0)).setTotalRate(anyInt());
@@ -288,7 +422,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC))
                 .thenReturn(rateLimitsTopics);
 
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureRateLimitsConfig(true).build());
 
         assertTrue(shadowManager.isErrored());
         verify(mockInboundRateLimiter, times(0)).setRate(anyInt());
@@ -319,7 +453,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
 
         verify(thingNameTopic, times(1)).subscribeGeneric(any());
         verify(thingNameTopic, times(0)).remove(any());
@@ -355,7 +489,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
 
         verify(thingNameTopic, times(0)).subscribeGeneric(any());
         verify(thingNameTopic, times(1)).remove(any());
@@ -383,7 +517,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
 
         verify(thingNameTopic, times(0)).subscribeGeneric(any());
         verify(thingNameTopic, times(1)).remove(any());
@@ -422,7 +556,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
 
         verify(thingNameTopic, times(0)).subscribeGeneric(any());
         verify(thingNameTopic, times(1)).remove(any());
@@ -448,7 +582,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
 
         assertFalse(shadowManager.isErrored());
         assertThat(shadowManager.getSyncConfiguration().getSyncConfigurations(),
@@ -473,7 +607,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
         assertTrue(shadowManager.isErrored());
     }
 
@@ -481,7 +615,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
     void GIVEN_bad_field_in_thing_sync_configuration_WHEN_initialize_THEN_service_errors(ExtensionContext extensionContext) throws UnsupportedInputTypeException {
         ignoreExceptionOfType(extensionContext, MismatchedInputException.class);
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
-        Topic maxDocSizeTopic = Topic.of(context, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC, DEFAULT_DOCUMENT_SIZE);
         Topics configTopics = Topics.of(context, CONFIGURATION_SYNCHRONIZATION_TOPIC, null);
         configTopics.createLeafChild(CONFIGURATION_CORE_THING_TOPIC).withValueChecked(null);
         List<Map<String, Object>> shadowDocumentsList = new ArrayList<>();
@@ -494,18 +627,15 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
 
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, KERNEL_THING);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))
-                .thenReturn(maxDocSizeTopic);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
         assertTrue(shadowManager.isErrored());
     }
 
     @Test
     void GIVEN_bad_type_of_thing_sync_configuration_WHEN_initialize_THEN_service_errors(ExtensionContext extensionContext) throws UnsupportedInputTypeException {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
-        Topic maxDocSizeTopic = Topic.of(context, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC, DEFAULT_DOCUMENT_SIZE);
         Topics configTopics = Topics.of(context, CONFIGURATION_SYNCHRONIZATION_TOPIC, null);
         configTopics.createLeafChild(CONFIGURATION_CORE_THING_TOPIC).withValueChecked(null);
         Topics shadowDocumentsTopics = configTopics.createInteriorChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC);
@@ -513,11 +643,9 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowDocumentsTopics.createLeafChild(CONFIGURATION_NAMED_SHADOWS_TOPIC).withValue(Collections.singletonList("boo2"));
         shadowDocumentsTopics.createLeafChild(CONFIGURATION_THING_NAME_TOPIC).withValue(THING_NAME_A);
 
-        when(config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))
-                .thenReturn(maxDocSizeTopic);
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
         assertTrue(shadowManager.isErrored());
     }
 
@@ -544,7 +672,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC))
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
         assertTrue(shadowManager.isErrored());
     }
 
@@ -573,7 +701,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
                 .thenReturn(configTopics);
         when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
 
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
         assertTrue(shadowManager.isErrored());
     }
 
@@ -660,7 +788,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             when(thingNameTopic.getOnce()).thenReturn(KERNEL_THING);
             when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC)).thenReturn(configTopics);
             when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
-            s.install();
+            s.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());
 
             // no dao access for sync during install
             verify(mockDao, never()).listSyncedShadows();
@@ -703,14 +831,15 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         ShadowManager s = spy(shadowManager);
 
         doReturn(true).when(s).inState(eq(State.RUNNING));
-        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC)).thenReturn(strategyTopics);
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC))
+                .thenReturn(strategyTopics);
         doNothing().when(shadowManager.getSyncHandler()).setSyncStrategy(strategyCaptor.capture());
         s.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
         ThingShadowSyncConfiguration config = mock(ThingShadowSyncConfiguration.class);
         s.getSyncConfiguration().getSyncConfigurations().add(config);
 
         when(mockMqttClient.connected()).thenReturn(true);
-        s.install();
+        s.install(ShadowManager.InstallConfig.builder().configureStrategyConfig(true).build());
 
         assertFalse(s.isErrored());
         assertThat(strategyCaptor.getValue(), is(notNullValue()));
@@ -732,20 +861,23 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         strategyTopics.createLeafChild("type").withValue("real Time");
 
         when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC)).thenReturn(strategyTopics);
-        shadowManager.install();
+        shadowManager.install(ShadowManager.InstallConfig.builder().configureStrategyConfig(true).build());
 
         assertTrue(shadowManager.isErrored());
         verify(mockSyncHandler, never()).setSyncStrategy(any());
     }
 
     @Test
-    void GIVEN_sync_strategy_WHEN_change_THEN_syncing_restarts(ExtensionContext extensionContext) {
-
+    void GIVEN_sync_strategy_WHEN_change_THEN_syncing_restarts() {
+        Topics strategyTopics = Topics.of(context, CONFIGURATION_STRATEGY_TOPIC, null);
+        strategyTopics.createLeafChild("type").withValue("realTime");
+        strategyTopics.createLeafChild("delay").withValue(30);
 
         ShadowManager s = spy(shadowManager);
 
         // set up mocks so sync start gets called
-
+        when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC))
+                .thenReturn(strategyTopics);
         when(mockMqttClient.connected()).thenReturn(true);
         Set<ThingShadowSyncConfiguration> syncConfigs = new HashSet<ThingShadowSyncConfiguration>() {{
             add(ThingShadowSyncConfiguration.builder().thingName("foo").shadowName("bar").build());
@@ -756,8 +888,8 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
                 .build();
         s.setSyncConfiguration(config);
         doReturn(true,true).when(s).inState(eq(State.RUNNING));
-        s.install();
-
+        s.install(ShadowManager.InstallConfig.builder().configureStrategyConfig(true).build());
+        reset(mockSyncHandler);
         // GIVEN
         Strategy update = Strategy.builder().type(StrategyType.PERIODIC).delay(500L).build();
         // WHEN

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientFactoryTest.java
@@ -67,38 +67,6 @@ class IotDataPlaneClientFactoryTest {
     }
 
     @Test
-    void GIVEN_good_config_WHEN_configure_client_THEN_correctly_configures_iot_data_client() {
-        clientFactory = new IotDataPlaneClientFactory(mockDeviceConfiguration);
-        assertThat(clientFactory.getIotDataPlaneClient(), is(notNullValue()));
-
-        verify(mockDeviceConfiguration, times(1)).getIotDataEndpoint();
-        verify(mockDeviceConfiguration, times(1)).getAWSRegion();
-        verify(mockDeviceConfiguration, times(1)).getPrivateKeyFilePath();
-        verify(mockDeviceConfiguration, times(1)).getCertificateFilePath();
-
-        reset(mockDeviceConfiguration);
-        Topic regionTopic = Topic.of(mockContext, DEVICE_PARAM_AWS_REGION, "dummyRegion");
-        ccCaptor.getValue().childChanged(WhatHappened.childChanged, regionTopic);
-
-        assertThat(clientFactory.getIotDataPlaneClient(), is(notNullValue()));
-
-        verify(mockDeviceConfiguration, times(1)).getIotDataEndpoint();
-        verify(mockDeviceConfiguration, times(1)).getAWSRegion();
-        verify(mockDeviceConfiguration, times(1)).getPrivateKeyFilePath();
-        verify(mockDeviceConfiguration, times(1)).getCertificateFilePath();
-
-        reset(mockDeviceConfiguration);
-        Topic endpointTopic = Topic.of(mockContext, DEVICE_PARAM_IOT_DATA_ENDPOINT, "dummyEndpoint");
-        ccCaptor.getValue().childChanged(WhatHappened.childChanged, endpointTopic);
-
-        assertThat(clientFactory.getIotDataPlaneClient(), is(notNullValue()));
-
-        verify(mockDeviceConfiguration, times(1)).getIotDataEndpoint();
-        verify(mockDeviceConfiguration, times(1)).getAWSRegion();
-        verify(mockDeviceConfiguration, times(1)).getPrivateKeyFilePath();
-        verify(mockDeviceConfiguration, times(1)).getCertificateFilePath();
-    }
-    @Test
     void GIVEN_bad_config_WHEN_configure_client_THEN_does_not_reconfigure_iot_data_client() {
         clientFactory = new IotDataPlaneClientFactory(mockDeviceConfiguration);
         assertThat(clientFactory.getIotDataPlaneClient(), is(notNullValue()));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -230,7 +230,7 @@ class FullShadowSyncRequestTest {
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
         assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
-        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(true));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.model;
+
+import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
+import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
+import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.model.ShadowDocument;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowResponse;
+import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowResponse;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.aws.greengrass.shadowmanager.TestUtils.SHADOW_NAME;
+import static com.aws.greengrass.shadowmanager.TestUtils.THING_NAME;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_VERSION;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class OverwriteCloudShadowRequestTest {
+    private static final byte[] LOCAL_DOCUMENT = "{\"version\": 10, \"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Pink Floyd\", \"SomethingNew\": true}}}".getBytes();
+    private static final byte[] BASE_DOCUMENT = "{\"version\": 1, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"The Beatles\"}}}".getBytes();
+
+    @Mock
+    private ShadowManagerDAO mockDao;
+    @Mock
+    private IotDataPlaneClientWrapper mockIotDataPlaneClientWrapper;
+    @Mock
+    private UpdateThingShadowRequestHandler mockUpdateThingShadowRequestHandler;
+    @Mock
+    private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
+    @Captor
+    private ArgumentCaptor<SyncInformation> syncInformationCaptor;
+    @Captor
+    private ArgumentCaptor<String> thingNameCaptor;
+    @Captor
+    private ArgumentCaptor<String> shadowNameCaptor;
+    @Captor
+    private ArgumentCaptor<byte[]> payloadCaptor;
+
+    private SyncContext syncContext;
+
+    @BeforeEach
+    void setup() throws IOException {
+        lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
+        syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
+                mockIotDataPlaneClientWrapper);
+        JsonUtil.loadSchema();
+    }
+
+    @Test
+    void GIVEN_updated_local_shadow_WHEN_execute_THEN_updates_cloud_shadow() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException {
+        long epochSeconds = Instant.now().getEpochSecond();
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT);
+        when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(shadowDocument));
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(epochSecondsMinus60)
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(false)
+                .lastSyncedDocument(BASE_DOCUMENT)
+                .cloudVersion(1L)
+                .localVersion(1L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+
+        when(mockIotDataPlaneClientWrapper.updateThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture(), payloadCaptor.capture()))
+                .thenReturn(UpdateThingShadowResponse.builder().payload(SdkBytes.fromString("{\"version\": 6, \"state\": {}}", UTF_8)).build());
+
+        OverwriteCloudShadowRequest request = new OverwriteCloudShadowRequest(THING_NAME, SHADOW_NAME);
+        request.execute(syncContext);
+
+        verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
+        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, times(1)).updateThingShadow(anyString(), anyString(), any(byte[].class));
+
+        assertThat(thingNameCaptor.getValue(), is(THING_NAME));
+        assertThat(shadowNameCaptor.getValue(), is(SHADOW_NAME));
+        JsonNode actualCloudUpdateDocument = JsonUtil.getPayloadJson(payloadCaptor.getValue()).get();
+        ((ObjectNode)actualCloudUpdateDocument).remove(SHADOW_DOCUMENT_VERSION);
+        assertThat(actualCloudUpdateDocument, is(shadowDocument.toJson(false)));
+
+        assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
+        assertThat(JsonUtil.getPayloadJson(syncInformationCaptor.getValue().getLastSyncedDocument()).get(), is(shadowDocument.toJson(false)));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(6L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(10L));
+        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
+        assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+    }
+
+    @Test
+    void GIVEN_deleted_local_shadow_WHEN_execute_THEN_deletes_cloud_shadow() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException {
+        long epochSeconds = Instant.now().getEpochSecond();
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.empty());
+        when(mockDao.getDeletedShadowVersion(anyString(), anyString())).thenReturn(Optional.of(5L));
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(epochSecondsMinus60)
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(false)
+                .lastSyncedDocument(BASE_DOCUMENT)
+                .cloudVersion(1L)
+                .localVersion(1L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+
+        when(mockIotDataPlaneClientWrapper.deleteThingShadow(thingNameCaptor.capture(), shadowNameCaptor.capture()))
+                .thenReturn(DeleteThingShadowResponse.builder().build());
+
+        OverwriteCloudShadowRequest request = new OverwriteCloudShadowRequest(THING_NAME, SHADOW_NAME);
+        request.execute(syncContext);
+
+        verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
+        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));
+        verify(mockIotDataPlaneClientWrapper, times(1)).deleteThingShadow(anyString(), anyString());
+
+        assertThat(thingNameCaptor.getValue(), is(THING_NAME));
+        assertThat(shadowNameCaptor.getValue(), is(SHADOW_NAME));
+
+        assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
+        assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(2L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(5L));
+        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
+        assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+    }
+
+    @Test
+    void GIVEN_same_local_shadow_WHEN_execute_THEN_does_not_update_cloud_shadow() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException {
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        ShadowDocument shadowDocument = new ShadowDocument(LOCAL_DOCUMENT);
+        when(mockDao.getShadowThing(anyString(), anyString())).thenReturn(Optional.of(shadowDocument));
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(epochSecondsMinus60)
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(false)
+                .lastSyncedDocument(BASE_DOCUMENT)
+                .cloudVersion(1L)
+                .localVersion(10L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+
+        OverwriteCloudShadowRequest request = new OverwriteCloudShadowRequest(THING_NAME, SHADOW_NAME);
+        request.execute(syncContext);
+
+        verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
+        verify(mockDao, never()).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));
+        verify(mockIotDataPlaneClientWrapper, never()).deleteThingShadow(anyString(), anyString());
+    }
+}

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
@@ -75,7 +75,7 @@ class OverwriteCloudShadowRequestTest {
 
     @BeforeEach
     void setup() throws IOException {
-        lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
+        lenient().when(mockDao.updateSyncInformation(any())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
                 mockIotDataPlaneClientWrapper);
         JsonUtil.loadSchema();
@@ -105,7 +105,7 @@ class OverwriteCloudShadowRequestTest {
         request.execute(syncContext);
 
         verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
-        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockDao, times(1)).updateSyncInformation(syncInformationCaptor.capture());
         verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
         verify(mockIotDataPlaneClientWrapper, times(1)).updateThingShadow(anyString(), anyString(), any(byte[].class));
 
@@ -150,7 +150,7 @@ class OverwriteCloudShadowRequestTest {
         request.execute(syncContext);
 
         verify(mockDao, times(1)).getShadowThing(anyString(), anyString());
-        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockDao, times(1)).updateSyncInformation(syncInformationCaptor.capture());
         verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
         verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
         verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));
@@ -167,7 +167,7 @@ class OverwriteCloudShadowRequestTest {
         assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
         assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
         assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
-        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(true));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
@@ -80,7 +80,7 @@ class OverwriteLocalShadowRequestTest {
 
     @BeforeEach
     void setup() throws IOException {
-        lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
+        lenient().when(mockDao.updateSyncInformation(any())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
                 mockIotDataPlaneClientWrapper);
         JsonUtil.loadSchema();
@@ -113,7 +113,7 @@ class OverwriteLocalShadowRequestTest {
 
         verify(mockIotDataPlaneClientWrapper, times(1)).getThingShadow(anyString(), anyString());
         verify(mockDao, never()).getShadowThing(anyString(), anyString());
-        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockDao, times(1)).updateSyncInformation(syncInformationCaptor.capture());
         verify(mockUpdateThingShadowRequestHandler, times(1)).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
         verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
         verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));
@@ -169,7 +169,7 @@ class OverwriteLocalShadowRequestTest {
 
         verify(mockIotDataPlaneClientWrapper, times(1)).getThingShadow(anyString(), anyString());
         verify(mockDao, never()).getShadowThing(anyString(), anyString());
-        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockDao, times(1)).updateSyncInformation(syncInformationCaptor.capture());
         verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
         verify(mockDeleteThingShadowRequestHandler, times(1)).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
         verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.model;
+
+import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
+import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
+import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowResponse;
+import software.amazon.awssdk.services.iotdataplane.model.ResourceNotFoundException;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.aws.greengrass.shadowmanager.TestUtils.SHADOW_NAME;
+import static com.aws.greengrass.shadowmanager.TestUtils.THING_NAME;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_METADATA;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_VERSION;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class OverwriteLocalShadowRequestTest {
+    private static final byte[] BASE_DOCUMENT = "{\"version\": 1, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"The Beatles\"}}}".getBytes();
+    private static final byte[] CLOUD_DOCUMENT_WITH_METADATA = "{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomeOtherThingNew\": 100}}, \"metadata\": {\"reported\": {\"name\": {\"timestamp\": 100}, \"OldField\": {\"timestamp\": 100}}, \"desired\": {\"name\": {\"timestamp\": 100}, \"SomeOtherThingNew\": {\"timestamp\": 100}}}}".getBytes();
+
+    @Mock
+    private ShadowManagerDAO mockDao;
+    @Mock
+    private IotDataPlaneClientWrapper mockIotDataPlaneClientWrapper;
+    @Mock
+    private UpdateThingShadowRequestHandler mockUpdateThingShadowRequestHandler;
+    @Mock
+    private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private UpdateThingShadowHandlerResponse mockUpdateThingShadowHandlerResponse;
+    @Captor
+    private ArgumentCaptor<SyncInformation> syncInformationCaptor;
+    @Captor
+    private ArgumentCaptor<software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest> localUpdateThingShadowRequestCaptor;
+    @Captor
+    private ArgumentCaptor<software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest> localDeleteThingShadowRequest;
+
+    private SyncContext syncContext;
+
+    @BeforeEach
+    void setup() throws IOException {
+        lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
+        syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
+                mockIotDataPlaneClientWrapper);
+        JsonUtil.loadSchema();
+    }
+
+    @Test
+    void GIVEN_updated_cloud_shadow_WHEN_execute_THEN_updates_local_shadow() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException {
+        long epochSeconds = Instant.now().getEpochSecond();
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        GetThingShadowResponse response = GetThingShadowResponse.builder()
+                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT_WITH_METADATA))
+                .build();
+        when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenReturn(response);
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(epochSecondsMinus60)
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(false)
+                .lastSyncedDocument(BASE_DOCUMENT)
+                .cloudVersion(1L)
+                .localVersion(1L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+        when(mockUpdateThingShadowHandlerResponse.getUpdateThingShadowResponse().getPayload()).thenReturn("{\"version\": 2, \"state\": {}}".getBytes(UTF_8));
+        when(mockUpdateThingShadowRequestHandler.handleRequest(localUpdateThingShadowRequestCaptor.capture(), anyString())).
+                thenReturn(mockUpdateThingShadowHandlerResponse);
+
+        OverwriteLocalShadowRequest request = new OverwriteLocalShadowRequest(THING_NAME, SHADOW_NAME);
+        request.execute(syncContext);
+
+        verify(mockIotDataPlaneClientWrapper, times(1)).getThingShadow(anyString(), anyString());
+        verify(mockDao, never()).getShadowThing(anyString(), anyString());
+        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, times(1)).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));
+        verify(mockIotDataPlaneClientWrapper, never()).deleteThingShadow(anyString(), anyString());
+
+        software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest localDocumentUpdateRequest = localUpdateThingShadowRequestCaptor.getValue();
+        assertThat(localDocumentUpdateRequest.getShadowName(), is(SHADOW_NAME));
+        assertThat(localDocumentUpdateRequest.getThingName(), is(THING_NAME));
+        JsonNode actualLocalUpdateDocument = JsonUtil.getPayloadJson(localDocumentUpdateRequest.getPayload()).get();
+        ((ObjectNode)actualLocalUpdateDocument).remove(SHADOW_DOCUMENT_METADATA);
+        ((ObjectNode)actualLocalUpdateDocument).remove(SHADOW_DOCUMENT_VERSION);
+        JsonNode expectedMergedDocument = JsonUtil.getPayloadJson(CLOUD_DOCUMENT_WITH_METADATA).get();
+        ((ObjectNode)expectedMergedDocument).remove(SHADOW_DOCUMENT_METADATA);
+        ((ObjectNode)expectedMergedDocument).remove(SHADOW_DOCUMENT_VERSION);
+        assertThat(actualLocalUpdateDocument, is(expectedMergedDocument));
+
+        assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
+        JsonNode lastSyncedDocument = JsonUtil.getPayloadJson(syncInformationCaptor.getValue().getLastSyncedDocument()).get();
+        ((ObjectNode)lastSyncedDocument).remove(SHADOW_DOCUMENT_METADATA);
+        ((ObjectNode)lastSyncedDocument).remove(SHADOW_DOCUMENT_VERSION);
+
+        assertThat(lastSyncedDocument, is(expectedMergedDocument));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(5L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(2L));
+        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(100L));
+        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
+        assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+    }
+
+    @Test
+    void GIVEN_deleted_cloud_shadow_WHEN_execute_THEN_deletes_local_shadow(ExtensionContext context) throws RetryableException, SkipSyncRequestException, IOException, InterruptedException {
+        ignoreExceptionOfType(context, ResourceNotFoundException.class);
+        long epochSeconds = Instant.now().getEpochSecond();
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(epochSecondsMinus60)
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(false)
+                .lastSyncedDocument(BASE_DOCUMENT)
+                .cloudVersion(1L)
+                .localVersion(1L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+        when(mockDeleteThingShadowRequestHandler.handleRequest(localDeleteThingShadowRequest.capture(), anyString())).
+                thenReturn(mock(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowResponse.class));
+
+        OverwriteLocalShadowRequest request = new OverwriteLocalShadowRequest(THING_NAME, SHADOW_NAME);
+        request.execute(syncContext);
+
+        verify(mockIotDataPlaneClientWrapper, times(1)).getThingShadow(anyString(), anyString());
+        verify(mockDao, never()).getShadowThing(anyString(), anyString());
+        verify(mockDao, times(1)).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockDeleteThingShadowRequestHandler, times(1)).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));
+        verify(mockIotDataPlaneClientWrapper, never()).deleteThingShadow(anyString(), anyString());
+
+        software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest localDocumentDeleteRequest = localDeleteThingShadowRequest.getValue();
+        assertThat(localDocumentDeleteRequest.getShadowName(), is(SHADOW_NAME));
+        assertThat(localDocumentDeleteRequest.getThingName(), is(THING_NAME));
+
+        assertThat(syncInformationCaptor.getValue(), is(notNullValue()));
+        assertThat(syncInformationCaptor.getValue().getLastSyncedDocument(), is(nullValue()));
+        assertThat(syncInformationCaptor.getValue().getCloudVersion(), is(2L));
+        assertThat(syncInformationCaptor.getValue().getLocalVersion(), is(2L));
+        assertThat(syncInformationCaptor.getValue().getCloudUpdateTime(), is(greaterThanOrEqualTo(epochSecondsMinus60)));
+        assertThat(syncInformationCaptor.getValue().getLastSyncTime(), is(greaterThanOrEqualTo(epochSeconds)));
+        assertThat(syncInformationCaptor.getValue().getShadowName(), is(SHADOW_NAME));
+        assertThat(syncInformationCaptor.getValue().getThingName(), is(THING_NAME));
+        assertThat(syncInformationCaptor.getValue().isCloudDeleted(), is(false));
+    }
+
+    @Test
+    void GIVEN_same_cloud_shadow_WHEN_execute_THEN_does_not_update_local_shadow() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException {
+        long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
+        GetThingShadowResponse response = GetThingShadowResponse.builder()
+                .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT_WITH_METADATA))
+                .build();
+        when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenReturn(response);
+        when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder()
+                .cloudUpdateTime(epochSecondsMinus60)
+                .thingName(THING_NAME)
+                .shadowName(SHADOW_NAME)
+                .cloudDeleted(false)
+                .lastSyncedDocument(BASE_DOCUMENT)
+                .cloudVersion(5L)
+                .localVersion(1L)
+                .lastSyncTime(epochSecondsMinus60)
+                .build()));
+
+        OverwriteLocalShadowRequest request = new OverwriteLocalShadowRequest(THING_NAME, SHADOW_NAME);
+        request.execute(syncContext);
+
+        verify(mockIotDataPlaneClientWrapper, times(1)).getThingShadow(anyString(), anyString());
+        verify(mockDao, never()).getShadowThing(anyString(), anyString());
+        verify(mockDao, never()).updateSyncInformation(any());
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest.class), anyString());
+        verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest.class), anyString());
+        verify(mockIotDataPlaneClientWrapper, never()).updateThingShadow(anyString(), anyString(), any(byte[].class));
+        verify(mockIotDataPlaneClientWrapper, never()).deleteThingShadow(anyString(), anyString());
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds the ability to configure Shadow Manager to sync the shadows in a particular direction. With a configuration change, Shadow Manager will either bidirectionality sync shadows or in either one of the directions (i.e. either only from the device to the cloud or from cloud to device).

If the Shadow Manager is configured to be synced from the device to the cloud only, on first launch or after a reconnection, the cloud shadow will be overwritten to have the same content as what the local shadow has.
If the Shadow Manager is configured to be synced from the cloud to the device only, on first launch or after a reconnection, the local shadow will be overwritten to have the same content as what the cloud shadow has.

**Why is this change necessary:**
Added a new configuration field to enable customers to specify in which direction the shadows should be synced. There are numerous use cases where the device shadows only need to be synced. This will avoid unnecessary connections to the cloud if the syncing from cloud to device is not needed. 

**How was this change tested:**
Added unit tests and integration tests.

**Any additional information or context required to review the change:**


**Checklist:**
 - [X] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
