### PR TITLE
feat: add support for shadow operations over local PubSub

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/PubSubIntegrator.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/PubSubIntegrator.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager;
+
+import com.aws.greengrass.builtin.services.pubsub.PublishEvent;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.ipc.GetThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.ipc.PubSubClientWrapper;
+import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.model.LogEvents;
+import com.aws.greengrass.shadowmanager.model.ShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.GetThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_OPERATION;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_THING_NAME_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.LOG_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_MANAGER_NAME;
+
+
+/**
+ * Class that handles PubSub shadow topic subscription and managing any publish events on the shadow topic.
+ */
+public class PubSubIntegrator {
+    private static final Logger logger = LogManager.getLogger(PubSubIntegrator.class);
+
+    private final DeleteThingShadowRequestHandler deleteThingShadowRequestHandler;
+    private final UpdateThingShadowRequestHandler updateThingShadowRequestHandler;
+    private final GetThingShadowRequestHandler getThingShadowRequestHandler;
+    private final PubSubClientWrapper pubSubClientWrapper;
+    private final Pattern shadowPattern = Pattern.compile("\\$aws\\/things\\/(.*)\\/shadow(\\/name\\/(.*))?"
+            + "\\/(update|delete|get)");
+    private final AtomicBoolean subscribed = new AtomicBoolean(false);
+
+    /**
+     * Constructor for PubSubIntegrator.
+     *
+     * @param pubSubClientWrapper             The PubSub client wrapper
+     * @param deleteThingShadowRequestHandler handler class to handle the Delete Shadow request.
+     * @param updateThingShadowRequestHandler handler class to handle the Update Shadow request.
+     * @param getThingShadowRequestHandler    handler class to handle the Get Shadow request.
+     */
+    public PubSubIntegrator(PubSubClientWrapper pubSubClientWrapper,
+                            DeleteThingShadowRequestHandler deleteThingShadowRequestHandler,
+                            UpdateThingShadowRequestHandler updateThingShadowRequestHandler,
+                            GetThingShadowRequestHandler getThingShadowRequestHandler) {
+        this.pubSubClientWrapper = pubSubClientWrapper;
+        this.deleteThingShadowRequestHandler = deleteThingShadowRequestHandler;
+        this.updateThingShadowRequestHandler = updateThingShadowRequestHandler;
+        this.getThingShadowRequestHandler = getThingShadowRequestHandler;
+    }
+
+    /**
+     * Subscribes to the shadow topic over local PubSub.
+     */
+    public void subscribe() {
+        if (this.subscribed.compareAndSet(false, true)) {
+            this.pubSubClientWrapper.subscribe(this::handlePublishedMessage);
+        }
+    }
+
+    /**
+     * Unsubscribes to the shadow topic over local PubSub.
+     */
+    public void unsubscribe() {
+        if (this.subscribed.compareAndSet(true, false)) {
+            this.pubSubClientWrapper.unsubscribe(this::handlePublishedMessage);
+        }
+
+    }
+
+    /**
+     * Helper function to extract the thingName, shadowName and shadow operation from mqtt topic.
+     *
+     * @param topic PubSub topic on which the message was sent.
+     * @return ShadowRequest object with shadow details
+     */
+    ShadowRequest extractShadowFromTopic(String topic) {
+        final Matcher matcher = shadowPattern.matcher(topic);
+
+        if (matcher.find() && matcher.groupCount() == 4) {
+            String thingName = matcher.group(1);
+            String shadowName = matcher.group(3);
+            String operation = matcher.group(4);
+            return new ShadowRequest(thingName, shadowName, operation);
+        }
+        logger.atWarn()
+                .kv("topic", topic)
+                .log("Unable to parse shadow topic for thing name, shadow name and shadow operation");
+        throw new IllegalArgumentException("Unable to parse shadow topic for thing name shadow name "
+                + "and shadow operation");
+    }
+
+    /**
+     * Handle the new message that is published oveg local PubSub. Extract the necessary information from the shadow
+     * topic to accurately route the message to the appropriate handler.
+     * It will ignore the message if it is unable to extract all the necessary information from the shadow topic.
+     *
+     * @param publishEvent The message that is published over local PubSub.
+     */
+    private void handlePublishedMessage(PublishEvent publishEvent) {
+        String topic = publishEvent.getTopic();
+        logger.atDebug().kv(LOG_TOPIC, topic).log("Processing new shadow operation message over local PubSub");
+        try {
+            ShadowRequest shadowRequest = extractShadowFromTopic(topic);
+            switch (shadowRequest.getOperation().toLowerCase()) {
+                case "update":
+                    UpdateThingShadowRequest request = new UpdateThingShadowRequest();
+                    request.setThingName(shadowRequest.getThingName());
+                    request.setShadowName(shadowRequest.getShadowName());
+                    request.setPayload(publishEvent.getPayload());
+
+                    this.updateThingShadowRequestHandler.handleRequest(request, SHADOW_MANAGER_NAME);
+                    logger.atTrace()
+                            .setEventType(LogEvents.UPDATE_THING_SHADOW.code())
+                            .kv(LOG_THING_NAME_KEY, shadowRequest.getThingName())
+                            .kv(LOG_SHADOW_NAME_KEY, shadowRequest.getShadowName())
+                            .log("Successfully updated shadow");
+                    break;
+                case "delete":
+                    DeleteThingShadowRequest deleteRequest = new DeleteThingShadowRequest();
+                    deleteRequest.setThingName(shadowRequest.getThingName());
+                    deleteRequest.setShadowName(shadowRequest.getShadowName());
+
+                    this.deleteThingShadowRequestHandler.handleRequest(deleteRequest, SHADOW_MANAGER_NAME);
+                    logger.atTrace()
+                            .setEventType(LogEvents.DELETE_THING_SHADOW.code())
+                            .kv(LOG_THING_NAME_KEY, shadowRequest.getThingName())
+                            .kv(LOG_SHADOW_NAME_KEY, shadowRequest.getShadowName())
+                            .log("Successfully deleted shadow");
+                    break;
+                case "get":
+                    GetThingShadowRequest getRequest = new GetThingShadowRequest();
+                    getRequest.setThingName(shadowRequest.getThingName());
+                    getRequest.setShadowName(shadowRequest.getShadowName());
+
+                    this.getThingShadowRequestHandler.handleRequest(getRequest, SHADOW_MANAGER_NAME);
+                    logger.atTrace()
+                            .setEventType(LogEvents.DELETE_THING_SHADOW.code())
+                            .kv(LOG_THING_NAME_KEY, shadowRequest.getThingName())
+                            .kv(LOG_SHADOW_NAME_KEY, shadowRequest.getShadowName())
+                            .log("Successfully retrieved shadow");
+                    break;
+                default:
+                    logger.atWarn()
+                            .kv(LOG_THING_NAME_KEY, shadowRequest.getThingName())
+                            .kv(LOG_SHADOW_NAME_KEY, shadowRequest.getShadowName())
+                            .kv(LOG_OPERATION, shadowRequest.getOperation())
+                            .log("Unable to perform shadow operation due to unknown value");
+                    break;
+            }
+            logger.atDebug().kv(LOG_TOPIC, topic)
+                    .log("Finished processing new shadow operation message over local PubSub");
+        } catch (IllegalArgumentException e) {
+            logger.atWarn()
+                    .setEventType(LogEvents.UPDATE_THING_SHADOW.code())
+                    .setCause(e)
+                    .kv(LOG_TOPIC, topic)
+                    .log("Unable to process shadow operation request over PubSub");
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -408,9 +408,9 @@ public class ShadowManager extends PluginService {
     protected void shutdown() throws InterruptedException {
         try {
             stopSyncingShadows(true);
-            database.close();
-            inboundRateLimiter.clear();
             pubSubIntegrator.unsubscribe();
+            inboundRateLimiter.clear();
+            database.close();
         } catch (IOException e) {
             logger.atError()
                     .setEventType(LogEvents.DATABASE_CLOSE_ERROR.code())

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/BaseRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/BaseRequestHandler.java
@@ -73,7 +73,7 @@ public class BaseRequestHandler {
      * @param shadowName  The shadow name.
      * @param clientToken The client token.
      * @param e           The Exception thrown
-     * @throws InvalidRequestParametersException always
+     * @throws InvalidArgumentsError always
      */
     @SuppressWarnings("PMD.AvoidUncheckedExceptionsInSignatures")
     void throwInvalidArgumentsError(String thingName, String shadowName, Optional<String> clientToken,

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapper.java
@@ -121,7 +121,7 @@ public class PubSubClientWrapper {
     /**
      * Subscribes to the shadow topic over local PubSub.
      *
-     * @param cb Cosnumer to invoke upon receiving a new message over local PubSub.
+     * @param cb Consumer to invoke upon receiving a new message over local PubSub.
      */
     public void subscribe(Consumer<PublishEvent> cb) {
         this.pubSubIPCEventStreamAgent.subscribe(PUBSUB_SUBSCRIBE_TOPIC, cb, SHADOW_MANAGER_NAME);
@@ -130,7 +130,7 @@ public class PubSubClientWrapper {
     /**
      * Unsubscribes to the shadow topic over local PubSub.
      *
-     * @param cb Cosnumer to invoke upon receiving a new message over local PubSub.
+     * @param cb Consumer to invoke upon receiving a new message over local PubSub.
      */
     public void unsubscribe(Consumer<PublishEvent> cb) {
         this.pubSubIPCEventStreamAgent.unsubscribe(PUBSUB_SUBSCRIBE_TOPIC, cb, SHADOW_MANAGER_NAME);

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapper.java
@@ -6,16 +6,20 @@
 package com.aws.greengrass.shadowmanager.ipc;
 
 import com.aws.greengrass.builtin.services.pubsub.PubSubIPCEventStreamAgent;
+import com.aws.greengrass.builtin.services.pubsub.PublishEvent;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.ipc.model.PubSubRequest;
 import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
 
+import java.util.function.Consumer;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
 import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
 import static com.aws.greengrass.shadowmanager.model.Constants.LOG_THING_NAME_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.PUBSUB_SUBSCRIBE_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_MANAGER_NAME;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_PUBLISH_ACCEPTED_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_PUBLISH_DELTA_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_PUBLISH_DOCUMENTS_TOPIC;
@@ -112,5 +116,23 @@ public class PubSubClientWrapper {
         String shadowTopicPrefix = ipcRequest.getShadowTopicPrefix();
         String publishTopicOp = ipcRequest.getPublishOperation().getOp();
         return shadowTopicPrefix + publishTopicOp + topic;
+    }
+
+    /**
+     * Subscribes to the shadow topic over local PubSub.
+     *
+     * @param cb Cosnumer to invoke upon receiving a new message over local PubSub.
+     */
+    public void subscribe(Consumer<PublishEvent> cb) {
+        this.pubSubIPCEventStreamAgent.subscribe(PUBSUB_SUBSCRIBE_TOPIC, cb, SHADOW_MANAGER_NAME);
+    }
+
+    /**
+     * Unsubscribes to the shadow topic over local PubSub.
+     *
+     * @param cb Cosnumer to invoke upon receiving a new message over local PubSub.
+     */
+    public void unsubscribe(Consumer<PublishEvent> cb) {
+        this.pubSubIPCEventStreamAgent.unsubscribe(PUBSUB_SUBSCRIBE_TOPIC, cb, SHADOW_MANAGER_NAME);
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
@@ -87,10 +87,11 @@ public class UpdateThingShadowRequestHandler extends BaseRequestHandler {
      * @param request     UpdateThingShadow request from IPC API
      * @param serviceName the service name making the request.
      * @return UpdateThingShadow response
-     * @throws ConflictError         if version conflict found when updating shadow document
-     * @throws UnauthorizedError     if UpdateThingShadow call not authorized
-     * @throws InvalidArgumentsError if validation error occurred with supplied request fields
-     * @throws ServiceError          if database error occurs
+     * @throws ConflictError                     if version conflict found when updating shadow document
+     * @throws UnauthorizedError                 if UpdateThingShadow call not authorized
+     * @throws InvalidArgumentsError             if validation error occurred with supplied request fields
+     * @throws ServiceError                      if database error occurs
+     * @throws InvalidRequestParametersException if the payload is empty or too large.
      */
     @SuppressWarnings({"PMD.PreserveStackTrace", "PMD.PrematureDeclaration", "checkstyle:JavadocMethod"})
     public UpdateThingShadowHandlerResponse handleRequest(UpdateThingShadowRequest request, String serviceName) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/Constants.java
@@ -23,6 +23,7 @@ public final class Constants {
     public static final String LOG_DELETED_CLOUD_VERSION_KEY = "deleted-cloud-version";
     public static final String LOG_UPDATED_CLOUD_VERSION_KEY = "updated-cloud-version";
     public static final String LOG_TOPIC = "topic";
+    public static final String LOG_OPERATION = "operation";
     public static final String SHADOW_DOCUMENT_VERSION = "version";
     public static final String SHADOW_DOCUMENT_TIMESTAMP = "timestamp";
     public static final String SHADOW_DOCUMENT_CLIENT_TOKEN = "clientToken";
@@ -78,6 +79,7 @@ public final class Constants {
     public static final String STRATEGY_TYPE_REAL_TIME = "realTime";
     public static final String STRATEGY_TYPE_PERIODIC = "periodic";
 
+    public static final String PUBSUB_SUBSCRIBE_TOPIC = "$aws/things/+/shadow/#";
 
     private Constants() {
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowRequest.java
@@ -21,11 +21,12 @@ import static com.aws.greengrass.shadowmanager.model.Constants.NAMED_SHADOW_TOPI
 public class ShadowRequest {
     String thingName;
     String shadowName;
+    String operation;
 
     /**
      * ShadowRequest constructor.
      *
-     * @param thingName the thing name of the shadow request
+     * @param thingName  the thing name of the shadow request
      * @param shadowName the shadow name of the shadow request
      */
     public ShadowRequest(String thingName, String shadowName) {
@@ -38,11 +39,13 @@ public class ShadowRequest {
     /**
      * ShadowRequest constructor for classic shadows.
      *
-     * @param thingName the thing name of the shadow request
+     * @param thingName  the thing name of the shadow request
+     * @param shadowName the shadow name of the shadow request
+     * @param operation  the shadow operation to be performed
      */
-    public ShadowRequest(String thingName) {
-        this.thingName = thingName;
-        this.shadowName = CLASSIC_SHADOW_IDENTIFIER;
+    public ShadowRequest(String thingName, String shadowName, String operation) {
+        this(thingName, shadowName);
+        this.operation = operation;
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/shadowmanager/PubSubIntegratorTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/PubSubIntegratorTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager;
+
+import com.aws.greengrass.builtin.services.pubsub.PublishEvent;
+import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.ipc.GetThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.ipc.PubSubClientWrapper;
+import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
+import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.DeleteThingShadowResponse;
+import software.amazon.awssdk.aws.greengrass.model.GetThingShadowRequest;
+import software.amazon.awssdk.aws.greengrass.model.GetThingShadowResponse;
+import software.amazon.awssdk.aws.greengrass.model.UpdateThingShadowRequest;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static com.aws.greengrass.shadowmanager.TestUtils.SHADOW_NAME;
+import static com.aws.greengrass.shadowmanager.model.Constants.CLASSIC_SHADOW_IDENTIFIER;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_MANAGER_NAME;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class PubSubIntegratorTest {
+    private static final byte[] PAYLOAD = "{\"version\": 10, \"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Pink Floyd\", \"SomethingNew\": true}}}".getBytes();
+    private static final String MOCK_THING = "thing1";
+
+    @Mock
+    private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
+    @Mock
+    private UpdateThingShadowRequestHandler mockUpdateThingShadowRequestHandler;
+    @Mock
+    private GetThingShadowRequestHandler mockGetThingShadowRequestHandler;
+    @Mock
+    private PubSubClientWrapper mockPubSubClientWrapper;
+
+    @Captor
+    private ArgumentCaptor<Consumer<PublishEvent>> publishEventCaptor;
+    @Captor
+    private ArgumentCaptor<UpdateThingShadowRequest> updateThingShadowRequestCaptor;
+    @Captor
+    private ArgumentCaptor<DeleteThingShadowRequest> deleteThingShadowRequestCaptor;
+    @Captor
+    private ArgumentCaptor<GetThingShadowRequest> getThingShadowRequestCaptor;
+
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    private static Stream<Arguments> classicAndNamedShadow() {
+        return Stream.of(
+                arguments(SHADOW_NAME, "update"),
+                arguments(SHADOW_NAME, "delete"),
+                arguments(SHADOW_NAME, "get"),
+                arguments(SHADOW_NAME, "badOp"),
+                arguments(CLASSIC_SHADOW_IDENTIFIER, "update"),
+                arguments(CLASSIC_SHADOW_IDENTIFIER, "delete"),
+                arguments(CLASSIC_SHADOW_IDENTIFIER, "get"),
+                arguments(CLASSIC_SHADOW_IDENTIFIER, "badOp")
+        );
+    }
+
+
+    @BeforeEach
+    void setup() {
+        lenient().when(mockUpdateThingShadowRequestHandler.handleRequest(updateThingShadowRequestCaptor.capture(), eq(SHADOW_MANAGER_NAME))).thenReturn(mock(UpdateThingShadowHandlerResponse.class));
+        lenient().when(mockDeleteThingShadowRequestHandler.handleRequest(deleteThingShadowRequestCaptor.capture(), eq(SHADOW_MANAGER_NAME))).thenReturn(mock(DeleteThingShadowResponse.class));
+        lenient().when(mockGetThingShadowRequestHandler.handleRequest(getThingShadowRequestCaptor.capture(), eq(SHADOW_MANAGER_NAME))).thenReturn(mock(GetThingShadowResponse.class));
+        lenient().doNothing().when(mockPubSubClientWrapper).subscribe(publishEventCaptor.capture());
+    }
+
+    @Test
+    void GIVEN_pubsubIntegrator_WHEN_multiple_subscribes_and_unsubscribes_THEN_only_subscribes_and_unsubscribes_once() {
+        PubSubIntegrator integrator = new PubSubIntegrator(mockPubSubClientWrapper, mockDeleteThingShadowRequestHandler,
+                mockUpdateThingShadowRequestHandler, mockGetThingShadowRequestHandler);
+
+        integrator.subscribe();
+        verify(mockPubSubClientWrapper, atMostOnce()).subscribe(any());
+
+        integrator.subscribe();
+        verify(mockPubSubClientWrapper, atMostOnce()).subscribe(any());
+
+        integrator.unsubscribe();
+        verify(mockPubSubClientWrapper, atMostOnce()).unsubscribe(any());
+
+        integrator.unsubscribe();
+        verify(mockPubSubClientWrapper, atMostOnce()).unsubscribe(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("classicAndNamedShadow")
+    void GIVEN_classic_shadow_op_invocation_WHEN_accept_THEN_calls_the_corret_handler(String shadowName, String op, ExtensionContext extensionContext) {
+        ignoreExceptionOfType(extensionContext, IllegalArgumentException.class);
+        PubSubIntegrator integrator = new PubSubIntegrator(mockPubSubClientWrapper, mockDeleteThingShadowRequestHandler,
+                mockUpdateThingShadowRequestHandler, mockGetThingShadowRequestHandler);
+        integrator.subscribe();
+        if (CLASSIC_SHADOW_IDENTIFIER.equals(shadowName)) {
+            publishEventCaptor.getValue().accept(PublishEvent.builder().topic("$aws/things/" + MOCK_THING + "/shadow/" + op).payload(PAYLOAD).build());
+        } else {
+            publishEventCaptor.getValue().accept(PublishEvent.builder().topic("$aws/things/" + MOCK_THING + "/shadow/name/" + shadowName + "/" + op).payload(PAYLOAD).build());
+        }
+
+        switch (op) {
+            case "update":
+                verify(mockUpdateThingShadowRequestHandler, atMostOnce()).handleRequest(any(UpdateThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+                assertThat(updateThingShadowRequestCaptor.getAllValues().size(), is(1));
+                UpdateThingShadowRequest updateRequest = updateThingShadowRequestCaptor.getValue();
+                assertThat(updateRequest.getThingName(), is(MOCK_THING));
+                assertThat(updateRequest.getShadowName(), is(shadowName));
+                assertThat(updateRequest.getPayload(), is(notNullValue()));
+                assertThat(updateRequest.getPayload(), is(PAYLOAD));
+                break;
+            case "delete":
+                verify(mockDeleteThingShadowRequestHandler, atMostOnce()).handleRequest(any(DeleteThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+                assertThat(deleteThingShadowRequestCaptor.getAllValues().size(), is(1));
+                DeleteThingShadowRequest deleteRequest = deleteThingShadowRequestCaptor.getValue();
+                assertThat(deleteRequest.getThingName(), is(MOCK_THING));
+                assertThat(deleteRequest.getShadowName(), is(shadowName));
+                break;
+            case "get":
+                verify(mockGetThingShadowRequestHandler, atMostOnce()).handleRequest(any(GetThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+                assertThat(getThingShadowRequestCaptor.getAllValues().size(), is(1));
+                GetThingShadowRequest getRequest = getThingShadowRequestCaptor.getValue();
+                assertThat(getRequest.getThingName(), is(MOCK_THING));
+                assertThat(getRequest.getShadowName(), is(shadowName));
+                break;
+            default:
+                verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(UpdateThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+                verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(DeleteThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+                verify(mockGetThingShadowRequestHandler, never()).handleRequest(any(GetThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+                break;
+        }
+    }
+
+    @Test
+    void GIVEN_bad_topic_WHEN_accept_THEN_throws_IllegalArgumentException(ExtensionContext extensionContext) {
+        ignoreExceptionOfType(extensionContext, IllegalArgumentException.class);
+        PubSubIntegrator integrator = new PubSubIntegrator(mockPubSubClientWrapper, mockDeleteThingShadowRequestHandler,
+                mockUpdateThingShadowRequestHandler, mockGetThingShadowRequestHandler);
+        integrator.subscribe();
+        // No shadow name or op
+        publishEventCaptor.getValue().accept(PublishEvent.builder().topic("$aws/things/" + MOCK_THING + "/shadow").payload(PAYLOAD).build());
+
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(UpdateThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+        verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(DeleteThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+        verify(mockGetThingShadowRequestHandler, never()).handleRequest(any(GetThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+
+        // No op
+        publishEventCaptor.getValue().accept(PublishEvent.builder().topic("$aws/things/" + MOCK_THING + "/shadow/name/" + SHADOW_NAME).payload(PAYLOAD).build());
+
+        verify(mockUpdateThingShadowRequestHandler, never()).handleRequest(any(UpdateThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+        verify(mockDeleteThingShadowRequestHandler, never()).handleRequest(any(DeleteThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+        verify(mockGetThingShadowRequestHandler, never()).handleRequest(any(GetThingShadowRequest.class), eq(SHADOW_MANAGER_NAME));
+
+    }
+}

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapperTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/PubSubClientWrapperTest.java
@@ -36,10 +36,14 @@ import java.time.Instant;
 import java.util.Optional;
 
 import static com.aws.greengrass.shadowmanager.ShadowManager.SERVICE_NAME;
+import static com.aws.greengrass.shadowmanager.model.Constants.PUBSUB_SUBSCRIBE_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_MANAGER_NAME;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -196,5 +200,19 @@ class PubSubClientWrapperTest {
                 .build());
         verify(mockPubSubIPCEventStreamAgent, times(1)).publish(topicCaptor.capture(),
                 payloadCaptor.capture(), serviceNameCaptor.capture());
+    }
+
+    @Test
+    void GIVEN_consumer_to_subscribe_WHEN_subscribe_THEN_calls_pubsub_agent_to_subscribe() {
+        PubSubClientWrapper pubSubClientWrapper = new PubSubClientWrapper(mockPubSubIPCEventStreamAgent);
+        pubSubClientWrapper.subscribe(publishEvent -> {});
+        verify(mockPubSubIPCEventStreamAgent, atMostOnce()).subscribe(eq(PUBSUB_SUBSCRIBE_TOPIC), any(), eq(SHADOW_MANAGER_NAME));
+    }
+
+    @Test
+    void GIVEN_consumer_to_unsubscribe_WHEN_unsubscribe_THEN_calls_pubsub_agent_to_unsubscribe() {
+        PubSubClientWrapper pubSubClientWrapper = new PubSubClientWrapper(mockPubSubIPCEventStreamAgent);
+        pubSubClientWrapper.unsubscribe(publishEvent -> {});
+        verify(mockPubSubIPCEventStreamAgent, atMostOnce()).unsubscribe(eq(PUBSUB_SUBSCRIBE_TOPIC), any(), eq(SHADOW_MANAGER_NAME));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This will add support for Shadow Manager operations over local PubSub. This change is contingent on the [Nucleus PubSub PR](https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1148).

**Why is this change necessary:**
This would enable customers to perform shadow operations over local PubSub. This would also open doors for Client device integration.

**How was this change tested:**
Added new unit tests.
Integration tests will be added once the  [Nucleus PubSub PR](https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1148) is merged in.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
