### PR TITLE
fix: improvements to sync stopping behavior

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -302,9 +302,12 @@ public class ShadowManager extends PluginService {
                 });
 
         Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
+        final Strategy[] currentStrategy = { DEFAULT_STRATEGY };
+
         strategyTopics.subscribe((why, newv) -> {
             Strategy strategy;
             Map<String, Object> strategyPojo = strategyTopics.toPOJO();
+
             if (WhatHappened.removed.equals(why) || strategyPojo == null || strategyPojo.isEmpty()) {
                 strategy = DEFAULT_STRATEGY;
             } else {
@@ -316,9 +319,12 @@ public class ShadowManager extends PluginService {
                     return;
                 }
             }
-            stopSyncingShadows(false);
-            syncHandler.setSyncStrategy(strategy);
-            startSyncingShadows(StartSyncInfo.builder().build());
+            if (!currentStrategy[0].equals(strategy)) {
+                currentStrategy[0] = strategy;
+                stopSyncingShadows(false);
+                syncHandler.setSyncStrategy(strategy);
+                startSyncingShadows(StartSyncInfo.builder().build());
+            }
         });
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
@@ -302,7 +303,7 @@ public class ShadowManager extends PluginService {
                 });
 
         Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
-        final Strategy[] currentStrategy = { DEFAULT_STRATEGY };
+        final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
 
         strategyTopics.subscribe((why, newv) -> {
             Strategy strategy;
@@ -319,15 +320,20 @@ public class ShadowManager extends PluginService {
                     return;
                 }
             }
-            if (!currentStrategy[0].equals(strategy)) {
-                currentStrategy[0] = strategy;
-                stopSyncingShadows(false);
-                syncHandler.setSyncStrategy(strategy);
-                startSyncingShadows(StartSyncInfo.builder().build());
-            }
+
+            currentStrategy.set(replaceStrategyIfNecessary(currentStrategy.get(), strategy));
         });
     }
 
+    Strategy replaceStrategyIfNecessary(Strategy currentStrategy, Strategy strategy) {
+        if (!currentStrategy.equals(strategy)) {
+            currentStrategy = strategy;
+            stopSyncingShadows(false);
+            syncHandler.setSyncStrategy(strategy);
+            startSyncingShadows(StartSyncInfo.builder().build());
+        }
+        return currentStrategy;
+    }
 
     private void deleteRemovedSyncInformation() {
         Set<Pair<String, String>> removedShadows = new HashSet<>(this.dao.listSyncedShadows());

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
@@ -23,6 +23,7 @@ import com.aws.greengrass.util.RetryUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.Synchronized;
 
 import java.util.Iterator;
 import java.util.List;
@@ -160,6 +161,7 @@ public class SyncHandler {
      * @param context         an context object for syncing
      * @param syncParallelism number of threads to use for syncing
      */
+    @Synchronized
     public void start(SyncContext context, int syncParallelism) {
         overallSyncStrategy.start(context, syncParallelism);
         this.context = context;
@@ -169,6 +171,7 @@ public class SyncHandler {
     /**
      * Stops sync threads and clear syncing queue.
      */
+    @Synchronized
     public void stop() {
         overallSyncStrategy.stop();
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
@@ -13,10 +13,10 @@ import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.util.RetryUtils;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Handles syncing of shadows on a specific cadence. With this strategy, the Shadow manager will only execute the
@@ -27,6 +27,7 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
     private static final Logger logger = LogManager.getLogger(PeriodicSyncStrategy.class);
     private final ScheduledExecutorService syncExecutorService;
     private final long interval;
+    final ReentrantLock syncThreadLock = new ReentrantLock(); // lock for ensuring thread ends before stopping
 
     /**
      * Constructor.
@@ -61,11 +62,30 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
     @Override
     void doStart(SyncContext context, int syncParallelism) {
         logger.atInfo(SYNC_EVENT_TYPE).kv("interval", interval).log("Start periodic syncing");
-        syncThreadEnd = new CountDownLatch(1);
         this.syncParallelism = 1; // ignore sync parallelism as there is only 1 thread running
         this.criticalExecBlock = new Semaphore(1);
         this.syncThreads.add(syncExecutorService
                 .scheduleAtFixedRate(this::syncLoop, 0, interval, TimeUnit.SECONDS));
+    }
+
+    @Override
+    protected void syncLoop() {
+        syncThreadLock.lock();
+        try {
+            super.syncLoop();
+        } finally {
+            syncThreadLock.unlock();
+        }
+    }
+
+    @Override
+    protected void waitForSyncEnd() throws InterruptedException {
+        if (syncThreadLock.tryLock(THREAD_END_WAIT_TIME_SECONDS, TimeUnit.SECONDS)) {
+            syncThreadLock.unlock(); // release lock just acquired
+        } else {
+            logger.atWarn(SYNC_EVENT_TYPE).log("1 thread did not exit after {} seconds",
+                    THREAD_END_WAIT_TIME_SECONDS);
+        }
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
@@ -13,7 +13,9 @@ import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.util.RetryUtils;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Handles syncing of shadows in real time. Whenever the device is connected, this strategy will try to execute the
@@ -23,6 +25,10 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
 
     private static final Logger logger = LogManager.getLogger(RealTimeSyncStrategy.class);
     private final ExecutorService syncExecutorService;
+    /**
+     * Track whether a sync thread has exited.
+     */
+    CountDownLatch syncThreadEnd;
 
     /**
      * Constructor.
@@ -34,6 +40,7 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
     public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer, RequestBlockingQueue syncQueue) {
         super(retryer, syncQueue);
         this.syncExecutorService = executorService;
+        this.syncThreadEnd = new CountDownLatch(1);
     }
 
     /**
@@ -51,11 +58,29 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
 
     @Override
     void doStart(SyncContext context, int syncParallelism) {
+        syncThreadEnd = new CountDownLatch(syncParallelism);
         logger.atInfo(SYNC_EVENT_TYPE).log("Start real time syncing");
         for (int i = 0; i < syncParallelism; i++) {
             syncThreads.add(syncExecutorService.submit(this::syncLoop));
         }
+    }
 
+    @Override
+    protected void syncLoop() {
+        try {
+            super.syncLoop();
+        } finally {
+            syncThreadEnd.countDown();
+        }
+    }
+
+    @Override
+    protected void waitForSyncEnd() throws InterruptedException {
+        // wait for threads to actually exit but don't block forever
+        if (!syncThreadEnd.await(THREAD_END_WAIT_TIME_SECONDS, TimeUnit.SECONDS)) {
+            logger.atWarn(SYNC_EVENT_TYPE).log("{} thread(s) did not exit after {} seconds",
+                    syncThreadEnd.getCount(),THREAD_END_WAIT_TIME_SECONDS);
+        }
     }
 
     @Override

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -618,28 +618,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         assertThat(captor.getValue().getThingName(), is("thing"));
         assertThat(captor.getValue().getShadowName(), is("shadow"));
     }
-
-    @Test
-    void GIVEN_shadow_manager_sync_config_WHEN_sync_config_changes_THEN_sync_handler_restarts() {
-        createSyncConfigForSingleShadow("thing", "shadow");
-        when(mockDao.listSyncedShadows()).thenReturn(Collections.singletonList(new Pair<>("foo", "bar")));
-
-        when(mockMqttClient.connected()).thenReturn(true);
-        shadowManager.startup();
-
-        verify(mockCloudDataClient, times(1)).updateSubscriptions(anySet());
-        verify(mockSyncHandler, times(1)).start(any(SyncContext.class), anyInt());
-
-        verify(mockDatabase, times(1)).open();
-        verify(mockDao, times(1)).deleteSyncInformation("foo", "bar");
-
-        ArgumentCaptor<SyncInformation> captor = ArgumentCaptor.forClass(SyncInformation.class);
-        verify(mockDao, times(1)).insertSyncInfoIfNotExists(captor.capture());
-        assertThat(captor.getValue().getThingName(), is("thing"));
-        assertThat(captor.getValue().getShadowName(), is("shadow"));
-    }
-
-
+    
     private void createSyncConfigForSingleShadow(String thing, String shadow) {
         shadowManager.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
         ThingShadowSyncConfiguration config = mock(ThingShadowSyncConfiguration.class);

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -618,6 +619,27 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         assertThat(captor.getValue().getShadowName(), is("shadow"));
     }
 
+    @Test
+    void GIVEN_shadow_manager_sync_config_WHEN_sync_config_changes_THEN_sync_handler_restarts() {
+        createSyncConfigForSingleShadow("thing", "shadow");
+        when(mockDao.listSyncedShadows()).thenReturn(Collections.singletonList(new Pair<>("foo", "bar")));
+
+        when(mockMqttClient.connected()).thenReturn(true);
+        shadowManager.startup();
+
+        verify(mockCloudDataClient, times(1)).updateSubscriptions(anySet());
+        verify(mockSyncHandler, times(1)).start(any(SyncContext.class), anyInt());
+
+        verify(mockDatabase, times(1)).open();
+        verify(mockDao, times(1)).deleteSyncInformation("foo", "bar");
+
+        ArgumentCaptor<SyncInformation> captor = ArgumentCaptor.forClass(SyncInformation.class);
+        verify(mockDao, times(1)).insertSyncInfoIfNotExists(captor.capture());
+        assertThat(captor.getValue().getThingName(), is("thing"));
+        assertThat(captor.getValue().getShadowName(), is("shadow"));
+    }
+
+
     private void createSyncConfigForSingleShadow(String thing, String shadow) {
         shadowManager.setSyncConfiguration(ShadowSyncConfiguration.builder().syncConfigurations(new HashSet<>()).build());
         ThingShadowSyncConfiguration config = mock(ThingShadowSyncConfiguration.class);
@@ -735,5 +757,47 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
 
         assertTrue(shadowManager.isErrored());
         verify(mockSyncHandler, never()).setSyncStrategy(any());
+    }
+
+    @Test
+    void GIVEN_sync_strategy_WHEN_change_THEN_syncing_restarts(ExtensionContext extensionContext) {
+
+
+        ShadowManager s = spy(shadowManager);
+
+        // set up mocks so sync start gets called
+
+        when(mockMqttClient.connected()).thenReturn(true);
+        Set<ThingShadowSyncConfiguration> syncConfigs = new HashSet<ThingShadowSyncConfiguration>() {{
+            add(ThingShadowSyncConfiguration.builder().thingName("foo").shadowName("bar").build());
+        }};
+
+        ShadowSyncConfiguration config = ShadowSyncConfiguration.builder()
+                .syncConfigurations(syncConfigs)
+                .build();
+        s.setSyncConfiguration(config);
+        doReturn(true,true).when(s).inState(eq(State.RUNNING));
+        s.install();
+
+        // GIVEN
+        Strategy update = Strategy.builder().type(StrategyType.PERIODIC).delay(500L).build();
+        // WHEN
+        Strategy ret = s.replaceStrategyIfNecessary(Strategy.DEFAULT_STRATEGY, update);
+        // THEN
+        assertThat(ret, equalTo(update));
+        verify(mockSyncHandler, times(1)).stop();
+        verify(mockSyncHandler, times(1)).start(any(), anyInt());
+    }
+
+    @Test
+    void GIVEN_sync_strategy_WHEN_no_change_THEN_syncing_does_not_restart(ExtensionContext extensionContext) {
+        ShadowManager s = spy(shadowManager);
+
+        // GIVEN / WHEN
+        Strategy ret = s.replaceStrategyIfNecessary(Strategy.DEFAULT_STRATEGY, Strategy.DEFAULT_STRATEGY);
+        // THEN
+        assertThat(ret, equalTo(Strategy.DEFAULT_STRATEGY));
+        verify(mockSyncHandler, never()).stop();
+        verify(mockSyncHandler, never()).start(any(), anyInt());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Only restart syncing on config changes that make a change
Don't block while periodic sync threads are scheduled but not executing

**Why is this change necessary:**
Config can get updated frequently without changing (e.g. timestamp updated) and this causes unnecessary full syncs by restarting

Cancelling periodic sync doesn't need to wait when it's not executing

**How was this change tested:**
unit

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
