### PR TITLE
fix: check if update is necessary before adding sync request.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -53,8 +53,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_METADATA;
@@ -116,11 +114,9 @@ class SyncTest extends NucleusLaunchUtils {
 
     private Supplier<Optional<SyncInformation>> syncInfo;
     private Supplier<Optional<ShadowDocument>> localShadow;
-    private final Lock sequential = new ReentrantLock();
 
     @BeforeEach
     void setup() {
-        sequential.lock();
         kernel = new Kernel();
         syncInfo = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowSyncInformation(MOCK_THING_NAME_1,
                 CLASSIC_SHADOW);
@@ -131,7 +127,6 @@ class SyncTest extends NucleusLaunchUtils {
     @AfterEach
     void cleanup() {
         kernel.shutdown();
-        sequential.unlock();
     }
 
     private String getSyncConfigFile(Class<?extends BaseSyncStrategy> clazz) {

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -15,7 +15,9 @@ import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfiguration;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
+import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
+import com.aws.greengrass.shadowmanager.sync.strategy.BaseSyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.PeriodicSyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.RealTimeSyncStrategy;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
@@ -51,6 +53,8 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_METADATA;
@@ -112,9 +116,11 @@ class SyncTest extends NucleusLaunchUtils {
 
     private Supplier<Optional<SyncInformation>> syncInfo;
     private Supplier<Optional<ShadowDocument>> localShadow;
+    private final Lock sequential = new ReentrantLock();
 
     @BeforeEach
     void setup() {
+        sequential.lock();
         kernel = new Kernel();
         syncInfo = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowSyncInformation(MOCK_THING_NAME_1,
                 CLASSIC_SHADOW);
@@ -125,9 +131,10 @@ class SyncTest extends NucleusLaunchUtils {
     @AfterEach
     void cleanup() {
         kernel.shutdown();
+        sequential.unlock();
     }
 
-    private String getSyncConfigFile(Class<?> clazz) {
+    private String getSyncConfigFile(Class<?extends BaseSyncStrategy> clazz) {
         if (RealTimeSyncStrategy.class.equals(clazz)) {
             return "sync.yaml";
         } else {
@@ -135,18 +142,23 @@ class SyncTest extends NucleusLaunchUtils {
         }
     }
 
-    private void assertEmptySyncQueue(Class<?> clazz) {
-        if (RealTimeSyncStrategy.class.equals(clazz)) {
-            assertThat(() -> kernel.getContext().get(RealTimeSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
-        } else {
-            assertThat(() -> kernel.getContext().get(PeriodicSyncStrategy.class).getSyncQueue().size(), eventuallyEval(is(0)));
-        }
+    private void assertEmptySyncQueue(Class<? extends BaseSyncStrategy> clazz) {
+        BaseSyncStrategy s = kernel.getContext().get(clazz);
+
+        assertThat("syncing has started", s::isSyncing, eventuallyEval(is(true)));
+
+        RequestBlockingQueue q = s.getSyncQueue();
+
+        // queue is eventually empty (full syncs are added and then eventually removed)
+        assertThat("sync queue is eventually empty", () -> q.isEmpty() && !s.isExecuting(),
+                eventuallyEval(is(true), Duration.ofSeconds(10)));
     }
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_sync_config_and_no_local_WHEN_startup_THEN_local_version_updated_via_full_sync(Class<?> clazz, ExtensionContext context)
+    void GIVEN_sync_config_and_no_local_WHEN_startup_THEN_local_version_updated_via_full_sync(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context)
             throws IOException, InterruptedException {
+        LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         ignoreExceptionOfType(context, InterruptedException.class);
 
         GetThingShadowResponse shadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
@@ -227,7 +239,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_sync_config_and_no_cloud_WHEN_startup_THEN_cloud_version_updated_via_full_sync(Class<?> clazz, ExtensionContext context)
+    void GIVEN_sync_config_and_no_cloud_WHEN_startup_THEN_cloud_version_updated_via_full_sync(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context)
             throws IOException, InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
@@ -280,7 +292,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_synced_shadow_WHEN_local_update_THEN_cloud_updates(Class<?> clazz, ExtensionContext context) throws IOException,
+    void GIVEN_synced_shadow_WHEN_local_update_THEN_cloud_updates(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context) throws IOException,
             InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
@@ -329,7 +341,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_synced_shadow_WHEN_cloud_update_THEN_local_updates(Class<?> clazz, ExtensionContext context) throws IOException, InterruptedException {
+    void GIVEN_synced_shadow_WHEN_cloud_update_THEN_local_updates(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context) throws IOException, InterruptedException {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
@@ -368,7 +380,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_synced_shadow_WHEN_local_delete_THEN_cloud_deletes(Class<?> clazz, ExtensionContext context) throws InterruptedException {
+    void GIVEN_synced_shadow_WHEN_local_delete_THEN_cloud_deletes(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context) throws InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
 
@@ -412,7 +424,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_synced_shadow_WHEN_cloud_delete_THEN_local_deletes(Class<?> clazz, ExtensionContext context) throws InterruptedException {
+    void GIVEN_synced_shadow_WHEN_cloud_delete_THEN_local_deletes(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context) throws InterruptedException {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
@@ -432,6 +444,9 @@ class SyncTest extends NucleusLaunchUtils {
                 .mockCloud(true)
                 .build());
 
+        // wait for it to process all full sync requests to finish.
+        assertEmptySyncQueue(clazz);
+
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
 
         // we have a local shadow from the initial full sync
@@ -440,7 +455,7 @@ class SyncTest extends NucleusLaunchUtils {
 
         syncHandler.pushLocalDeleteSyncRequest(MOCK_THING_NAME_1, CLASSIC_SHADOW, "{\"version\": 10}".getBytes(UTF_8));
 
-        // wait for it to process all sync requests.
+        // Wait for Local Delete to finish.
         assertEmptySyncQueue(clazz);
 
         assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
@@ -458,7 +473,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_unsynced_shadow_WHEN_local_deletes_THEN_no_cloud_delete(Class<?> clazz, ExtensionContext context) throws InterruptedException {
+    void GIVEN_unsynced_shadow_WHEN_local_deletes_THEN_no_cloud_delete(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context) throws InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
 
@@ -502,7 +517,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_unsynced_shadow_WHEN_local_updates_THEN_no_cloud_update(Class<?> clazz, ExtensionContext context) throws InterruptedException {
+    void GIVEN_unsynced_shadow_WHEN_local_updates_THEN_no_cloud_update(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context) throws InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, InterruptedException.class);
 
@@ -536,7 +551,7 @@ class SyncTest extends NucleusLaunchUtils {
 
     @ParameterizedTest
     @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
-    void GIVEN_cloud_update_request_WHEN_retryable_thrown_AND_new_cloud_update_request_THEN_retries_with_merged_request(Class<?> clazz, ExtensionContext context)
+    void GIVEN_cloud_update_request_WHEN_retryable_thrown_AND_new_cloud_update_request_THEN_retries_with_merged_request(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context)
             throws InterruptedException, IOException {
         LogConfig.getRootLogConfig().setLevel(Level.DEBUG);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -302,25 +302,24 @@ public class ShadowManager extends PluginService {
 
         Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
         strategyTopics.subscribe((why, newv) -> {
-                    Strategy strategy;
-                    Map<String, Object> strategyPojo = strategyTopics.toPOJO();
-                    if (WhatHappened.removed.equals(why) || strategyPojo == null || strategyPojo.isEmpty()) {
-                        strategy = DEFAULT_STRATEGY;
-                    } else {
-                        // Get the correct sync strategy configuration from the POJO.
-                        try {
-                            strategy = Strategy.fromPojo(strategyPojo);
-                        } catch (InvalidConfigurationException e) {
-                            serviceErrored(e);
-                            return;
-                        }
-                    }
-                    stopSyncingShadows(false);
-                    syncHandler.setSyncStrategy(strategy);
-                    startSyncingShadows(StartSyncInfo.builder().build());
-                });
+            Strategy strategy;
+            Map<String, Object> strategyPojo = strategyTopics.toPOJO();
+            if (WhatHappened.removed.equals(why) || strategyPojo == null || strategyPojo.isEmpty()) {
+                strategy = DEFAULT_STRATEGY;
+            } else {
+                // Get the correct sync strategy configuration from the POJO.
+                try {
+                    strategy = Strategy.fromPojo(strategyPojo);
+                } catch (InvalidConfigurationException e) {
+                    serviceErrored(e);
+                    return;
+                }
+            }
+            stopSyncingShadows(false);
+            syncHandler.setSyncStrategy(strategy);
+            startSyncingShadows(StartSyncInfo.builder().build());
+        });
     }
-
 
 
     private void deleteRemovedSyncInformation() {

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
@@ -81,7 +81,6 @@ public class UpdateThingShadowRequestHandler extends BaseRequestHandler {
         this.syncHandler = syncHandler;
     }
 
-
     /**
      * Handles UpdateThingShadow Requests from IPC.
      *
@@ -233,6 +232,7 @@ public class UpdateThingShadowRequestHandler extends BaseRequestHandler {
                             .log("Successfully updated shadow");
                     removeMetadataNode(updateDocumentRequest);
                     this.syncHandler.pushCloudUpdateSyncRequest(thingName, shadowName, updateDocumentRequest);
+
                     return new UpdateThingShadowHandlerResponse(updateThingShadowResponse, updateDocumentBytes);
                 } catch (ShadowManagerDataException | IOException e) {
                     throwServiceError(thingName, shadowName, clientToken, e);

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
@@ -115,4 +115,15 @@ public class CloudDeleteSyncRequest extends BaseSyncRequest {
                     .cause(e).log("Failed to update sync table after deleting cloud shadow");
         }
     }
+
+    /**
+     * Returning true for delete since multiple deletes will never happen from the cloud or device.
+     *
+     * @param context the execution context.
+     * @return true.
+     */
+    @Override
+    public boolean isUpdateNecessary(SyncContext context) {
+        return true;
+    }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -70,6 +70,17 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
     }
 
     /**
+     * Returning true for full sync since we have already figured out that both cloud and local have been updated.
+     *
+     * @param context the execution context.
+     * @return true.
+     */
+    @Override
+    public boolean isUpdateNecessary(SyncContext context) {
+        return true;
+    }
+
+    /**
      * Executes a full shadow sync.
      *
      * @param context the execution context.
@@ -278,7 +289,7 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
     /**
      * Delete the local shadow using the request handlers and then update the sync information.
      *
-     * @param syncInformation     The sync information for the thing's shadow.
+     * @param syncInformation The sync information for the thing's shadow.
      * @throws SkipSyncRequestException if the delete request encountered a skipable exception.
      */
     private void handleLocalDelete(@NonNull SyncInformation syncInformation) throws SkipSyncRequestException {

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequest.java
@@ -48,7 +48,7 @@ public class LocalDeleteSyncRequest extends BaseSyncRequest {
      * @param deletePayload Delete response payload containing the deleted shadow version
      */
     public LocalDeleteSyncRequest(String thingName, String shadowName, byte[] deletePayload) {
-         super(thingName,shadowName);
+        super(thingName, shadowName);
         this.deletePayload = deletePayload;
     }
 
@@ -117,7 +117,7 @@ public class LocalDeleteSyncRequest extends BaseSyncRequest {
                         .log("Skipping delete for local shadow");
                 throw new SkipSyncRequestException(e);
             }
-        // missed cloud update(s) need to do full sync
+            // missed cloud update(s) need to do full sync
         } else {
             logger.atDebug()
                     .kv(LOG_THING_NAME_KEY, getThingName())
@@ -128,5 +128,16 @@ public class LocalDeleteSyncRequest extends BaseSyncRequest {
                     .log("Unable to delete local shadow since some update(s) were missed from the cloud");
             throw new ConflictError("Missed update(s) from the cloud");
         }
+    }
+
+    /**
+     * Returning true for delete since multiple deletes will never happen from the cloud or device.
+     *
+     * @param context the execution context.
+     * @return true.
+     */
+    @Override
+    public boolean isUpdateNecessary(SyncContext context) {
+        return true;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
@@ -29,4 +29,15 @@ public interface SyncRequest {
     void execute(SyncContext context) throws RetryableException, SkipSyncRequestException,
             UnknownShadowException;
 
+    /**
+     * Check if an update is neccessary or not.
+     *
+     * @param context context object containing useful objects for requests to use when executing.
+     * @return true if an update is necessary; Else false.
+     * @throws RetryableException       When error occurs in sync operation indicating a request needs to be retried
+     * @throws SkipSyncRequestException When error occurs in sync operation indicating a request needs to be skipped.
+     * @throws UnknownShadowException   When shadow not found in the sync table.
+     */
+    boolean isUpdateNecessary(SyncContext context) throws RetryableException, SkipSyncRequestException,
+            UnknownShadowException;
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -8,6 +8,8 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
+import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
@@ -46,6 +48,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
 
     /**
      * The request blocking queue holding all the sync requests.
+     *
      * @implNote The Setter is only used in unit tests. The Getter is used in integration tests.
      */
     @Getter
@@ -96,6 +99,29 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
     AtomicBoolean syncing = new AtomicBoolean(false);
 
     /**
+     * Indicates whether a sync request is executing or not.
+     */
+    AtomicBoolean executing = new AtomicBoolean(false);
+
+    /**
+     * Getter for syncing boolean.
+     *
+     * @return true if Shadow Manger is syncing.
+     */
+    public boolean isSyncing() {
+        return syncing.get();
+    }
+
+    /**
+     * Getter for executing boolean.
+     *
+     * @return true if Shadow Manger is executing.
+     */
+    public boolean isExecuting() {
+        return executing.get();
+    }
+
+    /**
      * Constructor.
      *
      * @param retryer The retryer object.
@@ -114,7 +140,14 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      * @param retryConfig The config to be used by the retryer.
      */
     public BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig) {
-        this.retryer = retryer;
+        this.retryer = (config, request, context) -> {
+            try {
+                executing.set(true);
+                retryer.run(config, request, context);
+            } finally {
+                executing.set(false);
+            }
+        };
         this.retryConfig = retryConfig;
         RequestMerger requestMerger = new RequestMerger();
         this.syncQueue = new RequestBlockingQueue(requestMerger);
@@ -192,6 +225,24 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
                     .log("Syncing is stopped. Ignoring sync request");
             return;
         }
+
+        try {
+            if (!request.isUpdateNecessary(context)) {
+                logger.atDebug()
+                        .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
+                        .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                        .addKeyValue("type", request.getClass())
+                        .log("Ignoring sync request since update is not necessary");
+                return;
+            }
+        } catch (SkipSyncRequestException | RetryableException | UnknownShadowException e) {
+            logger.atWarn(SYNC_EVENT_TYPE)
+                    .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
+                    .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                    .log("Ignoring sync request since update is not necessary");
+            return;
+        }
+
         try {
             logger.atDebug(SYNC_EVENT_TYPE)
                     .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -106,7 +106,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
     /**
      * Getter for syncing boolean.
      *
-     * @return true if Shadow Manger is syncing.
+     * @return true if Shadow Manager is syncing.
      */
     public boolean isSyncing() {
         return syncing.get();
@@ -115,7 +115,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
     /**
      * Getter for executing boolean.
      *
-     * @return true if Shadow Manger is executing.
+     * @return true if Shadow Manager is executing.
      */
     public boolean isExecuting() {
         return executing.get();

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
@@ -57,13 +57,14 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -333,16 +334,22 @@ class LocalUpdateSyncRequestTest {
     }
 
     @Test
-    void GIVEN_no_change_WHEN_execute_THEN_does_not_update_local_shadow_and_sync_information() throws IOException {
+    void GIVEN_no_change_WHEN_isUpdateNecessary_THEN_returns_false() throws IOException, SkipSyncRequestException {
         ShadowDocument shadowDocument = new ShadowDocument(UPDATE_DOCUMENT);
         when(mockDao.getShadowThing(any(), any())).thenReturn(Optional.of(shadowDocument));
 
         LocalUpdateSyncRequest request = new LocalUpdateSyncRequest(THING_NAME, SHADOW_NAME, UPDATE_DOCUMENT);
 
-        assertDoesNotThrow(() -> request.execute(syncContext));
+        assertFalse(request.isUpdateNecessary(syncContext));
+    }
 
-        verify(mockDao, never()).updateSyncInformation(any());
-        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(), any());
+    @Test
+    void GIVEN_new_shadow_WHEN_isUpdateNecessary_THEN_returns_true() throws IOException, SkipSyncRequestException {
+        when(mockDao.getShadowThing(any(), any())).thenReturn(Optional.empty());
+
+        LocalUpdateSyncRequest request = new LocalUpdateSyncRequest(THING_NAME, SHADOW_NAME, UPDATE_DOCUMENT);
+
+        assertTrue(request.isUpdateNecessary(syncContext));
     }
 
     static Stream<Arguments> currentUpdatePayloads() {

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
@@ -68,6 +68,8 @@ class PeriodicSyncStrategyTest {
     private SyncContext mockSyncContext;
     @Mock
     private RequestBlockingQueue mockRequestBlockingQueue;
+    @Mock
+    private FullShadowSyncRequest mockFullShadowSyncRequest;
     private RequestBlockingQueue requestBlockingQueue;
 
     private ScheduledExecutorService scheduledExecutorService;
@@ -87,6 +89,7 @@ class PeriodicSyncStrategyTest {
     void setup() {
         scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
         this.requestBlockingQueue = new RequestBlockingQueue(new RequestMerger());
+        lenient().when(mockFullShadowSyncRequest.isUpdateNecessary(any())).thenReturn(true);
     }
 
     @AfterEach
@@ -100,7 +103,7 @@ class PeriodicSyncStrategyTest {
             throws Exception {
         syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, requestBlockingQueue);
         syncStrategy.start(mockSyncContext, 3);
-        syncStrategy.putSyncRequest(mock(FullShadowSyncRequest.class));
+        syncStrategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(1)).run(any(), any(), any());
     }
@@ -128,7 +131,7 @@ class PeriodicSyncStrategyTest {
         }).when(mockRequestBlockingQueue).put(any());
 
         syncStrategy.start(mockSyncContext, 2);
-        syncStrategy.putSyncRequest(mock(FullShadowSyncRequest.class));
+        syncStrategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRequestBlockingQueue, timeout(Duration.ofSeconds(5).toMillis()).times(1)).put(any());
         verify(mockRequestBlockingQueue, times(1)).remove(any());
@@ -143,7 +146,7 @@ class PeriodicSyncStrategyTest {
         doThrow(InterruptedException.class).when(mockRequestBlockingQueue).put(any());
 
         syncStrategy.start(mockSyncContext, 2);
-        syncStrategy.putSyncRequest(mock(FullShadowSyncRequest.class));
+        syncStrategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(0)).run(any(), any(), any());
         // check that we are interrupted by our "fake" exception. This also clears the thread state so cleanup

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
@@ -59,13 +59,14 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class RealTimeSyncStrategyTest {
-
     @Mock
     private Retryer mockRetryer;
     @Mock
     private SyncContext mockSyncContext;
     @Mock
     private RequestBlockingQueue mockRequestBlockingQueue;
+    @Mock
+    private FullShadowSyncRequest mockFullShadowSyncRequest;
     private RequestBlockingQueue requestBlockingQueue;
 
     private ExecutorService executorService;
@@ -85,6 +86,7 @@ class RealTimeSyncStrategyTest {
     void setup() {
         executorService = Executors.newCachedThreadPool();
         this.requestBlockingQueue = new RequestBlockingQueue(new RequestMerger());
+        lenient().when(mockFullShadowSyncRequest.isUpdateNecessary(any())).thenReturn(true);
     }
 
     @AfterEach
@@ -98,7 +100,7 @@ class RealTimeSyncStrategyTest {
             throws Exception {
         strategy = new RealTimeSyncStrategy(executorService, mockRetryer, requestBlockingQueue);
         strategy.start(mockSyncContext, 1);
-        strategy.putSyncRequest(mock(FullShadowSyncRequest.class));
+        strategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(1)).run(any(), any(), any());
     }
@@ -125,7 +127,7 @@ class RealTimeSyncStrategyTest {
         }).when(mockRequestBlockingQueue).put(any());
 
         strategy.start(mockSyncContext, 1);
-        strategy.putSyncRequest(mock(FullShadowSyncRequest.class));
+        strategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRequestBlockingQueue, timeout(Duration.ofSeconds(5).toMillis()).times(1)).put(any());
         verify(mockRequestBlockingQueue, times(1)).remove(any());
@@ -140,7 +142,7 @@ class RealTimeSyncStrategyTest {
         doThrow(InterruptedException.class).when(mockRequestBlockingQueue).put(any());
 
         strategy.start(mockSyncContext, 1);
-        strategy.putSyncRequest(mock(FullShadowSyncRequest.class));
+        strategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(0)).run(any(), any(), any());
         // check that we are interrupted by our "fake" exception. This also clears the thread state so cleanup


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Do not add the sync request in the queue if the update is not necessary. So we need to check that before we add it to the queue.
Also added some new booleans for tests to ensure that the queue is actually empty. 


**Why is this change necessary:**
We should not have a sync request which does not need to be processed in the queue. This was causing issue in the periodic sync wherein a local update was getting converted to a full sync due to an unnecessary local update request after the last cloud shadow update.

**How was this change tested:**
Updated the tests.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [X] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
