### PR TITLE
fix: allow 6 levels in shadow state

### DIFF
--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
@@ -100,15 +100,29 @@ class JsonUtilTest {
     @Test
     void GIVEN_state_with_6_levels_WHEN_validatePayload_THEN_successfully_validates() throws IOException {
         ShadowDocument source = new ShadowDocument();
-        JsonNode updateNode = getPayloadJson("{\"state\": {\"desired\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"The Beatles\"}}}}}}}}".getBytes()).get();
-        assertDoesNotThrow(() -> JsonUtil.validatePayload(source, updateNode));
+        JsonNode desiredNode = getPayloadJson("{\"state\": {\"desired\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"The Beatles\"}}}}}}}}".getBytes()).get();
+        assertDoesNotThrow(() -> JsonUtil.validatePayload(source, desiredNode));
+        JsonNode reportedNode = getPayloadJson("{\"state\": {\"reported\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"The Beatles\"}}}}}}}}".getBytes()).get();
+        assertDoesNotThrow(() -> JsonUtil.validatePayload(source, reportedNode));
     }
 
     @Test
     void GIVEN_state_with_7_levels_WHEN_validatePayload_THEN_throws_invalid_request_parameters_exception() throws IOException {
         ShadowDocument source = new ShadowDocument();
-        JsonNode updateNode = getPayloadJson("{\"state\": {\"desired\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": {\"7\": \"The Beatles\"}}}}}}}}}".getBytes()).get();
-        InvalidRequestParametersException thrown =  assertThrows(InvalidRequestParametersException.class, () -> JsonUtil.validatePayload(source, updateNode));
+        JsonNode desiredNode = getPayloadJson("{\"state\": {\"desired\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": {\"7\": \"The Beatles\"}}}}}}}}}".getBytes()).get();
+        InvalidRequestParametersException thrown =  assertThrows(InvalidRequestParametersException.class, () -> JsonUtil.validatePayload(source, desiredNode));
+        assertThat(thrown.getErrorMessage(), is(notNullValue()));
+        assertThat(thrown.getErrorMessage().getErrorCode(), is(400));
+        assertThat(thrown.getErrorMessage().getMessage(), is("JSON contains too many levels of nesting; maximum is 6"));
+
+        JsonNode reportedNode = getPayloadJson("{\"state\": {\"reported\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": {\"7\": \"The Beatles\"}}}}}}}}}".getBytes()).get();
+        thrown =  assertThrows(InvalidRequestParametersException.class, () -> JsonUtil.validatePayload(source, reportedNode));
+        assertThat(thrown.getErrorMessage(), is(notNullValue()));
+        assertThat(thrown.getErrorMessage().getErrorCode(), is(400));
+        assertThat(thrown.getErrorMessage().getMessage(), is("JSON contains too many levels of nesting; maximum is 6"));
+
+        JsonNode reportedAndDesiredNode = getPayloadJson("{\"state\": {\"desired\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"The Beatles\"}}}}}},\"reported\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": {\"7\": \"The Beatles\"}}}}}}}}}".getBytes()).get();
+        thrown =  assertThrows(InvalidRequestParametersException.class, () -> JsonUtil.validatePayload(source, reportedAndDesiredNode));
         assertThat(thrown.getErrorMessage(), is(notNullValue()));
         assertThat(thrown.getErrorMessage().getErrorCode(), is(400));
         assertThat(thrown.getErrorMessage().getMessage(), is("JSON contains too many levels of nesting; maximum is 6"));

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
@@ -96,4 +96,21 @@ class JsonUtilTest {
         assertThat(thrown.getErrorMessage().getErrorCode(), is(400));
         assertThat(thrown.getErrorMessage().getMessage(), is("Invalid version"));
     }
+
+    @Test
+    void GIVEN_state_with_6_levels_WHEN_validatePayload_THEN_successfully_validates() throws IOException {
+        ShadowDocument source = new ShadowDocument();
+        JsonNode updateNode = getPayloadJson("{\"state\": {\"desired\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": \"The Beatles\"}}}}}}}}".getBytes()).get();
+        assertDoesNotThrow(() -> JsonUtil.validatePayload(source, updateNode));
+    }
+
+    @Test
+    void GIVEN_state_with_7_levels_WHEN_validatePayload_THEN_throws_invalid_request_parameters_exception() throws IOException {
+        ShadowDocument source = new ShadowDocument();
+        JsonNode updateNode = getPayloadJson("{\"state\": {\"desired\": {\"1\": {\"2\": {\"3\": {\"4\": {\"5\": {\"6\": {\"7\": \"The Beatles\"}}}}}}}}}".getBytes()).get();
+        InvalidRequestParametersException thrown =  assertThrows(InvalidRequestParametersException.class, () -> JsonUtil.validatePayload(source, updateNode));
+        assertThat(thrown.getErrorMessage(), is(notNullValue()));
+        assertThat(thrown.getErrorMessage().getErrorCode(), is(400));
+        assertThat(thrown.getErrorMessage().getMessage(), is("JSON contains too many levels of nesting; maximum is 6"));
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updated the code to use the correct depth at the level. Validate the depth of `desired` and `reported` separately.

**Why is this change necessary:**
Allow 6 levels in the `state:desired` and `state:reported` section. IoT shadow allows the shadow state to have 6 levels in it.

**How was this change tested:**
Added unit tests

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [X] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
