### PR TITLE
feat: add sync direction in `RequestMerger` to merge appropriate sync requests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -115,6 +115,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
         kernel.getContext().put(RealTimeSyncStrategy.class, (RealTimeSyncStrategy) realTimeSyncStrategy);
         ExecutorService es = kernel.getContext().get(ExecutorService.class);
         ScheduledExecutorService ses = kernel.getContext().get(ScheduledExecutorService.class);
+        RequestBlockingQueue queue = kernel.getContext().get(RequestBlockingQueue.class);
         // set retry config to only try once so we can test failures earlier
         kernel.launch();
 
@@ -129,10 +130,10 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
                     .build();
             SyncStrategy syncStrategy;
             if (RealTimeSyncStrategy.class.equals(config.getSyncClazz())) {
-                syncStrategy = new RealTimeSyncStrategy(es, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), retryConfig);
+                syncStrategy = new RealTimeSyncStrategy(es, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), retryConfig, queue);
                 kernel.getContext().put(RealTimeSyncStrategy.class, (RealTimeSyncStrategy) syncStrategy);
             } else {
-                syncStrategy = new PeriodicSyncStrategy(ses, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), 3, retryConfig);
+                syncStrategy = new PeriodicSyncStrategy(ses, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), 3, retryConfig, queue);
                 kernel.getContext().put(PeriodicSyncStrategy.class, (PeriodicSyncStrategy) syncStrategy);
 
             }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -33,7 +33,6 @@ import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfi
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.CloudDataClient;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
-import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
@@ -103,7 +102,6 @@ public class ShadowManager extends PluginService {
     private final CloudDataClient cloudDataClient;
     private final MqttClient mqttClient;
     private final PubSubIntegrator pubSubIntegrator;
-    private final RequestMerger merger;
     public final MqttClientConnectionEvents callbacks = new MqttClientConnectionEvents() {
         @Override
         public void onConnectionInterrupted(int errorCode) {
@@ -146,7 +144,6 @@ public class ShadowManager extends PluginService {
      * @param syncHandler                 a synchronization handler
      * @param cloudDataClient             the data client subscribing to cloud shadow topics
      * @param mqttClient                  the mqtt client connected to IoT Core
-     * @param merger                      the request merger
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     @Inject
@@ -162,8 +159,7 @@ public class ShadowManager extends PluginService {
             IotDataPlaneClientWrapper iotDataPlaneClientWrapper,
             SyncHandler syncHandler,
             CloudDataClient cloudDataClient,
-            MqttClient mqttClient,
-            RequestMerger merger) {
+            MqttClient mqttClient) {
         super(topics);
         this.database = database;
         this.authorizationHandlerWrapper = authorizationHandlerWrapper;
@@ -174,7 +170,6 @@ public class ShadowManager extends PluginService {
         this.syncHandler = syncHandler;
         this.cloudDataClient = cloudDataClient;
         this.mqttClient = mqttClient;
-        this.merger = merger;
         this.deleteThingShadowRequestHandler = new DeleteThingShadowRequestHandler(dao, authorizationHandlerWrapper,
                 pubSubClientWrapper, synchronizeHelper, this.syncHandler);
         this.updateThingShadowRequestHandler = new UpdateThingShadowRequestHandler(dao, authorizationHandlerWrapper,
@@ -361,7 +356,6 @@ public class ShadowManager extends PluginService {
 
                         setupSync(newSyncDirection, Optional.of(currentDirection));
                         syncHandler.setSyncDirection(newSyncDirection);
-                        merger.setSyncDirection(newSyncDirection);
                     });
         }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
-import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
@@ -133,21 +132,8 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
         return executing.get();
     }
 
-    /**
-     * Constructor.
-     *
-     * @param retryer The retryer object.
-     */
-    protected BaseSyncStrategy(Retryer retryer) {
-        this(retryer, DEFAULT_RETRY_CONFIG);
-    }
-
     protected BaseSyncStrategy(Retryer retryer, RequestBlockingQueue syncQueue) {
         this(retryer, DEFAULT_RETRY_CONFIG, syncQueue);
-    }
-
-    protected BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig) {
-        this(retryer, retryConfig, new RequestBlockingQueue(new RequestMerger()));
     }
 
     /**
@@ -157,7 +143,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      * @param retryConfig The config to be used by the retryer.
      * @param syncQueue   A queue to use for sync requests.
      */
-    private BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
+    protected BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
         this.retryer = (config, request, context) -> {
             try {
                 executing.set(true);

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
@@ -51,10 +51,11 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
      * @param retryer     The retryer object.
      * @param interval    The interval at which to sync the shadows.
      * @param retryConfig The retryer configuration.
+     * @param syncQueue   The sync queue from the previous strategy if any.
      */
     public PeriodicSyncStrategy(ScheduledExecutorService ses, Retryer retryer, long interval,
-                                RetryUtils.RetryConfig retryConfig) {
-        super(retryer, retryConfig);
+                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
+        super(retryer, retryConfig, syncQueue);
         this.syncExecutorService = ses;
         this.interval = interval;
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
@@ -49,10 +49,11 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
      * @param executorService executor service.
      * @param retryer         The retryer object.
      * @param retryConfig     The retryer configuration.
+     * @param syncQueue       The sync queue from the previous strategy if any.
      */
     public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer,
-                                RetryUtils.RetryConfig retryConfig) {
-        super(retryer, retryConfig);
+                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
+        super(retryer, retryConfig, syncQueue);
         this.syncExecutorService = executorService;
     }
 
@@ -79,7 +80,7 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
         // wait for threads to actually exit but don't block forever
         if (!syncThreadEnd.await(THREAD_END_WAIT_TIME_SECONDS, TimeUnit.SECONDS)) {
             logger.atWarn(SYNC_EVENT_TYPE).log("{} thread(s) did not exit after {} seconds",
-                    syncThreadEnd.getCount(),THREAD_END_WAIT_TIME_SECONDS);
+                    syncThreadEnd.getCount(), THREAD_END_WAIT_TIME_SECONDS);
         }
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -23,6 +23,7 @@ import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfi
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.CloudDataClient;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
+import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
@@ -148,6 +149,8 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
     private MqttClient mockMqttClient;
     @Mock
     private GreengrassCoreIPCService mockGreengrassCoreIPCService;
+    @Mock
+    private RequestMerger mockRequestMerger;
 
     @Captor
     private ArgumentCaptor<Integer> intObjectCaptor;
@@ -166,7 +169,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         initializeMockedConfig();
         shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper,
                 mockPubSubClientWrapper, mockInboundRateLimiter, mockDeviceConfiguration, mockSynchronizeHelper,
-                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient);
+                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient, mockRequestMerger);
     }
 
     @ParameterizedTest
@@ -219,6 +222,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
             verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
+            verify(mockRequestMerger, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
@@ -230,6 +234,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         }
         verify(mockSyncHandler, never()).stop();
         verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
+        verify(mockRequestMerger, times(1)).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());
@@ -261,6 +266,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
             verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
+            verify(mockRequestMerger, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
@@ -270,6 +276,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         verify(mockSyncHandler, never()).stop();
 
         verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.DEVICE_TO_CLOUD));
+        verify(mockRequestMerger, times(1)).setSyncDirection(eq(Direction.DEVICE_TO_CLOUD));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());
@@ -301,6 +308,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
             verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
+            verify(mockRequestMerger, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
@@ -313,6 +321,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         verify(mockSyncHandler, never()).stop();
         verify(mockSyncHandler, never()).start(any(), anyInt());
         verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.CLOUD_TO_DEVICE));
+        verify(mockRequestMerger, times(1)).setSyncDirection(eq(Direction.CLOUD_TO_DEVICE));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -23,7 +23,6 @@ import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfi
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.CloudDataClient;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
-import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
@@ -149,8 +148,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
     private MqttClient mockMqttClient;
     @Mock
     private GreengrassCoreIPCService mockGreengrassCoreIPCService;
-    @Mock
-    private RequestMerger mockRequestMerger;
 
     @Captor
     private ArgumentCaptor<Integer> intObjectCaptor;
@@ -169,7 +166,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         initializeMockedConfig();
         shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper,
                 mockPubSubClientWrapper, mockInboundRateLimiter, mockDeviceConfiguration, mockSynchronizeHelper,
-                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient, mockRequestMerger);
+                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient);
     }
 
     @ParameterizedTest
@@ -222,7 +219,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
             verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
-            verify(mockRequestMerger, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
@@ -234,7 +230,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         }
         verify(mockSyncHandler, never()).stop();
         verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
-        verify(mockRequestMerger, times(1)).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());
@@ -266,7 +261,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
             verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
-            verify(mockRequestMerger, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
@@ -276,7 +270,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         verify(mockSyncHandler, never()).stop();
 
         verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.DEVICE_TO_CLOUD));
-        verify(mockRequestMerger, times(1)).setSyncDirection(eq(Direction.DEVICE_TO_CLOUD));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());
@@ -308,7 +301,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             verify(mockCloudDataClient, never()).updateSubscriptions(any());
             verify(mockSyncHandler, never()).stop();
             verify(mockSyncHandler, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
-            verify(mockRequestMerger, never()).setSyncDirection(eq(Direction.BETWEEN_DEVICE_AND_CLOUD));
             return;
         }
 
@@ -321,7 +313,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         verify(mockSyncHandler, never()).stop();
         verify(mockSyncHandler, never()).start(any(), anyInt());
         verify(mockSyncHandler, times(1)).setSyncDirection(eq(Direction.CLOUD_TO_DEVICE));
-        verify(mockRequestMerger, times(1)).setSyncDirection(eq(Direction.CLOUD_TO_DEVICE));
         verify(mockDao, never()).listSyncedShadows();
         verify(mockDao, never()).deleteSyncInformation(anyString(), anyString());
         verify(mockDao, never()).insertSyncInfoIfNotExists(any());

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestMergerTest.java
@@ -7,9 +7,12 @@ package com.aws.greengrass.shadowmanager.sync;
 
 import com.aws.greengrass.shadowmanager.sync.model.CloudDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
+import com.aws.greengrass.shadowmanager.sync.model.Direction;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalUpdateSyncRequest;
+import com.aws.greengrass.shadowmanager.sync.model.OverwriteCloudShadowRequest;
+import com.aws.greengrass.shadowmanager.sync.model.OverwriteLocalShadowRequest;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +38,10 @@ class RequestMergerTest {
 
     static FullShadowSyncRequest fullShadowSyncRequest = mock(FullShadowSyncRequest.class, "fullShadowSync");
 
+    static OverwriteLocalShadowRequest overwriteLocalShadowRequest = mock(OverwriteLocalShadowRequest.class, "overwriteLocal");
+
+    static OverwriteCloudShadowRequest overwriteCloudShadowRequest = mock(OverwriteCloudShadowRequest.class, "overwriteCloud");
+
     static CloudUpdateSyncRequest cloudUpdateSyncRequest = mock(CloudUpdateSyncRequest.class, "cloudUpdate");
 
     static CloudDeleteSyncRequest cloudDeleteSyncRequest = mock(CloudDeleteSyncRequest.class, "cloudDelete");
@@ -51,35 +58,57 @@ class RequestMergerTest {
     @ParameterizedTest
     @MethodSource("overridingRequests")
     void GIVEN_overriding_requests_WHEN_merge_THEN_return_overriding_request(SyncRequest old, SyncRequest value,
-            SyncRequest expected) {
-        assertThat(merger.merge(old, value), is(expected));
+            SyncRequest expected, Direction direction) {
+        merger.setSyncDirection(direction);
+        assertThat(merger.merge(old, value), is(instanceOf(expected.getClass())));
     }
 
     static Stream<Arguments> overridingRequests() {
         return Stream.of(
-                arguments(fullShadowSyncRequest, cloudUpdateSyncRequest, fullShadowSyncRequest),
-                arguments(cloudUpdateSyncRequest, fullShadowSyncRequest, fullShadowSyncRequest),
-                arguments(cloudUpdateSyncRequest, cloudDeleteSyncRequest, cloudDeleteSyncRequest),
-                arguments(localUpdateSyncRequest, localDeleteSyncRequest, localDeleteSyncRequest),
-                arguments(cloudUpdateSyncRequest, localDeleteSyncRequest, localDeleteSyncRequest),
-                arguments(localUpdateSyncRequest, cloudDeleteSyncRequest, cloudDeleteSyncRequest),
-                arguments(cloudDeleteSyncRequest, localUpdateSyncRequest, cloudDeleteSyncRequest),
-                arguments(localDeleteSyncRequest, cloudUpdateSyncRequest, localDeleteSyncRequest)
+                arguments(fullShadowSyncRequest, cloudUpdateSyncRequest, fullShadowSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(cloudUpdateSyncRequest, fullShadowSyncRequest, fullShadowSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(overwriteLocalShadowRequest, cloudUpdateSyncRequest, overwriteLocalShadowRequest, Direction.CLOUD_TO_DEVICE),
+                arguments(cloudUpdateSyncRequest, overwriteLocalShadowRequest, overwriteLocalShadowRequest, Direction.CLOUD_TO_DEVICE),
+                arguments(overwriteCloudShadowRequest, cloudUpdateSyncRequest, overwriteCloudShadowRequest, Direction.DEVICE_TO_CLOUD),
+                arguments(cloudUpdateSyncRequest, overwriteCloudShadowRequest, overwriteCloudShadowRequest, Direction.DEVICE_TO_CLOUD),
+                arguments(cloudUpdateSyncRequest, cloudDeleteSyncRequest, cloudDeleteSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(localUpdateSyncRequest, localDeleteSyncRequest, localDeleteSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(cloudUpdateSyncRequest, localDeleteSyncRequest, localDeleteSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(localUpdateSyncRequest, cloudDeleteSyncRequest, cloudDeleteSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(cloudDeleteSyncRequest, localUpdateSyncRequest, cloudDeleteSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(localDeleteSyncRequest, cloudUpdateSyncRequest, localDeleteSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD)
         );
     }
 
     @ParameterizedTest
     @MethodSource("nonMergingRequests")
     void GIVEN_non_mergable_request_WHEN_merge_THEN_return_full_shadow_sync(SyncRequest request1,
-            SyncRequest request2) {
-        assertThat(merger.merge(request1, request2), is(instanceOf(FullShadowSyncRequest.class)));
+            SyncRequest request2, Direction direction) {
+        merger.setSyncDirection(direction);
+        switch (direction) {
+            case BETWEEN_DEVICE_AND_CLOUD:
+                assertThat(merger.merge(request1, request2), is(instanceOf(FullShadowSyncRequest.class)));
+                break;
+            case DEVICE_TO_CLOUD:
+                assertThat(merger.merge(request1, request2), is(instanceOf(OverwriteCloudShadowRequest.class)));
+                break;
+            case CLOUD_TO_DEVICE:
+                assertThat(merger.merge(request1, request2), is(instanceOf(OverwriteLocalShadowRequest.class)));
+                break;
+        }
     }
 
     static Stream<Arguments> nonMergingRequests() {
         return Stream.of(
-                arguments(localUpdateSyncRequest, cloudUpdateSyncRequest),
-                arguments(cloudUpdateSyncRequest, localUpdateSyncRequest),
-                arguments(localDeleteSyncRequest, cloudDeleteSyncRequest)
+                arguments(localUpdateSyncRequest, cloudUpdateSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(cloudUpdateSyncRequest, localUpdateSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(localDeleteSyncRequest, cloudDeleteSyncRequest, Direction.BETWEEN_DEVICE_AND_CLOUD),
+                arguments(localUpdateSyncRequest, cloudUpdateSyncRequest, Direction.CLOUD_TO_DEVICE),
+                arguments(cloudUpdateSyncRequest, localUpdateSyncRequest, Direction.CLOUD_TO_DEVICE),
+                arguments(localDeleteSyncRequest, cloudDeleteSyncRequest, Direction.CLOUD_TO_DEVICE),
+                arguments(localUpdateSyncRequest, cloudUpdateSyncRequest, Direction.DEVICE_TO_CLOUD),
+                arguments(cloudUpdateSyncRequest, localUpdateSyncRequest, Direction.DEVICE_TO_CLOUD),
+                arguments(localDeleteSyncRequest, cloudDeleteSyncRequest, Direction.DEVICE_TO_CLOUD)
         );
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Add ability to set the `syncDirection` in the `RequestMerger` class from the `ShadowManager` configuration subscription.

Also inject the `RequestMerger` class instead of creating a new one every time.

**Why is this change necessary:**
`RequestMerger` needs to know the exact direction in which the sync is configured in order to properly merge in new sync requests based on it.

**How was this change tested:**
Added unit tests.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
