### PR TITLE
fix: handle `AbortedException` correctly when syncing with cloud.

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -292,7 +292,7 @@ class SyncTest extends NucleusLaunchUtils {
     }
 
     @ParameterizedTest
-    @ValueSource(classes = {PeriodicSyncStrategy.class})
+    @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
     void GIVEN_synced_shadow_WHEN_local_update_THEN_cloud_updates(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context) throws IOException,
             InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
@@ -25,9 +25,10 @@ public interface SyncRequest {
      * @throws RetryableException       When error occurs in sync operation indicating a request needs to be retried
      * @throws SkipSyncRequestException When error occurs in sync operation indicating a request needs to be skipped.
      * @throws UnknownShadowException   When shadow not found in the sync table.
+     * @throws InterruptedException     if the thread is interrupted while syncing shadow with cloud.
      */
     void execute(SyncContext context) throws RetryableException, SkipSyncRequestException,
-            UnknownShadowException;
+            UnknownShadowException, InterruptedException;
 
     /**
      * Check if an update is neccessary or not.

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -189,11 +189,11 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
                 // queue will be transferred to the new sync strategy.
                 if (remaining > 0) {
                     logger.atInfo(SYNC_EVENT_TYPE)
-                            .log("Stopped real time syncing with {} pending sync items", remaining);
+                            .log("Stopped syncing with {} pending sync items", remaining);
                 }
             } else {
                 logger.atDebug(SYNC_EVENT_TYPE)
-                        .log("Real time Syncing is already stopped. Ignoring request to stop");
+                        .log("Syncing is already stopped. Ignoring request to stop");
             }
         }
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
@@ -139,6 +139,8 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
                     }
                 } catch (InterruptedException e) {
                     logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
+                    // Add the sync request back in the queue since we still need to process this later.
+                    syncQueue.offer(request);
                     Thread.currentThread().interrupt();
                 } catch (ConflictException | ConflictError e) {
                     logger.atWarn(SYNC_EVENT_TYPE)

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
@@ -120,6 +120,8 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
                     }
                 } catch (InterruptedException e) {
                     logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
+                    // Add the sync request back in the queue since we still need to process this later.
+                    syncQueue.offer(request);
                     Thread.currentThread().interrupt();
                 } catch (ConflictException | ConflictError e) {
                     logger.atWarn(SYNC_EVENT_TYPE)

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
@@ -80,21 +80,26 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
     /**
      * Take and execute items from the sync queue. This is intended to be run in a separate thread.
      */
-    @SuppressWarnings({"PMD.CompareObjectsWithEquals", "PMD.AvoidCatchingGenericException"})
+    @SuppressWarnings({"PMD.CompareObjectsWithEquals", "PMD.AvoidCatchingGenericException", "PMD.NullAssignment"})
     private void syncLoop() {
         logger.atInfo(SYNC_EVENT_TYPE).log("Start waiting for sync requests");
         try {
             SyncRequest request = syncQueue.take();
             RetryUtils.RetryConfig retryConfig = this.retryConfig;
+            String currProcessingThingName = null;
+            String currProcessingShadowName = null;
             do {
                 try {
+                    currProcessingThingName = request.getThingName();
+                    currProcessingShadowName = request.getShadowName();
                     logger.atInfo(SYNC_EVENT_TYPE)
-                            .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
                             .addKeyValue("Type", request.getClass().getSimpleName())
                             .log("Executing sync request");
 
                     retryer.run(retryConfig, request, context);
+                    request = null;
                     retryConfig = this.retryConfig; // reset the retry config back to default after success
 
                     logger.atDebug(SYNC_EVENT_TYPE).log("Waiting for next sync request");
@@ -103,8 +108,8 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
                     // this will be rethrown if all retries fail in RetryUtils
                     logger.atDebug(SYNC_EVENT_TYPE)
                             .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
                             .log("Retry sync request. Adding back to queue");
 
                     // put request to back of queue and get the front of queue in a single operation
@@ -120,23 +125,21 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
                     }
                 } catch (InterruptedException e) {
                     logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
-                    // Add the sync request back in the queue since we still need to process this later.
-                    syncQueue.offer(request);
                     Thread.currentThread().interrupt();
                 } catch (ConflictException | ConflictError e) {
                     logger.atWarn(SYNC_EVENT_TYPE)
                             .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
                             .log("Received conflict when processing request. Retrying as a full sync");
                     // add back to queue to merge over any shadow request that came in while it was executing
-                    request = syncQueue.offerAndTake(new FullShadowSyncRequest(request.getThingName(),
-                            request.getShadowName()), true);
+                    request = syncQueue.offerAndTake(new FullShadowSyncRequest(currProcessingThingName,
+                            currProcessingShadowName), true);
                 } catch (UnknownShadowException e) {
                     logger.atWarn(SYNC_EVENT_TYPE)
                             .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
                             .log("Received unknown shadow when processing request. Retrying as a full sync");
                     // add back to queue to merge over any shadow request that came in while it was executing
                     request = syncQueue.offerAndTake(new FullShadowSyncRequest(request.getThingName(),
@@ -144,12 +147,19 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
                 } catch (Exception e) {
                     logger.atError(SYNC_EVENT_TYPE)
                             .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
                             .log("Skipping sync request");
                     request = syncQueue.take();
+                    currProcessingThingName = request.getThingName();
+                    currProcessingShadowName = request.getShadowName();
                 }
             } while (!Thread.currentThread().isInterrupted());
+
+            // Add the sync request back in the queue if it was not processed.
+            if (request != null) {
+                syncQueue.offer(request);
+            }
         } catch (InterruptedException e) {
             logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
         }

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
@@ -102,11 +102,11 @@ class PeriodicSyncStrategyTest {
     @Test
     void GIVEN_sync_request_WHEN_putSyncRequest_and_sync_loop_runs_THEN_request_is_executed_successfully()
             throws Exception {
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, requestBlockingQueue);
+        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 1, requestBlockingQueue);
         syncStrategy.start(mockSyncContext, 3);
-        syncStrategy.putSyncRequest(mockFullShadowSyncRequest);
+        syncStrategy.putSyncRequest(new FullShadowSyncRequest("thing", "shadow"));
 
-        verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(1)).run(any(), any(), any());
+        verify(mockRetryer, timeout(Duration.ofSeconds(7).toMillis()).times(1)).run(any(), any(), any());
     }
 
 
@@ -205,7 +205,8 @@ class PeriodicSyncStrategyTest {
         CountDownLatch takeLatch = new CountDownLatch(2);
         doAnswer(invocation -> {
             takeLatch.countDown();
-            return requests.poll();
+            FullShadowSyncRequest request = requests.poll();
+            return request == null ? mock(FullShadowSyncRequest.class) : request;
         }).when(mockRequestBlockingQueue).poll();
         when(mockRequestBlockingQueue.offerAndTake(request1, false)).thenReturn(request1);
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
@@ -51,6 +51,7 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -153,6 +154,7 @@ class PeriodicSyncStrategyTest {
         // happens correctly
         assertThat(Thread.interrupted(), is(true));
 
+        verify(mockRequestBlockingQueue, atMostOnce()).offer(any());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
@@ -48,6 +48,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -149,6 +150,7 @@ class RealTimeSyncStrategyTest {
         // happens correctly
         assertThat(Thread.interrupted(), is(true));
 
+        verify(mockRequestBlockingQueue, atMostOnce()).offer(any());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
@@ -127,6 +127,11 @@ class RealTimeSyncStrategyTest {
             return null;
         }).when(mockRequestBlockingQueue).put(any());
 
+        lenient().doAnswer(invocation -> {
+            TimeUnit.SECONDS.sleep(10);
+            return mockFullShadowSyncRequest;
+        }).when(mockRequestBlockingQueue).take();
+
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(mockFullShadowSyncRequest);
 
@@ -141,6 +146,11 @@ class RealTimeSyncStrategyTest {
         ignoreExceptionOfType(extensionContext, InterruptedException.class);
         strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue);
         doThrow(InterruptedException.class).when(mockRequestBlockingQueue).put(any());
+
+        lenient().doAnswer(invocation -> {
+            TimeUnit.SECONDS.sleep(10);
+            return mockFullShadowSyncRequest;
+        }).when(mockRequestBlockingQueue).take();
 
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(mockFullShadowSyncRequest);
@@ -200,7 +210,8 @@ class RealTimeSyncStrategyTest {
         CountDownLatch takeLatch = new CountDownLatch(2);
         doAnswer(invocation -> {
             takeLatch.countDown();
-            return requests.poll();
+            FullShadowSyncRequest request = requests.poll();
+            return request == null ? mock(FullShadowSyncRequest.class) : request;
         }).when(mockRequestBlockingQueue).take();
         when(mockRequestBlockingQueue.offerAndTake(request1, false)).thenReturn(request1);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If an `AbortedException` is thrown, check the cause to see if it was caused due to an `InterruptedException`. If it is, then rethrow that back to the caller. The `syncLoop` should add this request back in the queue if the sync request failed due to an `InterruptedException`.

**Why is this change necessary:**
There might be times when a sync request fails due to the thread being interrupted (while syncing) or if the thread just dies.

**How was this change tested:**
Added / Updated unit tests.

**Any additional information or context required to review the change:**


**Checklist:**
 - [X] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
