### PR TITLE
fix: respond to config updates after config reset

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -139,7 +139,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
             }
             syncHandler.setOverallSyncStrategy(syncStrategy);
             isSyncMocked.set(true);
-            shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().build());
+            shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().startSyncStrategy(true).build());
         }
 
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -194,7 +194,10 @@ class ShadowManagerTest extends NucleusLaunchUtils {
                 .mqttConnected(false)
                 .build());
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
-        assertThat(syncHandler.getSyncDirection(), is(Direction.BETWEEN_DEVICE_AND_CLOUD));
+        shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC)
+                .lookup(CONFIGURATION_SYNC_DIRECTION_TOPIC).withValue(Direction.DEVICE_TO_CLOUD.getCode());
+        kernel.getContext().waitForPublishQueueToClear();
+        assertThat(syncHandler.getSyncDirection(), is(Direction.DEVICE_TO_CLOUD));
 
         shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC)
                 .lookup(CONFIGURATION_SYNC_DIRECTION_TOPIC).remove();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -360,7 +360,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .mockCloud(true)
                 .mockDao(true)
                 .build());
-        cdl.await(2,TimeUnit.SECONDS);
+        assertThat("cloud shadow updated", cdl.await(2, TimeUnit.SECONDS), is(true));
         assertThat(() -> cloudUpdateThingShadowRequestCaptor.getValue(), eventuallyEval(is(notNullValue())));
         assertThat(() -> syncInformationCaptor.getValue(), eventuallyEval(is(notNullValue())));
 
@@ -704,7 +704,7 @@ class SyncTest extends NucleusLaunchUtils {
 
         // Fire the initial request
         handler.get().handleRequest(request1, "DoAll");
-        cdl.await(2, TimeUnit.SECONDS);
+        assertThat("thing shadow updated", cdl.await(2, TimeUnit.SECONDS), is(true));
         assertThat("update thing shadow called", updateThingShadowCalled::get, eventuallyEval(is(1)));
         assertThat("dao cloud version updated", () -> syncInfo.get()
                 .map(SyncInformation::getCloudVersion).orElse(0L), eventuallyEval(is(11L)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -325,13 +325,20 @@ class SyncTest extends NucleusLaunchUtils {
     void GIVEN_sync_config_and_no_cloud_WHEN_startup_THEN_cloud_version_updated_via_full_sync(Class<?extends BaseSyncStrategy> clazz, ExtensionContext context)
             throws IOException, InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
-
+        CountDownLatch cdl = new CountDownLatch(2);
         when(mockUpdateThingShadowResponse.payload()).thenReturn(SdkBytes.fromString("{\"version\": 1}", UTF_8));
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
-                .thenReturn(mockUpdateThingShadowResponse);
+                .thenAnswer(invocation->{
+                    cdl.countDown();
+                    return mockUpdateThingShadowResponse;
+                });
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
                 .thenThrow(ResourceNotFoundException.class);
-        when(dao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
+
+        when(dao.updateSyncInformation(syncInformationCaptor.capture())).thenAnswer(invocation->{
+            cdl.countDown();
+            return true;
+        });
         when(dao.listSyncedShadows()).thenReturn(Collections.singletonList(new Pair<>(MOCK_THING_NAME_1, CLASSIC_SHADOW)));
 
         ShadowDocument localDocument = new ShadowDocument(localShadowContentV1.getBytes(UTF_8), 1);
@@ -353,7 +360,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .mockCloud(true)
                 .mockDao(true)
                 .build());
-
+        cdl.await(2,TimeUnit.SECONDS);
         assertThat(() -> cloudUpdateThingShadowRequestCaptor.getValue(), eventuallyEval(is(notNullValue())));
         assertThat(() -> syncInformationCaptor.getValue(), eventuallyEval(is(notNullValue())));
 
@@ -666,7 +673,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .getThingShadow(any(GetThingShadowRequest.class))).thenReturn(shadowResponse);
         AtomicInteger updateThingShadowCalled = new AtomicInteger(0);
         AtomicReference<UpdateThingShadowRequestHandler> handler = new AtomicReference<>();
-
+        CountDownLatch cdl = new CountDownLatch(1);
         // throw an exception first - before throwing we make another request so that there is another request for
         // to update this shadow in the queue
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
@@ -681,7 +688,7 @@ class SyncTest extends NucleusLaunchUtils {
                         // request #2 comes in as we are processing request #1
                         handler.get().handleRequest(request2, "DoAll");
                     }
-
+                    cdl.countDown();
                     throw new RetryableException(new TestException());
                 });
 
@@ -697,7 +704,7 @@ class SyncTest extends NucleusLaunchUtils {
 
         // Fire the initial request
         handler.get().handleRequest(request1, "DoAll");
-
+        cdl.await(2, TimeUnit.SECONDS);
         assertThat("update thing shadow called", updateThingShadowCalled::get, eventuallyEval(is(1)));
         assertThat("dao cloud version updated", () -> syncInfo.get()
                 .map(SyncInformation::getCloudVersion).orElse(0L), eventuallyEval(is(11L)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -360,7 +360,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .mockCloud(true)
                 .mockDao(true)
                 .build());
-        assertThat("cloud shadow updated", cdl.await(2, TimeUnit.SECONDS), is(true));
+        assertThat("cloud shadow updated", cdl.await(5, TimeUnit.SECONDS), is(true));
         assertThat(() -> cloudUpdateThingShadowRequestCaptor.getValue(), eventuallyEval(is(notNullValue())));
         assertThat(() -> syncInformationCaptor.getValue(), eventuallyEval(is(notNullValue())));
 
@@ -704,7 +704,7 @@ class SyncTest extends NucleusLaunchUtils {
 
         // Fire the initial request
         handler.get().handleRequest(request1, "DoAll");
-        assertThat("thing shadow updated", cdl.await(2, TimeUnit.SECONDS), is(true));
+        assertThat("thing shadow updated", cdl.await(5, TimeUnit.SECONDS), is(true));
         assertThat("update thing shadow called", updateThingShadowCalled::get, eventuallyEval(is(1)));
         assertThat("dao cloud version updated", () -> syncInfo.get()
                 .map(SyncInformation::getCloudVersion).orElse(0L), eventuallyEval(is(11L)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/UnhappyUpdateIPCTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/UnhappyUpdateIPCTest.java
@@ -133,7 +133,7 @@ class UnhappyUpdateIPCTest extends NucleusLaunchUtils {
                 StringUtils.repeat('*', repeatLength)).getBytes(UTF_8));
         assertDoesNotThrow(() -> updateHandler.handleRequest(request, "DoAll"));
 
-        shadowManager.getConfig().remove();
+        shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY).remove();
         eventually(() -> {
             assertThat(Coerce.toInt(Validator.getMaxShadowDocumentSize()), is(DEFAULT_DOCUMENT_SIZE));
             return null;

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -249,15 +249,15 @@ public class ShadowManager extends PluginService {
             }
             if (installConfig.configureRateLimitsConfig
                     && (newv == null || newv.childOf(CONFIGURATION_RATE_LIMITS_TOPIC))) {
-                rateLimits();
+                configureRateLimits();
             }
             if (installConfig.configureMaxDocSizeLimitConfig
                     && (newv == null || newv.childOf(CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))) {
-                maxSizeDocLimitConfig();
+                configureMaxSizeDocLimitConfig();
             }
             if (installConfig.configureSyncDirectionConfig
                     && (newv == null || newv.childOf(CONFIGURATION_SYNC_DIRECTION_TOPIC))) {
-                syncDirection();
+                configureSyncDirection();
             }
             if (installConfig.configureStrategyConfig
                     && (newv == null || newv.childOf(CONFIGURATION_STRATEGY_TOPIC))) {
@@ -310,7 +310,7 @@ public class ShadowManager extends PluginService {
         }
     }
 
-    private void rateLimits() {
+    private void configureRateLimits() {
         Topics rateLimitTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC);
         Map<String, Object> rateLimitsPojo = rateLimitTopics.toPOJO();
         try {
@@ -339,7 +339,7 @@ public class ShadowManager extends PluginService {
         }
     }
 
-    private void maxSizeDocLimitConfig() {
+    private void configureMaxSizeDocLimitConfig() {
         int newMaxShadowSize = Coerce.toInt(config.lookup(CONFIGURATION_CONFIG_KEY,
                 CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC)
                 .dflt(DEFAULT_DOCUMENT_SIZE));
@@ -355,7 +355,7 @@ public class ShadowManager extends PluginService {
         }
     }
 
-    private void syncDirection() {
+    private void configureSyncDirection() {
         String newSyncDirectionStr = Coerce.toString(config.lookup(CONFIGURATION_CONFIG_KEY,
                 CONFIGURATION_SYNCHRONIZATION_TOPIC,
                 CONFIGURATION_SYNC_DIRECTION_TOPIC).dflt(Direction.BETWEEN_DEVICE_AND_CLOUD.getCode()));

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -355,7 +355,7 @@ public class ShadowManager extends PluginService {
                     .kv("maxShadowSize", newMaxShadowSize)
                     .log();
         } catch (InvalidConfigurationException e) {
-            serviceErrored(new InvalidConfigurationException(e));
+            serviceErrored(e);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -243,25 +243,20 @@ public class ShadowManager extends PluginService {
             if (what.equals(WhatHappened.timestampUpdated)) {
                 return;
             }
-            if (installConfig.configureSynchronizeConfig
-                    && (newv == null || newv.childOf(CONFIGURATION_SYNCHRONIZATION_TOPIC))) {
-                configureSynchronization();
+            if (installConfig.configureSynchronizeConfig) {
+                configureSynchronization(newv);
             }
-            if (installConfig.configureRateLimitsConfig
-                    && (newv == null || newv.childOf(CONFIGURATION_RATE_LIMITS_TOPIC))) {
-                configureRateLimits();
+            if (installConfig.configureRateLimitsConfig) {
+                configureRateLimits(newv);
             }
-            if (installConfig.configureMaxDocSizeLimitConfig
-                    && (newv == null || newv.childOf(CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))) {
-                configureMaxSizeDocLimitConfig();
+            if (installConfig.configureMaxDocSizeLimitConfig) {
+                configureMaxSizeDocLimitConfig(newv);
             }
-            if (installConfig.configureSyncDirectionConfig
-                    && (newv == null || newv.childOf(CONFIGURATION_SYNC_DIRECTION_TOPIC))) {
-                configureSyncDirection();
+            if (installConfig.configureSyncDirectionConfig) {
+                configureSyncDirection(newv);
             }
-            if (installConfig.configureStrategyConfig
-                    && (newv == null || newv.childOf(CONFIGURATION_STRATEGY_TOPIC))) {
-                configureStrategy();
+            if (installConfig.configureStrategyConfig) {
+                configureStrategy(newv);
             }
         });
     }
@@ -276,7 +271,10 @@ public class ShadowManager extends PluginService {
         return currentStrategy;
     }
 
-    private void configureSynchronization() {
+    private void configureSynchronization(Node newv) {
+        if (newv != null && !newv.childOf(CONFIGURATION_SYNCHRONIZATION_TOPIC)) {
+            return;
+        }
         Topics configTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC);
         Map<String, Object> configTopicsPojo = configTopics.toPOJO();
         try {
@@ -310,7 +308,10 @@ public class ShadowManager extends PluginService {
         }
     }
 
-    private void configureRateLimits() {
+    private void configureRateLimits(Node newv) {
+        if (newv != null && !newv.childOf(CONFIGURATION_RATE_LIMITS_TOPIC)) {
+            return;
+        }
         Topics rateLimitTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC);
         Map<String, Object> rateLimitsPojo = rateLimitTopics.toPOJO();
         try {
@@ -339,7 +340,10 @@ public class ShadowManager extends PluginService {
         }
     }
 
-    private void configureMaxSizeDocLimitConfig() {
+    private void configureMaxSizeDocLimitConfig(Node newv) {
+        if (newv != null && !newv.childOf(CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC)) {
+            return;
+        }
         int newMaxShadowSize = Coerce.toInt(config.lookup(CONFIGURATION_CONFIG_KEY,
                 CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC)
                 .dflt(DEFAULT_DOCUMENT_SIZE));
@@ -355,7 +359,10 @@ public class ShadowManager extends PluginService {
         }
     }
 
-    private void configureSyncDirection() {
+    private void configureSyncDirection(Node newv) {
+        if (newv != null && !newv.childOf(CONFIGURATION_SYNC_DIRECTION_TOPIC)) {
+            return;
+        }
         String newSyncDirectionStr = Coerce.toString(config.lookup(CONFIGURATION_CONFIG_KEY,
                 CONFIGURATION_SYNCHRONIZATION_TOPIC,
                 CONFIGURATION_SYNC_DIRECTION_TOPIC).dflt(Direction.BETWEEN_DEVICE_AND_CLOUD.getCode()));
@@ -380,7 +387,10 @@ public class ShadowManager extends PluginService {
         syncHandler.setSyncDirection(newSyncDirection);
     }
 
-    private void configureStrategy() {
+    private void configureStrategy(Node newv) {
+        if (newv != null && !newv.childOf(CONFIGURATION_STRATEGY_TOPIC)) {
+            return;
+        }
         Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
         Strategy strategy;
         Map<String, Object> strategyPojo = strategyTopics.toPOJO();

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -239,156 +239,31 @@ public class ShadowManager extends PluginService {
         }
 
         inboundRateLimiter.clear();
-
-        if (installConfig.configureSynchronizeConfig) {
-            Topics configTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC);
-            configTopics.subscribe((what, newv) -> {
-                Map<String, Object> configTopicsPojo = configTopics.toPOJO();
-                try {
-                    Topic thingNameTopic = this.deviceConfiguration.getThingName();
-                    String thingName = Coerce.toString(thingNameTopic);
-                    ShadowSyncConfiguration newSyncConfiguration =
-                            ShadowSyncConfiguration.processConfiguration(configTopicsPojo, thingName);
-                    if (this.syncConfiguration != null && this.syncConfiguration.equals(newSyncConfiguration)) {
-                        return;
-                    }
-                    this.syncConfiguration = newSyncConfiguration;
-                    this.syncHandler.setSyncConfigurations(this.syncConfiguration.getSyncConfigurations());
-
-                    // Subscribe to the thing name topic if the Nucleus thing shadows have been synced.
-                    Optional<ThingShadowSyncConfiguration> coreThingConfig =
-                            getCoreThingShadowSyncConfiguration(thingName);
-                    if (coreThingConfig.isPresent()) {
-                        thingNameTopic.subscribeGeneric(this.deviceThingNameWatcher);
-                    } else {
-                        thingNameTopic.remove(this.deviceThingNameWatcher);
-                    }
-
-                    // only stop / start syncing if we are not in install - it will otherwise be started by lifecycle
-                    if (inState(State.RUNNING)) {
-                        stopSyncingShadows(true);
-                        startSyncingShadows(StartSyncInfo.builder().reInitializeSyncInfo(true).startSyncStrategy(true)
-                                .updateCloudSubscriptions(true).build());
-                    }
-                } catch (InvalidConfigurationException e) {
-                    serviceErrored(e);
-                }
-            });
-        }
-
-        if (installConfig.configureRateLimitsConfig) {
-            Topics rateLimitTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC);
-            rateLimitTopics.subscribe((what, newv) -> {
-                Map<String, Object> rateLimitsPojo = rateLimitTopics.toPOJO();
-                try {
-                    if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC)) {
-                        int maxOutboundSyncUpdatesPerSecond = Coerce.toInt(rateLimitsPojo
-                                .get(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC));
-                        Validator.validateOutboundSyncUpdatesPerSecond(maxOutboundSyncUpdatesPerSecond);
-                        iotDataPlaneClientWrapper.setRate(maxOutboundSyncUpdatesPerSecond);
-                    }
-
-                    if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE)) {
-                        int maxTotalLocalRequestRate = Coerce.toInt(rateLimitsPojo
-                                .get(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE));
-                        Validator.validateTotalLocalRequestRate(maxTotalLocalRequestRate);
-                        inboundRateLimiter.setTotalRate(maxTotalLocalRequestRate);
-                    }
-
-                    if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC)) {
-                        int maxLocalShadowUpdatesPerThingPerSecond = Coerce.toInt(rateLimitsPojo
-                                .get(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC));
-                        Validator.validateLocalShadowRequestsPerThingPerSecond(maxLocalShadowUpdatesPerThingPerSecond);
-                        inboundRateLimiter.setRate(maxLocalShadowUpdatesPerThingPerSecond);
-                    }
-                } catch (InvalidConfigurationException e) {
-                    serviceErrored(e);
-                }
-            });
-        }
-
-
-        if (installConfig.configureMaxDocSizeLimitConfig) {
-            config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC)
-                    .dflt(DEFAULT_DOCUMENT_SIZE)
-                    .subscribe((why, newv) -> {
-                        int newMaxShadowSize;
-                        if (WhatHappened.removed.equals(why)) {
-                            newMaxShadowSize = DEFAULT_DOCUMENT_SIZE;
-                        } else {
-                            newMaxShadowSize = Coerce.toInt(newv);
-                        }
-                        try {
-                            Validator.validateMaxShadowSize(newMaxShadowSize);
-                            Validator.setMaxShadowDocumentSize(newMaxShadowSize);
-                            logger.atDebug()
-                                    .setEventType("config")
-                                    .kv("maxShadowSize", newMaxShadowSize)
-                                    .log();
-                        } catch (InvalidConfigurationException e) {
-                            serviceErrored(new InvalidConfigurationException(e));
-                        }
-                    });
-        }
-
-        if (installConfig.configureSyncDirectionConfig) {
-            config.lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC,
-                            CONFIGURATION_SYNC_DIRECTION_TOPIC)
-                    .dflt(Direction.BETWEEN_DEVICE_AND_CLOUD.getCode())
-                    .subscribe((why, newv) -> {
-                        Direction newSyncDirection;
-                        if (WhatHappened.removed.equals(why)) {
-                            newSyncDirection = Direction.BETWEEN_DEVICE_AND_CLOUD;
-                        } else {
-                            try {
-                                newSyncDirection = Direction.getDirection(Coerce.toString(newv));
-                            } catch (IllegalArgumentException e) {
-                                serviceErrored(e);
-                                return;
-                            }
-                        }
-
-                        logger.atDebug()
-                                .setEventType("config")
-                                .kv("syncDirection", newSyncDirection.toString())
-                                .log();
-                        Direction currentDirection = syncHandler.getSyncDirection();
-                        // if the sync direction is the same, then just return and do nothing.
-                        if (newSyncDirection.equals(currentDirection)) {
-                            return;
-                        }
-
-                        setupSync(newSyncDirection, Optional.of(currentDirection));
-                        syncHandler.setSyncDirection(newSyncDirection);
-                    });
-        }
-
-        if (installConfig.configureStrategyConfig) {
-            Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
-            final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
-
-            strategyTopics.subscribe((why, newv) -> {
-                Strategy strategy;
-                Map<String, Object> strategyPojo = strategyTopics.toPOJO();
-
-                if (WhatHappened.removed.equals(why) || strategyPojo == null || strategyPojo.isEmpty()) {
-                    strategy = DEFAULT_STRATEGY;
-                } else {
-                    // Get the correct sync strategy configuration from the POJO.
-                    try {
-                        strategy = Strategy.fromPojo(strategyPojo);
-                    } catch (InvalidConfigurationException e) {
-                        serviceErrored(e);
-                        return;
-                    }
-                }
-                logger.atDebug()
-                        .setEventType("config")
-                        .kv("syncStrategy", strategy.getType().getCode())
-                        .log();
-                currentStrategy.set(replaceStrategyIfNecessary(currentStrategy.get(), strategy));
-            });
-        }
+        config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((what, newv) -> {
+            if (what.equals(WhatHappened.timestampUpdated)) {
+                return;
+            }
+            if (installConfig.configureSynchronizeConfig
+                    && (newv == null || newv.childOf(CONFIGURATION_SYNCHRONIZATION_TOPIC))) {
+                configureSynchronization();
+            }
+            if (installConfig.configureRateLimitsConfig
+                    && (newv == null || newv.childOf(CONFIGURATION_RATE_LIMITS_TOPIC))) {
+                rateLimits();
+            }
+            if (installConfig.configureMaxDocSizeLimitConfig
+                    && (newv == null || newv.childOf(CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC))) {
+                maxSizeDocLimitConfig();
+            }
+            if (installConfig.configureSyncDirectionConfig
+                    && (newv == null || newv.childOf(CONFIGURATION_SYNC_DIRECTION_TOPIC))) {
+                syncDirection();
+            }
+            if (installConfig.configureStrategyConfig
+                    && (newv == null || newv.childOf(CONFIGURATION_STRATEGY_TOPIC))) {
+                configureStrategy();
+            }
+        });
     }
 
     Strategy replaceStrategyIfNecessary(Strategy currentStrategy, Strategy strategy) {
@@ -399,6 +274,133 @@ public class ShadowManager extends PluginService {
             startSyncingShadows(StartSyncInfo.builder().startSyncStrategy(true).build());
         }
         return currentStrategy;
+    }
+
+    private void configureSynchronization() {
+        Topics configTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC);
+        Map<String, Object> configTopicsPojo = configTopics.toPOJO();
+        try {
+            Topic thingNameTopic = this.deviceConfiguration.getThingName();
+            String thingName = Coerce.toString(thingNameTopic);
+            ShadowSyncConfiguration newSyncConfiguration =
+                    ShadowSyncConfiguration.processConfiguration(configTopicsPojo, thingName);
+            if (this.syncConfiguration != null && this.syncConfiguration.equals(newSyncConfiguration)) {
+                return;
+            }
+            this.syncConfiguration = newSyncConfiguration;
+            this.syncHandler.setSyncConfigurations(this.syncConfiguration.getSyncConfigurations());
+
+            // Subscribe to the thing name topic if the Nucleus thing shadows have been synced.
+            Optional<ThingShadowSyncConfiguration> coreThingConfig =
+                    getCoreThingShadowSyncConfiguration(thingName);
+            if (coreThingConfig.isPresent()) {
+                thingNameTopic.subscribeGeneric(this.deviceThingNameWatcher);
+            } else {
+                thingNameTopic.remove(this.deviceThingNameWatcher);
+            }
+
+            // only stop / start syncing if we are not in install - it will otherwise be started by lifecycle
+            if (inState(State.RUNNING)) {
+                stopSyncingShadows(true);
+                startSyncingShadows(StartSyncInfo.builder().reInitializeSyncInfo(true).startSyncStrategy(true)
+                        .updateCloudSubscriptions(true).build());
+            }
+        } catch (InvalidConfigurationException e) {
+            serviceErrored(e);
+        }
+    }
+
+    private void rateLimits() {
+        Topics rateLimitTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC);
+        Map<String, Object> rateLimitsPojo = rateLimitTopics.toPOJO();
+        try {
+            if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC)) {
+                int maxOutboundSyncUpdatesPerSecond = Coerce.toInt(rateLimitsPojo
+                        .get(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC));
+                Validator.validateOutboundSyncUpdatesPerSecond(maxOutboundSyncUpdatesPerSecond);
+                iotDataPlaneClientWrapper.setRate(maxOutboundSyncUpdatesPerSecond);
+            }
+
+            if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE)) {
+                int maxTotalLocalRequestRate = Coerce.toInt(rateLimitsPojo
+                        .get(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE));
+                Validator.validateTotalLocalRequestRate(maxTotalLocalRequestRate);
+                inboundRateLimiter.setTotalRate(maxTotalLocalRequestRate);
+            }
+
+            if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC)) {
+                int maxLocalShadowUpdatesPerThingPerSecond = Coerce.toInt(rateLimitsPojo
+                        .get(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC));
+                Validator.validateLocalShadowRequestsPerThingPerSecond(maxLocalShadowUpdatesPerThingPerSecond);
+                inboundRateLimiter.setRate(maxLocalShadowUpdatesPerThingPerSecond);
+            }
+        } catch (InvalidConfigurationException e) {
+            serviceErrored(e);
+        }
+    }
+
+    private void maxSizeDocLimitConfig() {
+        int newMaxShadowSize = Coerce.toInt(config.lookup(CONFIGURATION_CONFIG_KEY,
+                CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC)
+                .dflt(DEFAULT_DOCUMENT_SIZE));
+        try {
+            Validator.validateMaxShadowSize(newMaxShadowSize);
+            Validator.setMaxShadowDocumentSize(newMaxShadowSize);
+            logger.atDebug()
+                    .setEventType("config")
+                    .kv("maxShadowSize", newMaxShadowSize)
+                    .log();
+        } catch (InvalidConfigurationException e) {
+            serviceErrored(new InvalidConfigurationException(e));
+        }
+    }
+
+    private void syncDirection() {
+        String newSyncDirectionStr = Coerce.toString(config.lookup(CONFIGURATION_CONFIG_KEY,
+                CONFIGURATION_SYNCHRONIZATION_TOPIC,
+                CONFIGURATION_SYNC_DIRECTION_TOPIC).dflt(Direction.BETWEEN_DEVICE_AND_CLOUD.getCode()));
+
+        Direction newSyncDirection;
+        try {
+            newSyncDirection = Direction.getDirection(Coerce.toString(newSyncDirectionStr));
+        } catch (IllegalArgumentException e) {
+            serviceErrored(e);
+            return;
+        }
+        logger.atDebug()
+                .setEventType("config")
+                .kv("syncDirection", newSyncDirection.toString())
+                .log();
+        Direction currentDirection = syncHandler.getSyncDirection();
+        // if the sync direction is the same, then just return and do nothing.
+        if (newSyncDirection.equals(currentDirection)) {
+            return;
+        }
+        setupSync(newSyncDirection, Optional.of(currentDirection));
+        syncHandler.setSyncDirection(newSyncDirection);
+    }
+
+    private void configureStrategy() {
+        Topics strategyTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC);
+        Strategy strategy;
+        Map<String, Object> strategyPojo = strategyTopics.toPOJO();
+        if (strategyPojo == null || strategyPojo.isEmpty()) {
+            strategy = DEFAULT_STRATEGY;
+        } else {
+            // Get the correct sync strategy configuration from the POJO.
+            try {
+                strategy = Strategy.fromPojo(strategyPojo);
+            } catch (InvalidConfigurationException e) {
+                serviceErrored(e);
+                return;
+            }
+        }
+        logger.atInfo()
+                .setEventType("config")
+                .kv("syncStrategy", strategy.getType().getCode())
+                .log();
+        final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
+        currentStrategy.set(replaceStrategyIfNecessary(currentStrategy.get(), strategy));
     }
 
     private void setupSync(Direction newSyncDirection, Optional<Direction> currentDirection) {

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -168,6 +168,8 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper,
                 mockPubSubClientWrapper, mockInboundRateLimiter, mockDeviceConfiguration, mockSynchronizeHelper,
                 mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient);
+        lenient().when(config.lookupTopics(CONFIGURATION_CONFIG_KEY))
+                .thenReturn(Topics.of(context, CONFIGURATION_CONFIG_KEY, null));
     }
 
     @AfterEach
@@ -809,6 +811,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
             configTopics.createLeafChild(CONFIGURATION_SHADOW_DOCUMENTS_TOPIC).withValueChecked(shadowDocumentsList);
 
             when(thingNameTopic.getOnce()).thenReturn(KERNEL_THING);
+            when(config.lookupTopics(CONFIGURATION_CONFIG_KEY)).thenReturn(configTopics);
             when(config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC)).thenReturn(configTopics);
             when(mockDeviceConfiguration.getThingName()).thenReturn(thingNameTopic);
             s.install(ShadowManager.InstallConfig.builder().configureSynchronizeConfig(true).build());


### PR DESCRIPTION
**Issue #, if available:**
#129 

**Description of changes:**
Subscribe to the changes on the parent configuration node instead of specific child nodes as the child nodes can be removed during reset. 

**Why is this change necessary:**
If the configuration is updated after reset, the component should behave according to the configuration changes without restarting the component. Without this change, the configuration won't be updated once the reset happens. 

**How was this change tested:**
Updated tests. Need to do manual testing. 

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
