### PR TITLE
fix: wait for executing sync request to finish before cancelling threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <h2.version>1.4.200</h2.version>
         <nucleus.version>2.2.0-SNAPSHOT</nucleus.version>
         <junit.version>5.6.2</junit.version>
-        <mockito.version>3.2.4</mockito.version>
+        <mockito.version>4.3.1</mockito.version>
         <lombok.version>1.18.10</lombok.version>
         <hamcrest.core.version>2.2</hamcrest.core.version>
         <hamcrest.eventually.version>0.0.3</hamcrest.eventually.version>
@@ -533,7 +533,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.2.4</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
@@ -31,7 +31,7 @@ public interface SyncRequest {
             UnknownShadowException, InterruptedException;
 
     /**
-     * Check if an update is neccessary or not.
+     * Check if an update is necessary or not.
      *
      * @param context context object containing useful objects for requests to use when executing.
      * @return true if an update is necessary; Else false.

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -13,19 +13,25 @@ import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
+import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.util.RetryUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import software.amazon.awssdk.aws.greengrass.model.ConflictError;
+import software.amazon.awssdk.services.iotdataplane.model.ConflictException;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
@@ -52,8 +58,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      * @implNote The Setter is only used in unit tests. The Getter is used in integration tests.
      */
     @Getter
-    @Setter
-    RequestBlockingQueue syncQueue;
+    final RequestBlockingQueue syncQueue;
 
     /**
      * Interface for executing sync requests.
@@ -103,6 +108,10 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      */
     AtomicBoolean executing = new AtomicBoolean(false);
 
+    Semaphore exec;
+    int syncParallelism;
+    CountDownLatch latch;
+
     /**
      * Getter for syncing boolean.
      *
@@ -127,10 +136,15 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      * @param retryer The retryer object.
      */
     public BaseSyncStrategy(Retryer retryer) {
-        this.retryer = retryer;
-        this.retryConfig = DEFAULT_RETRY_CONFIG;
-        RequestMerger requestMerger = new RequestMerger();
-        this.syncQueue = new RequestBlockingQueue(requestMerger);
+        this(retryer, DEFAULT_RETRY_CONFIG);
+    }
+
+    public BaseSyncStrategy(Retryer retryer, RequestBlockingQueue syncQueue) {
+        this(retryer, DEFAULT_RETRY_CONFIG, syncQueue);
+    }
+
+    public BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig) {
+        this(retryer, retryConfig, new RequestBlockingQueue(new RequestMerger()));
     }
 
     /**
@@ -138,8 +152,9 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      *
      * @param retryer     The retryer object.
      * @param retryConfig The config to be used by the retryer.
+     * @param syncQueue   A queue to use for sync requests.
      */
-    public BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig) {
+    public BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
         this.retryer = (config, request, context) -> {
             try {
                 executing.set(true);
@@ -149,8 +164,12 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
             }
         };
         this.retryConfig = retryConfig;
-        RequestMerger requestMerger = new RequestMerger();
-        this.syncQueue = new RequestBlockingQueue(requestMerger);
+        this.syncQueue = syncQueue;
+
+        // initialize some defaults
+        this.syncParallelism = 1;
+        this.exec = new Semaphore(1);
+        this.latch = new CountDownLatch(1);
     }
 
     /**
@@ -164,6 +183,9 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
         synchronized (lifecycleLock) {
             this.context = context;
             if (syncing.compareAndSet(false, true)) {
+                exec = new Semaphore(syncParallelism);
+                this.syncParallelism = syncParallelism;
+                latch = new CountDownLatch(syncParallelism);
                 doStart(context, syncParallelism);
             } else {
                 logger.atDebug(SYNC_EVENT_TYPE).log("Already started syncing");
@@ -179,7 +201,6 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
         synchronized (lifecycleLock) {
             if (syncing.compareAndSet(true, false)) {
                 logger.atInfo(SYNC_EVENT_TYPE).log("Stop syncing");
-                syncing.set(false);
 
                 doStop();
 
@@ -198,10 +219,51 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
         }
     }
 
-
     abstract void doStart(SyncContext context, int syncParallelism);
 
-    abstract void doStop();
+    protected void doStop() {
+        logger.atInfo(SYNC_EVENT_TYPE).log("Cancel {} sync thread(s)", syncThreads.size());
+        try {
+            // The syncing flag is set to false by this point so once current requests have finished threads will not
+            // pick up another
+
+            // We need to cancel threads, but we should wait for any inflight requests to finish
+            // Cancelling a thread while the db is in the middle of an operation will cause errors in the connection.
+            // FullSyncRequests can generate a local and cloud request and we want both of those to get executed before
+            // cancelling the sync threads.
+
+            // There is a semaphore around the critical section in the sync loop - we do not want to cancel while
+            // that is held.
+            // There is a latch that is decremented when the syncLoop exits - this allows us to know when stopped or
+            // cancelled threads have actually exited. Cancelling a future will not let you know when the thread has
+            // actually finished.
+            if (!exec.tryAcquire(syncParallelism)) {
+                logger.atInfo(SYNC_EVENT_TYPE).log("Waiting for in-flight sync requests to finish");
+                exec.acquireUninterruptibly(syncParallelism);
+                logger.atInfo(SYNC_EVENT_TYPE).log("Finished waiting for sync requests to finish");
+            }
+            syncThreads.forEach(t -> t.cancel(true));
+
+            // wait for threads to actually exit
+            try {
+                // wait for threads to actually exit but don't block forever
+                if (!latch.await(30, TimeUnit.SECONDS)) {
+                    logger.atWarn(SYNC_EVENT_TYPE).log("{} threads did not exit in time", latch.getCount());
+                }
+            } catch (InterruptedException e) {
+                logger.atDebug(SYNC_EVENT_TYPE).log("Interrupted while waiting for threads to finish");
+            }
+            syncThreads.clear();
+        } finally {
+            exec.release(syncParallelism);
+        }
+    }
+
+    /**
+     * Get the request from the queue.
+     * @return a request.
+     */
+    abstract SyncRequest getRequest() throws InterruptedException;
 
     /**
      * Put a sync request into the queue if syncing is started.
@@ -283,5 +345,116 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
     @Override
     public int getRemainingCapacity() {
         return syncQueue.remainingCapacity();
+    }
+
+    /**
+     * Take and execute items from the sync queue. This is intended to be run in a separate thread.
+     * This will work on all the sync requests in the queue until it's empty.
+     */
+    @SuppressWarnings({"PMD.CompareObjectsWithEquals", "PMD.AvoidCatchingGenericException", "PMD.NullAssignment"})
+    protected void syncLoop() {
+        SyncRequest request = null;
+        try {
+            logger.atInfo(SYNC_EVENT_TYPE).log("Start processing sync requests");
+            RetryUtils.RetryConfig retryConfig = this.retryConfig;
+            request = getRequest();
+            String currProcessingThingName = null;
+            String currProcessingShadowName = null;
+
+            // Process the sync requests until there is a sync request in the queue and until the thread has not
+            // been interrupted.
+            while (request != null && !Thread.currentThread().isInterrupted() && syncing.get()) {
+                try {
+                    currProcessingThingName = request.getThingName();
+                    currProcessingShadowName = request.getShadowName();
+
+                    // acquire a permit so that if syncing is stopped while executing, we get to finish the request
+                    exec.acquire();
+                    try {
+                        // if we are currently stopped - don't run the current request
+                        if (!syncing.get()) {
+                            logger.atTrace(SYNC_EVENT_TYPE)
+                                    .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                                    .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
+                                    .addKeyValue("Type", request.getClass().getSimpleName())
+                                    .log("Syncing stopped after acquiring permit, exit");
+                            break;
+                        }
+                        logger.atInfo(SYNC_EVENT_TYPE)
+                                .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                                .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
+                                .addKeyValue("Type", request.getClass().getSimpleName())
+                                .log("Executing sync request");
+                        retryer.run(retryConfig, request, context);
+                    } finally {
+                        exec.release();
+                    }
+                    request = null; // Reset the request here since we have already processed it successfully.
+
+                    retryConfig = this.retryConfig; // reset the retry config back to default after success
+                    request = getRequest();
+                } catch (RetryableException e) {
+                    // this will be rethrown if all retries fail in RetryUtils
+                    logger.atDebug(SYNC_EVENT_TYPE)
+                            .cause(e)
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
+                            .log("Retry sync request. Adding back to queue");
+
+                    // put request to back of queue and get the front of queue in a single operation
+                    SyncRequest failedRequest = request;
+
+                    // tell queue this is not a new value so it merges correctly with any update that came in
+                    request = syncQueue.offerAndTake(request, false);
+
+                    // if queue was empty, we are going to immediately retrying the same request. For this case don't
+                    // use the default retry configuration - keep from spamming too quickly
+                    if (request == failedRequest) {
+                        retryConfig = FAILED_RETRY_CONFIG;
+                    }
+                } catch (InterruptedException e) {
+                    logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
+                    Thread.currentThread().interrupt();
+                } catch (ConflictException | ConflictError e) {
+                    logger.atWarn(SYNC_EVENT_TYPE)
+                            .cause(e)
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
+                            .log("Received conflict when processing request. Retrying as a full sync");
+                    // add back to queue to merge over any shadow request that came in while it was executing
+                    request = syncQueue.offerAndTake(new FullShadowSyncRequest(currProcessingThingName,
+                            currProcessingShadowName), true);
+                } catch (UnknownShadowException e) {
+                    logger.atWarn(SYNC_EVENT_TYPE).cause(e).addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
+                            .log("Received unknown shadow when processing request. Retrying as a full sync");
+                    // add back to queue to merge over any shadow request that came in while it was executing
+                    request = syncQueue.offerAndTake(
+                            new FullShadowSyncRequest(currProcessingThingName, currProcessingShadowName), true);
+                } catch (Exception e) {
+                    logger.atError(SYNC_EVENT_TYPE)
+                            .cause(e)
+                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
+                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
+                            .log("Skipping sync request");
+                    request = getRequest();
+                }
+            }
+
+        } catch (InterruptedException e) {
+            logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
+        } finally {
+            // Add the sync request back in the queue if it was not processed.
+            if (request != null) {
+                logger.atTrace(SYNC_EVENT_TYPE)
+                        .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
+                        .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
+                        .addKeyValue("Type", request.getClass().getSimpleName())
+                        .log("Adding request item back to queue");
+                syncQueue.offer(request);
+            }
+            logger.atInfo(SYNC_EVENT_TYPE).log("Finished processing sync requests");
+            latch.countDown();
+        }
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
@@ -61,9 +61,9 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
     @Override
     void doStart(SyncContext context, int syncParallelism) {
         logger.atInfo(SYNC_EVENT_TYPE).kv("interval", interval).log("Start periodic syncing");
-        latch = new CountDownLatch(1);
+        syncThreadEnd = new CountDownLatch(1);
         this.syncParallelism = 1; // ignore sync parallelism as there is only 1 thread running
-        this.exec = new Semaphore(1);
+        this.criticalExecBlock = new Semaphore(1);
         this.syncThreads.add(syncExecutorService
                 .scheduleAtFixedRate(this::syncLoop, 0, interval, TimeUnit.SECONDS));
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
@@ -7,21 +7,13 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.shadowmanager.exception.RetryableException;
-import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
-import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.util.RetryUtils;
-import software.amazon.awssdk.aws.greengrass.model.ConflictError;
-import software.amazon.awssdk.services.iotdataplane.model.ConflictException;
 
 import java.util.concurrent.ExecutorService;
-
-import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
-import static com.aws.greengrass.shadowmanager.model.Constants.LOG_THING_NAME_KEY;
 
 /**
  * Handles syncing of shadows in real time. Whenever the device is connected, this strategy will try to execute the
@@ -40,11 +32,8 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
      * @param syncQueue       The sync queue from the previous strategy if any.
      */
     public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer, RequestBlockingQueue syncQueue) {
-        super(retryer);
+        super(retryer, syncQueue);
         this.syncExecutorService = executorService;
-        if (syncQueue != null) {
-            this.syncQueue = syncQueue;
-        }
     }
 
     /**
@@ -70,99 +59,7 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
     }
 
     @Override
-    void doStop() {
-        logger.atInfo(SYNC_EVENT_TYPE).log("Cancel {} real time sync thread(s)", syncThreads.size());
-        syncThreads.forEach(t -> t.cancel(true));
-        syncThreads.clear();
-    }
-
-
-    /**
-     * Take and execute items from the sync queue. This is intended to be run in a separate thread.
-     */
-    @SuppressWarnings({"PMD.CompareObjectsWithEquals", "PMD.AvoidCatchingGenericException", "PMD.NullAssignment"})
-    private void syncLoop() {
-        logger.atInfo(SYNC_EVENT_TYPE).log("Start waiting for sync requests");
-        try {
-            SyncRequest request = syncQueue.take();
-            RetryUtils.RetryConfig retryConfig = this.retryConfig;
-            String currProcessingThingName = null;
-            String currProcessingShadowName = null;
-            do {
-                try {
-                    currProcessingThingName = request.getThingName();
-                    currProcessingShadowName = request.getShadowName();
-                    logger.atInfo(SYNC_EVENT_TYPE)
-                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
-                            .addKeyValue("Type", request.getClass().getSimpleName())
-                            .log("Executing sync request");
-
-                    retryer.run(retryConfig, request, context);
-                    request = null;
-                    retryConfig = this.retryConfig; // reset the retry config back to default after success
-
-                    logger.atDebug(SYNC_EVENT_TYPE).log("Waiting for next sync request");
-                    request = syncQueue.take();
-                } catch (RetryableException e) {
-                    // this will be rethrown if all retries fail in RetryUtils
-                    logger.atDebug(SYNC_EVENT_TYPE)
-                            .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
-                            .log("Retry sync request. Adding back to queue");
-
-                    // put request to back of queue and get the front of queue in a single operation
-                    SyncRequest failedRequest = request;
-
-                    // tell queue this is not a new value so it merges correctly with any update that came in
-                    request = syncQueue.offerAndTake(request, false);
-
-                    // if queue was empty, we are going to immediately retrying the same request. For this case don't
-                    // use the default retry configuration - keep from spamming too quickly
-                    if (request == failedRequest) {
-                        retryConfig = FAILED_RETRY_CONFIG;
-                    }
-                } catch (InterruptedException e) {
-                    logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
-                    Thread.currentThread().interrupt();
-                } catch (ConflictException | ConflictError e) {
-                    logger.atWarn(SYNC_EVENT_TYPE)
-                            .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
-                            .log("Received conflict when processing request. Retrying as a full sync");
-                    // add back to queue to merge over any shadow request that came in while it was executing
-                    request = syncQueue.offerAndTake(new FullShadowSyncRequest(currProcessingThingName,
-                            currProcessingShadowName), true);
-                } catch (UnknownShadowException e) {
-                    logger.atWarn(SYNC_EVENT_TYPE)
-                            .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
-                            .log("Received unknown shadow when processing request. Retrying as a full sync");
-                    // add back to queue to merge over any shadow request that came in while it was executing
-                    request = syncQueue.offerAndTake(new FullShadowSyncRequest(request.getThingName(),
-                            request.getShadowName()), true);
-                } catch (Exception e) {
-                    logger.atError(SYNC_EVENT_TYPE)
-                            .cause(e)
-                            .addKeyValue(LOG_THING_NAME_KEY, currProcessingThingName)
-                            .addKeyValue(LOG_SHADOW_NAME_KEY, currProcessingShadowName)
-                            .log("Skipping sync request");
-                    request = syncQueue.take();
-                    currProcessingThingName = request.getThingName();
-                    currProcessingShadowName = request.getShadowName();
-                }
-            } while (!Thread.currentThread().isInterrupted());
-
-            // Add the sync request back in the queue if it was not processed.
-            if (request != null) {
-                syncQueue.offer(request);
-            }
-        } catch (InterruptedException e) {
-            logger.atWarn(SYNC_EVENT_TYPE).log("Interrupted while waiting for sync requests");
-        }
-        logger.atInfo(SYNC_EVENT_TYPE).log("Stop waiting for sync requests");
+    SyncRequest getRequest() throws InterruptedException {
+        return syncQueue.take();
     }
 }

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
@@ -75,7 +75,7 @@ class SyncHandlerTest {
 
     @BeforeEach
     void setup() {
-        syncHandler = new SyncHandler(executorService, scheduledExecutorService);
+        syncHandler = new SyncHandler(executorService, scheduledExecutorService, mock(RequestBlockingQueue.class));
         syncHandler.setOverallSyncStrategy(mockSyncStrategy);
     }
 
@@ -117,7 +117,7 @@ class SyncHandlerTest {
     @Test
     void GIVEN_sync_strategy_WHEN_setSyncStrategy_THEN_calls_sync_factory() {
         // GIVEN
-        syncHandler = new SyncHandler(mockSyncStrategyFactory);
+        syncHandler = new SyncHandler(mockSyncStrategyFactory, mock(RequestBlockingQueue.class));
 
         // WHEN
         syncHandler.setSyncStrategy(mock(Strategy.class));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
@@ -5,30 +5,21 @@
 
 package com.aws.greengrass.shadowmanager.sync.strategy;
 
-import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.RequestMerger;
-import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
-import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.event.Level;
 import software.amazon.awssdk.aws.greengrass.model.ConflictError;
 import software.amazon.awssdk.services.iotdataplane.model.ConflictException;
 
@@ -41,7 +32,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
@@ -62,49 +52,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-class PeriodicSyncStrategyTest {
-    @Mock
-    private Retryer mockRetryer;
-    @Mock
-    private SyncContext mockSyncContext;
-    @Mock
-    private RequestBlockingQueue mockRequestBlockingQueue;
-    @Mock
-    private FullShadowSyncRequest mockFullShadowSyncRequest;
-    private RequestBlockingQueue requestBlockingQueue;
+class PeriodicSyncStrategyTest extends SyncStrategyTestBase<PeriodicSyncStrategy, ScheduledExecutorService> {
 
-    private ScheduledExecutorService scheduledExecutorService;
-    private PeriodicSyncStrategy syncStrategy;
-
-    @BeforeAll
-    static void setupLogger() {
-        LogConfig.getRootLogConfig().setLevel(Level.ERROR);
+    PeriodicSyncStrategyTest() {
+        super(Executors::newSingleThreadScheduledExecutor);
     }
 
-    @AfterAll
-    static void cleanupLogger() {
-        LogConfig.getRootLogConfig().setLevel(Level.INFO);
-    }
-
-    @BeforeEach
-    void setup() {
-        scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
-        this.requestBlockingQueue = new RequestBlockingQueue(new RequestMerger());
-        lenient().when(mockFullShadowSyncRequest.isUpdateNecessary(any())).thenReturn(true);
-    }
-
-    @AfterEach
-    void tearDown() {
-        syncStrategy.stop();
-        scheduledExecutorService.shutdownNow();
+    @Override
+    PeriodicSyncStrategy defaultTestInstance() {
+        return new PeriodicSyncStrategy(executorService, mockRetryer, 3, mockRequestBlockingQueue);
     }
 
     @Test
     void GIVEN_sync_request_WHEN_putSyncRequest_and_sync_loop_runs_THEN_request_is_executed_successfully()
             throws Exception {
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 1, requestBlockingQueue);
-        syncStrategy.start(mockSyncContext, 3);
-        syncStrategy.putSyncRequest(new FullShadowSyncRequest("thing", "shadow"));
+        strategy = new PeriodicSyncStrategy(executorService, mockRetryer, 1,
+                new RequestBlockingQueue(new RequestMerger()));
+        strategy.start(mockSyncContext, 1);
+        strategy.putSyncRequest(new FullShadowSyncRequest("thing", "shadow"));
 
         verify(mockRetryer, timeout(Duration.ofSeconds(7).toMillis()).times(1)).run(any(), any(), any());
     }
@@ -113,9 +78,7 @@ class PeriodicSyncStrategyTest {
     @Test
     void GIVEN_sync_request_WHEN_putSyncRequest_and_syncing_is_stopped_THEN_request_is_not_added_to_queue()
             throws Exception {
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, mockRequestBlockingQueue);
-
-        syncStrategy.putSyncRequest(mock(FullShadowSyncRequest.class));
+        strategy.putSyncRequest(mock(FullShadowSyncRequest.class));
 
         verify(mockRequestBlockingQueue, timeout(Duration.ofSeconds(5).toMillis()).times(0)).put(any());
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(0)).run(any(), any(), any());
@@ -124,15 +87,13 @@ class PeriodicSyncStrategyTest {
     @Test
     void GIVEN_sync_request_WHEN_sync_stops_during_put_in_queue_THEN_request_is_removed_from_queue()
             throws Exception {
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, mockRequestBlockingQueue);
-
         doAnswer(i -> {
-            syncStrategy.syncing.set(false);
+            strategy.syncing.set(false);
             return null;
         }).when(mockRequestBlockingQueue).put(any());
 
-        syncStrategy.start(mockSyncContext, 2);
-        syncStrategy.putSyncRequest(mockFullShadowSyncRequest);
+        strategy.start(mockSyncContext, 2);
+        strategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRequestBlockingQueue, timeout(Duration.ofSeconds(5).toMillis()).times(1)).put(any());
         verify(mockRequestBlockingQueue, times(1)).remove(any());
@@ -143,11 +104,10 @@ class PeriodicSyncStrategyTest {
     void GIVEN_sync_request_WHEN_queue_throws_interrupted_exception_THEN_sync_request_is_not_added(ExtensionContext extensionContext)
             throws Exception {
         ignoreExceptionOfType(extensionContext, InterruptedException.class);
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, mockRequestBlockingQueue);
         doThrow(InterruptedException.class).when(mockRequestBlockingQueue).put(any());
 
-        syncStrategy.start(mockSyncContext, 2);
-        syncStrategy.putSyncRequest(mockFullShadowSyncRequest);
+        strategy.start(mockSyncContext, 1);
+        strategy.putSyncRequest(mockFullShadowSyncRequest);
 
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(0)).run(any(), any(), any());
         // check that we are interrupted by our "fake" exception. This also clears the thread state so cleanup
@@ -159,20 +119,20 @@ class PeriodicSyncStrategyTest {
 
     @Test
     void GIVEN_request_queue_WHEN_put_and_clear_THEN_queue_has_correct_number_of_requests() throws InterruptedException {
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, requestBlockingQueue);
-
-        syncStrategy.syncing.set(true);
-
+        strategy = new PeriodicSyncStrategy(executorService, mockRetryer, 3,
+                new RequestBlockingQueue(new RequestMerger()));
+        strategy.syncing.set(true);
+        strategy.latch = new CountDownLatch(0); // not actually syncing
         Random rand = new Random();
         int randomNumberOfSyncRequests = rand.nextInt(1024);
         for (int i = 0; i < randomNumberOfSyncRequests; i++) {
-            syncStrategy.putSyncRequest(new FullShadowSyncRequest("foo-" + i, "bar-" + i));
+            strategy.putSyncRequest(new FullShadowSyncRequest("foo-" + i, "bar-" + i));
         }
-        assertThat(syncStrategy.getRemainingCapacity(), is(1024 - randomNumberOfSyncRequests));
+        assertThat(strategy.getRemainingCapacity(), is(1024 - randomNumberOfSyncRequests));
 
-        syncStrategy.clearSyncQueue();
+        strategy.clearSyncQueue();
 
-        assertThat(syncStrategy.getRemainingCapacity(), is(1024));
+        assertThat(strategy.getRemainingCapacity(), is(1024));
     }
 
     @Test
@@ -193,7 +153,6 @@ class PeriodicSyncStrategyTest {
         requests.add(request1);
         requests.add(request2);
 
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, mockRequestBlockingQueue);
         doAnswer(invocation -> {
             executeLatch.countDown();
             if (executeLatch.getCount() != 0) {
@@ -210,8 +169,8 @@ class PeriodicSyncStrategyTest {
         }).when(mockRequestBlockingQueue).poll();
         when(mockRequestBlockingQueue.offerAndTake(request1, false)).thenReturn(request1);
 
-        syncStrategy.start(mockSyncContext, 2);
-        syncStrategy.putSyncRequest(new FullShadowSyncRequest("foo", "bar"));
+        strategy.start(mockSyncContext, 1);
+        strategy.putSyncRequest(new FullShadowSyncRequest("foo", "bar"));
 
         assertThat("executed request", executeLatch.await(5, TimeUnit.SECONDS), is(true));
         assertThat("take all requests", takeLatch.await(5, TimeUnit.SECONDS), is(true));
@@ -228,7 +187,6 @@ class PeriodicSyncStrategyTest {
         lenient().when(request1.getThingName()).thenReturn("thing1");
         lenient().when(request1.getShadowName()).thenReturn("shadow1");
 
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, mockRequestBlockingQueue);
         doAnswer(invocation -> {
             executeLatch.countDown();
             if (executeLatch.getCount() != 0) {
@@ -239,8 +197,8 @@ class PeriodicSyncStrategyTest {
 
         when(mockRequestBlockingQueue.poll()).thenReturn(request1);
 
-        syncStrategy.start(mockSyncContext, 2);
-        syncStrategy.putSyncRequest(new FullShadowSyncRequest("foo", "bar"));
+        strategy.start(mockSyncContext, 1);
+        strategy.putSyncRequest(new FullShadowSyncRequest("foo", "bar"));
 
         assertThat("executed request", executeLatch.await(5, TimeUnit.SECONDS), is(true));
         verify(mockRequestBlockingQueue, atLeastOnce()).poll();
@@ -254,7 +212,6 @@ class PeriodicSyncStrategyTest {
         ignoreExceptionOfType(extensionContext, clazz);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
-        syncStrategy = new PeriodicSyncStrategy(scheduledExecutorService, mockRetryer, 3, mockRequestBlockingQueue);
 
         CloudUpdateSyncRequest request1 = mock(CloudUpdateSyncRequest.class);
         lenient().when(request1.getThingName()).thenReturn("thing1");
@@ -286,7 +243,7 @@ class PeriodicSyncStrategyTest {
                 .thenAnswer(invocation -> invocation.getArgument(0, FullShadowSyncRequest.class));
 
         try {
-            syncStrategy.start(mockSyncContext, 2);
+            strategy.start(mockSyncContext, 1);
 
             assertThat("executed requests", executeLatch.await(5, TimeUnit.SECONDS), is(true));
         } finally {

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategyTest.java
@@ -122,7 +122,7 @@ class PeriodicSyncStrategyTest extends SyncStrategyTestBase<PeriodicSyncStrategy
         strategy = new PeriodicSyncStrategy(executorService, mockRetryer, 3,
                 new RequestBlockingQueue(new RequestMerger()));
         strategy.syncing.set(true);
-        strategy.latch = new CountDownLatch(0); // not actually syncing
+        strategy.syncThreadEnd = new CountDownLatch(0); // not actually syncing
         Random rand = new Random();
         int randomNumberOfSyncRequests = rand.nextInt(1024);
         for (int i = 0; i < randomNumberOfSyncRequests; i++) {

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
@@ -130,7 +130,7 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
         strategy = new RealTimeSyncStrategy(executorService, mockRetryer,
                 new RequestBlockingQueue(new RequestMerger()));
         strategy.syncing.set(true);
-        strategy.latch = new CountDownLatch(0); // no sync actually running
+        strategy.syncThreadEnd = new CountDownLatch(0); // no sync actually running
 
         int numberOfSyncRequests = 100;
         for (int i = 0; i < numberOfSyncRequests; i++) {

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
@@ -5,30 +5,21 @@
 
 package com.aws.greengrass.shadowmanager.sync.strategy;
 
-import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.RequestMerger;
-import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
-import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.event.Level;
 import software.amazon.awssdk.aws.greengrass.model.ConflictError;
 import software.amazon.awssdk.services.iotdataplane.model.ConflictException;
 
@@ -44,8 +35,8 @@ import java.util.concurrent.TimeUnit;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMostOnce;
@@ -59,47 +50,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-class RealTimeSyncStrategyTest {
-    @Mock
-    private Retryer mockRetryer;
-    @Mock
-    private SyncContext mockSyncContext;
-    @Mock
-    private RequestBlockingQueue mockRequestBlockingQueue;
-    @Mock
-    private FullShadowSyncRequest mockFullShadowSyncRequest;
-    private RequestBlockingQueue requestBlockingQueue;
+class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy, ExecutorService> {
 
-    private ExecutorService executorService;
-    private RealTimeSyncStrategy strategy;
-
-    @BeforeAll
-    static void setupLogger() {
-        LogConfig.getRootLogConfig().setLevel(Level.ERROR);
+    RealTimeSyncStrategyTest() {
+        super(Executors::newCachedThreadPool);
     }
 
-    @AfterAll
-    static void cleanupLogger() {
-        LogConfig.getRootLogConfig().setLevel(Level.INFO);
-    }
-
-    @BeforeEach
-    void setup() {
-        executorService = Executors.newCachedThreadPool();
-        this.requestBlockingQueue = new RequestBlockingQueue(new RequestMerger());
-        lenient().when(mockFullShadowSyncRequest.isUpdateNecessary(any())).thenReturn(true);
-    }
-
-    @AfterEach
-    void tearDown() {
-        strategy.stop();
-        executorService.shutdownNow();
+    @Override
+    RealTimeSyncStrategy defaultTestInstance() {
+        return new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue);
     }
 
     @Test
     void GIVEN_sync_request_WHEN_putSyncRequest_and_sync_loop_runs_THEN_request_is_executed_successfully()
             throws Exception {
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, requestBlockingQueue);
+        strategy = new RealTimeSyncStrategy(executorService, mockRetryer,
+                new RequestBlockingQueue(new RequestMerger()));
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(mockFullShadowSyncRequest);
 
@@ -109,8 +75,6 @@ class RealTimeSyncStrategyTest {
     @Test
     void GIVEN_sync_request_WHEN_putSyncRequest_and_syncing_is_stopped_THEN_request_is_not_added_to_queue()
             throws Exception {
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue);
-
         strategy.putSyncRequest(mock(FullShadowSyncRequest.class));
 
         verify(mockRequestBlockingQueue, timeout(Duration.ofSeconds(5).toMillis()).times(0)).put(any());
@@ -120,8 +84,6 @@ class RealTimeSyncStrategyTest {
     @Test
     void GIVEN_sync_request_WHEN_sync_stops_during_put_in_queue_THEN_request_is_removed_from_queue()
             throws Exception {
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue);
-
         doAnswer(i -> {
             strategy.syncing.set(false);
             return null;
@@ -144,7 +106,6 @@ class RealTimeSyncStrategyTest {
     void GIVEN_sync_request_WHEN_queue_throws_interrupted_exception_THEN_sync_request_is_not_added(ExtensionContext extensionContext)
             throws Exception {
         ignoreExceptionOfType(extensionContext, InterruptedException.class);
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue);
         doThrow(InterruptedException.class).when(mockRequestBlockingQueue).put(any());
 
         lenient().doAnswer(invocation -> {
@@ -165,9 +126,11 @@ class RealTimeSyncStrategyTest {
 
     @Test
     void GIVEN_request_queue_WHEN_put_and_clear_THEN_queue_has_correct_number_of_requests() throws InterruptedException {
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, requestBlockingQueue);
 
+        strategy = new RealTimeSyncStrategy(executorService, mockRetryer,
+                new RequestBlockingQueue(new RequestMerger()));
         strategy.syncing.set(true);
+        strategy.latch = new CountDownLatch(0); // no sync actually running
 
         int numberOfSyncRequests = 100;
         for (int i = 0; i < numberOfSyncRequests; i++) {
@@ -198,7 +161,6 @@ class RealTimeSyncStrategyTest {
         requests.add(request1);
         requests.add(request2);
 
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue);
         doAnswer(invocation -> {
             executeLatch.countDown();
             if (executeLatch.getCount() != 0) {
@@ -233,7 +195,6 @@ class RealTimeSyncStrategyTest {
         lenient().when(request1.getThingName()).thenReturn("thing1");
         lenient().when(request1.getShadowName()).thenReturn("shadow1");
 
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue);
         doAnswer(invocation -> {
             executeLatch.countDown();
             if (executeLatch.getCount() != 0) {

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
@@ -161,7 +161,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         when(strategy.getRequest())
                 .thenAnswer(i -> mockFullShadowSyncRequest)
                 .thenAnswer(i -> {
-                    strategy.exec = s;
+                    strategy.criticalExecBlock = s;
                     // wait for the stop to try and acquire - it will then wait until requests have finished
                     stopFuture[0] = Executors.newSingleThreadExecutor().submit(() -> strategy.stop());
                     return request2;

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.strategy;
+
+import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.Retryer;
+import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
+import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
+import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
+import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.event.Level;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"PMD.AvoidCatchingGenericException"})
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends ExecutorService> {
+
+    Retryer mockRetryer;
+    SyncContext mockSyncContext;
+    RequestBlockingQueue mockRequestBlockingQueue;
+    FullShadowSyncRequest mockFullShadowSyncRequest;
+    S executorService;
+    T strategy;
+
+    Supplier<S> executorServiceSupplier;
+
+    SyncStrategyTestBase(Supplier<S> execServiceSupplier) {
+        this.executorServiceSupplier = execServiceSupplier;
+    }
+
+    abstract T defaultTestInstance();
+
+    @BeforeEach
+    void setup() {
+        executorService = executorServiceSupplier.get();
+        mockRequestBlockingQueue = mock(RequestBlockingQueue.class);
+        mockSyncContext = mock(SyncContext.class);
+        mockRetryer = mock(Retryer.class);
+        mockFullShadowSyncRequest = mock(FullShadowSyncRequest.class);
+        lenient().when(mockFullShadowSyncRequest.isUpdateNecessary(any())).thenReturn(true);
+        strategy = defaultTestInstance();
+    }
+
+    @BeforeAll
+    static void setupLogger() {
+        LogConfig.getRootLogConfig().setLevel(Level.ERROR);
+    }
+
+    @AfterAll
+    static void cleanupLogger() {
+        LogConfig.getRootLogConfig().setLevel(Level.INFO);
+    }
+
+    @AfterEach
+    void tearDown() {
+        strategy.stop();
+        executorService.shutdownNow();
+    }
+
+    @Test
+    void GIVEN_sync_request_WHEN_syncing_stopped_THEN_request_added_back_without_executing(
+            ExtensionContext extensionContext)
+            throws Exception {
+
+        CountDownLatch requestCalled = new CountDownLatch(1);
+        when(strategy.getRequest()).thenAnswer(invocation -> {
+            strategy.syncing.set(false);
+            requestCalled.countDown();
+            return mockFullShadowSyncRequest;
+        });
+
+        strategy.start(mockSyncContext, 1);
+        if (!requestCalled.await(5, TimeUnit.SECONDS)) {
+            fail("sync request not taken from queue");
+        }
+
+        verify(mockRetryer, never()).run(any(), any(), any());
+        verify(mockRequestBlockingQueue, timeout(ofSeconds(5).toMillis())).offer(mockFullShadowSyncRequest);
+    }
+
+    @Test
+    void GIVEN_sync_request_WHEN_syncing_stopped_after_enter_loop_THEN_request_added_back_without_executing(ExtensionContext extensionContext)
+            throws Exception {
+        CountDownLatch finished = new CountDownLatch(1);
+        SyncRequest request2 = mock(CloudUpdateSyncRequest.class);
+
+        when(strategy.getRequest())
+                .thenReturn(mockFullShadowSyncRequest)
+                .thenAnswer(i -> {
+                    strategy.syncing.set(false);
+                    finished.countDown();
+                    return request2;
+                });
+        strategy.start(mockSyncContext, 1);
+
+        if (!finished.await(10, TimeUnit.SECONDS)) {
+            fail("Did not return second sync request");
+        }
+
+        verify(mockRetryer, times(1)).run(any(), eq(mockFullShadowSyncRequest), any());
+        verify(mockRequestBlockingQueue, timeout(ofSeconds(5).toMillis())).offer(request2);
+    }
+
+    @Test
+    void GIVEN_sync_request_WHEN_syncing_stopped_after_acquire_permit_THEN_request_added_back_without_executing(ExtensionContext extensionContext)
+            throws Exception {
+        Semaphore s = mock(Semaphore.class);
+
+        // latch for when stop checks for running requests
+        CountDownLatch tryAcquireCalled = new CountDownLatch(1);
+
+        when(s.tryAcquire(1)).thenAnswer(i -> {
+            tryAcquireCalled.countDown();
+            return false;
+        });
+        doAnswer(i -> {
+                    if (!tryAcquireCalled.await(5, TimeUnit.SECONDS)) {
+                        fail("tryAcquire was not called");
+                    }
+                    return null;
+                }
+        ).when(s).acquire();
+
+        SyncRequest request2 = mock(CloudUpdateSyncRequest.class);
+
+        final Future<?>[] stopFuture = new Future<?>[1];
+
+        when(strategy.getRequest())
+                .thenAnswer(i -> mockFullShadowSyncRequest)
+                .thenAnswer(i -> {
+                    strategy.exec = s;
+                    // wait for the stop to try and acquire - it will then wait until requests have finished
+                    stopFuture[0] = Executors.newSingleThreadExecutor().submit(() -> strategy.stop());
+                    return request2;
+                });
+
+        strategy.start(mockSyncContext, 1);
+
+        if (!tryAcquireCalled.await(5, TimeUnit.SECONDS)) {
+            fail("Did not attempt to stop while executing");
+        }
+
+        // wait for the request to finish
+        try {
+            stopFuture[0].get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            fail("Did not finish stopping", e);
+        }
+        verify(mockRetryer, times(1)).run(any(), eq(mockFullShadowSyncRequest), any());
+        verify(mockRetryer, never()).run(any(), eq(request2), any());
+
+        verify(mockRequestBlockingQueue, timeout(ofSeconds(5).toMillis()).times(1)).offer(request2);
+    }
+
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Cancelling sync threads can cause database exceptions if an I/O operation is occurring when the thread is cancelled.

A semaphore is used along with the existing  flag to force the stopper to wait until the request is finished.

SyncStrategy common logic was refactored into the BaseSyncStrategy class to avoid duplication. 

The `syncLoop` method from the `PeriodicSyncStrategy` class was pulled up to the `BaseSyncStrategy`.  Periodic still uses the non-blocking `poll` and RealTime still uses the blocking `take` to get data off the queue. A permit on the semaphore is acquired before executing the request and there are checks for whether syncing has stopped. A latch is used to wait for threads to exit.

Extra test cases have been added to cover this change, and an integration test that turns syncing on and off repeatedly for 30 seconds has been added.

**Why is this change necessary:**
To avoid H2 database exceptions and other Interrupted exceptions when syncing gets stopped while a request is processing.

**How was this change tested:**
Unit/integration

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
