### PR TITLE
chore: remove Web Servlet classes from shaded jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>org/h2/server/web/*</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
**Issue #, if available:**


**Description of changes:**
Since upgrading to H2 v2.0 seems to be a breaking change, this will remove the Servlet classes from the shaded jar

**Why is this change necessary:**
https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/107

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
