### PR TITLE
refactor: rate limits configuration updates

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -269,7 +269,7 @@ public class ShadowManager extends PluginService {
 
     private void configureRateLimits(RateLimitsConfiguration rateLimitsConfig) {
         inboundRateLimiter.updateRateLimits(rateLimitsConfig.getMaxTotalLocalRequestRate(),
-                rateLimitsConfig.getMaxTotalLocalRequestRate());
+                rateLimitsConfig.getMaxLocalRequestRatePerThing());
         iotDataPlaneClientWrapper.updateRateLimits(rateLimitsConfig.getMaxOutboundUpdatesPerSecond());
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.mqttclient.CallbackEventManager;
 import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.shadowmanager.configuration.ComponentConfiguration;
 import com.aws.greengrass.shadowmanager.exception.InvalidConfigurationException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowIPCHandler;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
@@ -65,10 +66,6 @@ import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE;
-import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_RATE_LIMITS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_STRATEGY_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNCHRONIZATION_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNC_DIRECTION_TOPIC;
@@ -91,6 +88,7 @@ public class ShadowManager extends PluginService {
     private final AuthorizationHandlerWrapper authorizationHandlerWrapper;
     private final InboundRateLimiter inboundRateLimiter;
     private final DeviceConfiguration deviceConfiguration;
+    private ComponentConfiguration componentConfiguration;
     @Getter
     private final DeleteThingShadowRequestHandler deleteThingShadowRequestHandler;
     @Getter
@@ -244,11 +242,9 @@ public class ShadowManager extends PluginService {
             if (what.equals(WhatHappened.timestampUpdated) || what.equals(WhatHappened.interiorAdded)) {
                 return;
             }
+            onConfigurationUpdate();
             if (installConfig.configureSynchronizeConfig) {
                 configureSynchronization(newv);
-            }
-            if (installConfig.configureRateLimitsConfig) {
-                configureRateLimits(newv);
             }
             if (installConfig.configureMaxDocSizeLimitConfig) {
                 configureMaxSizeDocLimitConfig(newv);
@@ -260,6 +256,14 @@ public class ShadowManager extends PluginService {
                 configureStrategy(newv);
             }
         });
+    }
+
+    private void onConfigurationUpdate() {
+        try {
+            componentConfiguration = ComponentConfiguration.from(componentConfiguration, getConfig());
+        } catch (InvalidConfigurationException e) {
+            serviceErrored(e);
+        }
     }
 
     Strategy replaceStrategyIfNecessary(Strategy currentStrategy, Strategy strategy) {
@@ -303,38 +307,6 @@ public class ShadowManager extends PluginService {
                 stopSyncingShadows(true);
                 startSyncingShadows(StartSyncInfo.builder().reInitializeSyncInfo(true).startSyncStrategy(true)
                         .updateCloudSubscriptions(true).build());
-            }
-        } catch (InvalidConfigurationException e) {
-            serviceErrored(e);
-        }
-    }
-
-    private void configureRateLimits(Node newv) {
-        if (newv != null && !newv.childOf(CONFIGURATION_RATE_LIMITS_TOPIC)) {
-            return;
-        }
-        Topics rateLimitTopics = config.lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_RATE_LIMITS_TOPIC);
-        Map<String, Object> rateLimitsPojo = rateLimitTopics.toPOJO();
-        try {
-            if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC)) {
-                int maxOutboundSyncUpdatesPerSecond = Coerce.toInt(rateLimitsPojo
-                        .get(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC));
-                Validator.validateOutboundSyncUpdatesPerSecond(maxOutboundSyncUpdatesPerSecond);
-                iotDataPlaneClientWrapper.setRate(maxOutboundSyncUpdatesPerSecond);
-            }
-
-            if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE)) {
-                int maxTotalLocalRequestRate = Coerce.toInt(rateLimitsPojo
-                        .get(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE));
-                Validator.validateTotalLocalRequestRate(maxTotalLocalRequestRate);
-                inboundRateLimiter.setTotalRate(maxTotalLocalRequestRate);
-            }
-
-            if (rateLimitsPojo.containsKey(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC)) {
-                int maxLocalShadowUpdatesPerThingPerSecond = Coerce.toInt(rateLimitsPojo
-                        .get(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC));
-                Validator.validateLocalShadowRequestsPerThingPerSecond(maxLocalShadowUpdatesPerThingPerSecond);
-                inboundRateLimiter.setRate(maxLocalShadowUpdatesPerThingPerSecond);
             }
         } catch (InvalidConfigurationException e) {
             serviceErrored(e);

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.mqttclient.CallbackEventManager;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.shadowmanager.configuration.ComponentConfiguration;
+import com.aws.greengrass.shadowmanager.configuration.RateLimitsConfiguration;
 import com.aws.greengrass.shadowmanager.exception.InvalidConfigurationException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowIPCHandler;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
@@ -261,9 +262,15 @@ public class ShadowManager extends PluginService {
     private void onConfigurationUpdate() {
         try {
             componentConfiguration = ComponentConfiguration.from(componentConfiguration, getConfig());
+            configureRateLimits(componentConfiguration.getRateLimitsConfiguration());
         } catch (InvalidConfigurationException e) {
             serviceErrored(e);
         }
+    }
+
+    private void configureRateLimits(RateLimitsConfiguration rateLimitsConfiguration) {
+        inboundRateLimiter.updateRateLimits(rateLimitsConfiguration);
+        iotDataPlaneClientWrapper.updateRateLimits(rateLimitsConfiguration);
     }
 
     Strategy replaceStrategyIfNecessary(Strategy currentStrategy, Strategy strategy) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -219,7 +219,6 @@ public class ShadowManager extends PluginService {
     protected void install() {
         install(InstallConfig.builder()
                 .configureMaxDocSizeLimitConfig(true)
-                .configureRateLimitsConfig(true)
                 .configureStrategyConfig(true)
                 .configureSyncDirectionConfig(true)
                 .configureSynchronizeConfig(true)
@@ -268,9 +267,10 @@ public class ShadowManager extends PluginService {
         }
     }
 
-    private void configureRateLimits(RateLimitsConfiguration rateLimitsConfiguration) {
-        inboundRateLimiter.updateRateLimits(rateLimitsConfiguration);
-        iotDataPlaneClientWrapper.updateRateLimits(rateLimitsConfiguration);
+    private void configureRateLimits(RateLimitsConfiguration rateLimitsConfig) {
+        inboundRateLimiter.updateRateLimits(rateLimitsConfig.getMaxTotalLocalRequestRate(),
+                rateLimitsConfig.getMaxTotalLocalRequestRate());
+        iotDataPlaneClientWrapper.updateRateLimits(rateLimitsConfig.getMaxOutboundUpdatesPerSecond());
     }
 
     Strategy replaceStrategyIfNecessary(Strategy currentStrategy, Strategy strategy) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
@@ -9,10 +9,10 @@ import com.aws.greengrass.config.Topics;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 
-public class ComponentConfiguration {
+public final class ComponentConfiguration {
     RateLimitsConfiguration rateLimitsConfiguration;
 
-    public ComponentConfiguration(RateLimitsConfiguration rateLimitsConfiguration) {
+    private ComponentConfiguration(RateLimitsConfiguration rateLimitsConfiguration) {
         this.rateLimitsConfiguration = rateLimitsConfiguration;
     }
 
@@ -23,26 +23,9 @@ public class ComponentConfiguration {
      * @return shadow manager component configuration object
      */
     public static ComponentConfiguration from(ComponentConfiguration oldConfiguration, Topics updatedTopics) {
-        Topics serviceConfiguration = updatedTopics.lookupTopics(CONFIGURATION_CONFIG_KEY);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(serviceConfiguration);
-        ComponentConfiguration newConfiguration = new ComponentConfiguration(rateLimitsConfiguration);
-        newConfiguration.triggerUpdates(oldConfiguration);
-        return newConfiguration;
+        Topics serviceTopics = updatedTopics.lookupTopics(CONFIGURATION_CONFIG_KEY);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, serviceTopics);
+        return new ComponentConfiguration(rateLimitsConfiguration);
     }
 
-    private void triggerUpdates(ComponentConfiguration oldConfiguration) {
-        if (this.equals(oldConfiguration)) {
-            return;
-        }
-        if (hasRateLimitsChanged(oldConfiguration)) {
-            rateLimitsConfiguration.triggerUpdates();
-        }
-    }
-
-    private boolean hasRateLimitsChanged(ComponentConfiguration oldConfiguration) {
-        if (oldConfiguration == null) {
-            return true;
-        }
-        return rateLimitsConfiguration.hasChanged(oldConfiguration.rateLimitsConfiguration);
-    }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
@@ -24,8 +24,15 @@ public final class ComponentConfiguration {
      */
     public static ComponentConfiguration from(ComponentConfiguration oldConfiguration, Topics updatedTopics) {
         Topics serviceTopics = updatedTopics.lookupTopics(CONFIGURATION_CONFIG_KEY);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, serviceTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(
+                getOldRateLimitsConfiguration(oldConfiguration), serviceTopics);
         return new ComponentConfiguration(rateLimitsConfiguration);
     }
 
+    private static RateLimitsConfiguration getOldRateLimitsConfiguration(ComponentConfiguration oldComponentConfig) {
+        if (oldComponentConfig != null) {
+            return oldComponentConfig.rateLimitsConfiguration;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
@@ -6,11 +6,13 @@
 package com.aws.greengrass.shadowmanager.configuration;
 
 import com.aws.greengrass.config.Topics;
+import lombok.Getter;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 
 public final class ComponentConfiguration {
-    RateLimitsConfiguration rateLimitsConfiguration;
+    @Getter
+    private final RateLimitsConfiguration rateLimitsConfiguration;
 
     private ComponentConfiguration(RateLimitsConfiguration rateLimitsConfiguration) {
         this.rateLimitsConfiguration = rateLimitsConfiguration;
@@ -24,15 +26,7 @@ public final class ComponentConfiguration {
      */
     public static ComponentConfiguration from(ComponentConfiguration oldConfiguration, Topics updatedTopics) {
         Topics serviceTopics = updatedTopics.lookupTopics(CONFIGURATION_CONFIG_KEY);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(
-                getOldRateLimitsConfiguration(oldConfiguration), serviceTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(serviceTopics);
         return new ComponentConfiguration(rateLimitsConfiguration);
-    }
-
-    private static RateLimitsConfiguration getOldRateLimitsConfiguration(ComponentConfiguration oldComponentConfig) {
-        if (oldComponentConfig != null) {
-            return oldComponentConfig.rateLimitsConfiguration;
-        }
-        return null;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/ComponentConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.configuration;
+
+import com.aws.greengrass.config.Topics;
+
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+
+public class ComponentConfiguration {
+    RateLimitsConfiguration rateLimitsConfiguration;
+
+    public ComponentConfiguration(RateLimitsConfiguration rateLimitsConfiguration) {
+        this.rateLimitsConfiguration = rateLimitsConfiguration;
+    }
+
+    /**
+     * Constructor for shadow manager component.
+     * @param oldConfiguration previous configuration of the component
+     * @param updatedTopics current configuration topics
+     * @return shadow manager component configuration object
+     */
+    public static ComponentConfiguration from(ComponentConfiguration oldConfiguration, Topics updatedTopics) {
+        Topics serviceConfiguration = updatedTopics.lookupTopics(CONFIGURATION_CONFIG_KEY);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(serviceConfiguration);
+        ComponentConfiguration newConfiguration = new ComponentConfiguration(rateLimitsConfiguration);
+        newConfiguration.triggerUpdates(oldConfiguration);
+        return newConfiguration;
+    }
+
+    private void triggerUpdates(ComponentConfiguration oldConfiguration) {
+        if (this.equals(oldConfiguration)) {
+            return;
+        }
+        if (hasRateLimitsChanged(oldConfiguration)) {
+            rateLimitsConfiguration.triggerUpdates();
+        }
+    }
+
+    private boolean hasRateLimitsChanged(ComponentConfiguration oldConfiguration) {
+        if (oldConfiguration == null) {
+            return true;
+        }
+        return rateLimitsConfiguration.hasChanged(oldConfiguration.rateLimitsConfiguration);
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/RateLimitsConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/RateLimitsConfiguration.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.configuration;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.shadowmanager.ipc.InboundRateLimiter;
+import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
+import com.aws.greengrass.shadowmanager.util.Validator;
+import com.aws.greengrass.util.Coerce;
+import lombok.Getter;
+
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_RATE_LIMITS_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_LOCAL_REQUESTS_RATE;
+import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS;
+import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_TOTAL_LOCAL_REQUESTS_RATE;
+
+public final class RateLimitsConfiguration {
+    @Getter
+    private final int maxTotalLocalRequestRate;
+    @Getter
+    private final int maxLocalRequestRatePerThing;
+    @Getter
+    private final int maxOutboundUpdatesPerSecond;
+    private final InboundRateLimiter inboundRateLimiter;
+    private final IotDataPlaneClientWrapper iotDataPlaneClientWrapper;
+
+    private static int getMaxTotalLocalRequestRateFromTopics(Topics rateLimitsTopics) {
+        int maxTotalLocalRequestRate = Coerce.toInt(rateLimitsTopics
+                .lookup(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE)
+                .dflt(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE));
+        Validator.validateTotalLocalRequestRate(maxTotalLocalRequestRate);
+        return maxTotalLocalRequestRate;
+    }
+
+    private static int getMaxLocalRequestRatePerThingFromTopics(Topics rateLimitsTopics) {
+        int maxLocalRequestRatePerThing = Coerce.toInt(rateLimitsTopics
+                .lookup(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC)
+                .dflt(DEFAULT_LOCAL_REQUESTS_RATE));
+        Validator.validateLocalShadowRequestsPerThingPerSecond(maxLocalRequestRatePerThing);
+        return maxLocalRequestRatePerThing;
+    }
+
+    private static int getMaxOutboundUpdatesPerSecondFromTopics(Topics rateLimitsTopics) {
+        int maxOutboundUpdatesPerSecond = Coerce.toInt(rateLimitsTopics
+                .lookup(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC)
+                .dflt(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS));
+        Validator.validateOutboundSyncUpdatesPerSecond(maxOutboundUpdatesPerSecond);
+        return maxOutboundUpdatesPerSecond;
+    }
+
+    private RateLimitsConfiguration(Topics topics) {
+        Topics rateLimitsTopics = topics.lookupTopics(CONFIGURATION_RATE_LIMITS_TOPIC);
+        maxTotalLocalRequestRate = getMaxTotalLocalRequestRateFromTopics(rateLimitsTopics);
+        maxLocalRequestRatePerThing = getMaxLocalRequestRatePerThingFromTopics(rateLimitsTopics);
+        maxOutboundUpdatesPerSecond = getMaxOutboundUpdatesPerSecondFromTopics(rateLimitsTopics);
+        inboundRateLimiter = topics.getContext().get(InboundRateLimiter.class);
+        iotDataPlaneClientWrapper = topics.getContext().get(IotDataPlaneClientWrapper.class);
+    }
+
+    public static RateLimitsConfiguration from(Topics serviceTopics) {
+        return new RateLimitsConfiguration(serviceTopics);
+    }
+
+    /**
+     * Updates request rate limits with the latest configuration of the component.
+     */
+    public void triggerUpdates() {
+        inboundRateLimiter.setRate(maxLocalRequestRatePerThing);
+        inboundRateLimiter.setTotalRate(maxTotalLocalRequestRate);
+        iotDataPlaneClientWrapper.setRate(maxOutboundUpdatesPerSecond);
+    }
+
+    /**
+     * Compares current configuration with the previous configuration.
+     *
+     * @param oldRateLimitsConfiguration previous rate limits configuration
+     * @return True if the configurations are different
+     */
+    public boolean hasChanged(RateLimitsConfiguration oldRateLimitsConfiguration) {
+        return !this.equals(oldRateLimitsConfiguration);
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/RateLimitsConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/RateLimitsConfiguration.java
@@ -28,24 +28,21 @@ public final class RateLimitsConfiguration {
 
     private static int getMaxTotalLocalRequestRateFromTopics(Topics rateLimitsTopics) {
         int maxTotalLocalRequestRate = Coerce.toInt(rateLimitsTopics
-                .lookup(CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE)
-                .dflt(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE));
+                .findOrDefault(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE, CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE));
         Validator.validateTotalLocalRequestRate(maxTotalLocalRequestRate);
         return maxTotalLocalRequestRate;
     }
 
     private static int getMaxLocalRequestRatePerThingFromTopics(Topics rateLimitsTopics) {
         int maxLocalRequestRatePerThing = Coerce.toInt(rateLimitsTopics
-                .lookup(CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC)
-                .dflt(DEFAULT_LOCAL_REQUESTS_RATE));
+                .findOrDefault(DEFAULT_LOCAL_REQUESTS_RATE, CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC));
         Validator.validateLocalShadowRequestsPerThingPerSecond(maxLocalRequestRatePerThing);
         return maxLocalRequestRatePerThing;
     }
 
     private static int getMaxOutboundUpdatesPerSecondFromTopics(Topics rateLimitsTopics) {
         int maxOutboundUpdatesPerSecond = Coerce.toInt(rateLimitsTopics
-                .lookup(CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC)
-                .dflt(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS));
+                .findOrDefault(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS, CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC));
         Validator.validateOutboundSyncUpdatesPerSecond(maxOutboundUpdatesPerSecond);
         return maxOutboundUpdatesPerSecond;
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/RateLimitsConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/RateLimitsConfiguration.java
@@ -59,7 +59,6 @@ public final class RateLimitsConfiguration {
                                     int maxOutboundUpdatesPerSecond,
                                     InboundRateLimiter inboundRateLimiter,
                                     IotDataPlaneClientWrapper iotDataPlaneClientWrapper) {
-
         this.maxLocalRequestRatePerThing = maxLocalRequestRatePerThing;
         this.maxTotalLocalRequestRate = maxTotalLocalRequestRate;
         this.maxOutboundUpdatesPerSecond = maxOutboundUpdatesPerSecond;
@@ -82,21 +81,17 @@ public final class RateLimitsConfiguration {
     /**
      * Creates a new rate limits configuration object and triggers updates based on previous configuration.
      *
-     * @param oldConfiguration previous configuration of the component
+     * @param oldRateLimitsConfig previous rate limits configuration of the component
      * @param serviceTopics    current configuration topics
      * @return rate limits configuration objects
      */
-    public static RateLimitsConfiguration from(ComponentConfiguration oldConfiguration, Topics serviceTopics) {
+    public static RateLimitsConfiguration from(RateLimitsConfiguration oldRateLimitsConfig, Topics serviceTopics) {
         RateLimitsConfiguration rateLimitsConfiguration = getRateLimitsConfigurationFromTopics(serviceTopics);
-        rateLimitsConfiguration.triggerUpdates(oldConfiguration);
+        rateLimitsConfiguration.triggerUpdates(oldRateLimitsConfig);
         return rateLimitsConfiguration;
     }
 
-    private void triggerUpdates(ComponentConfiguration oldComponentConfiguration) {
-        RateLimitsConfiguration oldRateLimitsConfiguration = null;
-        if (oldComponentConfiguration != null) {
-            oldRateLimitsConfiguration = oldComponentConfiguration.rateLimitsConfiguration;
-        }
+    private void triggerUpdates(RateLimitsConfiguration oldRateLimitsConfiguration) {
         if (hasMaxLocalRequestPerThingChanged(oldRateLimitsConfiguration)) {
             inboundRateLimiter.setRate(maxLocalRequestRatePerThing);
         }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/InboundRateLimiter.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/InboundRateLimiter.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.shadowmanager.ipc;
 
 
+import com.aws.greengrass.shadowmanager.configuration.RateLimitsConfiguration;
 import com.aws.greengrass.shadowmanager.exception.ThrottledRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -88,5 +89,10 @@ public class InboundRateLimiter {
     public void setRate(int rate) {
         ratePerThing.set(rate);
         rateLimitersPerThing.forEach((k, v) -> v.setRate(ratePerThing.get()));
+    }
+
+    public void updateRateLimits(RateLimitsConfiguration rateLimitsConfiguration) {
+        setTotalRate(rateLimitsConfiguration.getMaxTotalLocalRequestRate());
+        setRate(rateLimitsConfiguration.getMaxLocalRequestRatePerThing());
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/InboundRateLimiter.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/InboundRateLimiter.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.shadowmanager.ipc;
 
 
-import com.aws.greengrass.shadowmanager.configuration.RateLimitsConfiguration;
 import com.aws.greengrass.shadowmanager.exception.ThrottledRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -91,8 +90,8 @@ public class InboundRateLimiter {
         rateLimitersPerThing.forEach((k, v) -> v.setRate(ratePerThing.get()));
     }
 
-    public void updateRateLimits(RateLimitsConfiguration rateLimitsConfiguration) {
-        setTotalRate(rateLimitsConfiguration.getMaxTotalLocalRequestRate());
-        setRate(rateLimitsConfiguration.getMaxLocalRequestRatePerThing());
+    public void updateRateLimits(int totalRequestRate, int totalRequestRatePerThing) {
+        setTotalRate(totalRequestRate);
+        setRate(totalRequestRatePerThing);
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.shadowmanager.sync;
 
+import com.aws.greengrass.shadowmanager.configuration.RateLimitsConfiguration;
 import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationException;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest;
@@ -42,12 +43,11 @@ public class IotDataPlaneClientWrapper {
     }
 
     /**
-     * Sets the rate for the RateLimiter for outbound requests.
-     *
-     * @param rate Max outbound requests per second
+     * Set max outbound updates per second from configuration.
+     * @param rateLimitsConfiguration rate limits configuration object
      */
-    public void setRate(int rate) {
-        rateLimiter.setRate(rate);
+    public void updateRateLimits(RateLimitsConfiguration rateLimitsConfiguration) {
+        rateLimiter.setRate(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond());
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.shadowmanager.sync;
 
-import com.aws.greengrass.shadowmanager.configuration.RateLimitsConfiguration;
 import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationException;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest;
@@ -44,10 +43,10 @@ public class IotDataPlaneClientWrapper {
 
     /**
      * Set max outbound updates per second from configuration.
-     * @param rateLimitsConfiguration rate limits configuration object
+     * @param maxOutboundUpdatesPerSecond maxOutboundUpdatesPerSecond
      */
-    public void updateRateLimits(RateLimitsConfiguration rateLimitsConfiguration) {
-        rateLimiter.setRate(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond());
+    public void updateRateLimits(int maxOutboundUpdatesPerSecond) {
+        rateLimiter.setRate(maxOutboundUpdatesPerSecond);
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.configuration;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.shadowmanager.exception.InvalidConfigurationException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_RATE_LIMITS_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_LOCAL_REQUESTS_RATE;
+import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS;
+import static com.aws.greengrass.shadowmanager.model.Constants.DEFAULT_TOTAL_LOCAL_REQUESTS_RATE;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class RateLimitConfigurationTest extends GGServiceTestUtil {
+    private Topics configurationTopics;
+    private final static int RATE_LIMIT = 500;
+
+
+    @BeforeEach
+    void beforeEach() {
+        configurationTopics = Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        configurationTopics.getContext().close();
+    }
+
+
+    @Test
+    public void GIVEN_default_configuration_WHEN_getMaxLocalRequestRatePerThing_THEN_return_default() {
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        assertThat(rateLimitsConfiguration.getMaxLocalRequestRatePerThing(), is(DEFAULT_LOCAL_REQUESTS_RATE));
+    }
+
+    @Test
+    public void GIVEN_default_configuration_WHEN_getMaxTotalLocalRequestRate_THEN_return_default() {
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        assertThat(rateLimitsConfiguration.getMaxTotalLocalRequestRate(), is(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE));
+    }
+
+    @Test
+    public void GIVEN_default_configuration_WHEN_getMaxOutboundUpdatesPerSecond_THEN_return_default() {
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        assertThat(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond(), is(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS));
+    }
+
+    @Test
+    public void GIVEN_good_maxLocalRequestRatePerThing_WHEN_getMaxLocalRequestRatePerThing_THEN_return_from_config() {
+        configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
+                CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC).withValue(RATE_LIMIT);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        assertThat(rateLimitsConfiguration.getMaxLocalRequestRatePerThing(), is(RATE_LIMIT));
+    }
+
+    @Test
+    public void GIVEN_bad_getMaxLocalRequestRatePerThing_WHEN_getMaxLocalRequestRatePerThing_THEN_return_from_config(ExtensionContext extensionContext) {
+        ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
+        configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
+                CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC).withValue(-1);
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
+    }
+
+    @Test
+    public void GIVEN_good_maxTotalLocalRequestRate_WHEN_getMaxTotalLocalRequestRate_THEN_return_from_config() {
+        configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
+                CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE).withValue(RATE_LIMIT);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        assertThat(rateLimitsConfiguration.getMaxTotalLocalRequestRate(), is(RATE_LIMIT));
+    }
+
+    @Test
+    public void GIVEN_bad_maxTotalLocalRequestRate_WHEN_getMaxTotalLocalRequestRate_THEN_return_from_config(ExtensionContext extensionContext) {
+        ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
+        configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
+                CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE).withValue(-1);
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
+    }
+
+    @Test
+    public void GIVEN_good_maxOutboundUpdatesPS_WHEN_getMaxOutboundUpdatesPerSecond_THEN_return_from_config() {
+        configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
+                CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC).withValue(RATE_LIMIT);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        assertThat(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond(), is(RATE_LIMIT));
+    }
+
+    @Test
+    public void GIVEN_bad_maxLocalRequestRatePerThing_WHEN_getMaxLocalRequestRatePerThing_THEN_return_from_config(ExtensionContext extensionContext) {
+        ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
+        configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
+                CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC).withValue(-1);
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
+    }
+}
+

--- a/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
@@ -34,13 +34,10 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class RateLimitConfigurationTest extends GGServiceTestUtil {
     private Topics configurationTopics;
-    private final static RateLimitsConfiguration oldConfiguration = null;
     private final static int RATE_LIMIT = 500;
     @Mock
     private InboundRateLimiter mockInboundRateLimiter;
@@ -64,32 +61,28 @@ class RateLimitConfigurationTest extends GGServiceTestUtil {
 
     @Test
     public void GIVEN_default_configuration_WHEN_getMaxLocalRequestRatePerThing_THEN_return_default() {
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxLocalRequestRatePerThing(), is(DEFAULT_LOCAL_REQUESTS_RATE));
-        verify(mockInboundRateLimiter, times(1)).setRate(DEFAULT_LOCAL_REQUESTS_RATE);
     }
 
     @Test
     public void GIVEN_default_configuration_WHEN_getMaxTotalLocalRequestRate_THEN_return_default() {
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxTotalLocalRequestRate(), is(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE));
-        verify(mockInboundRateLimiter, times(1)).setTotalRate(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE);
     }
 
     @Test
     public void GIVEN_default_configuration_WHEN_getMaxOutboundUpdatesPerSecond_THEN_return_default() {
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond(), is(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS));
-        verify(mockIotDataPlaneClientWrapper, times(1)).setRate(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS);
     }
 
     @Test
     public void GIVEN_good_maxLocalRequestRatePerThing_WHEN_getMaxLocalRequestRatePerThing_THEN_return_from_config() {
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC).withValue(RATE_LIMIT);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxLocalRequestRatePerThing(), is(RATE_LIMIT));
-        verify(mockInboundRateLimiter, times(1)).setRate(RATE_LIMIT);
     }
 
     @Test
@@ -97,17 +90,15 @@ class RateLimitConfigurationTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC).withValue(-1);
-        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(oldConfiguration, configurationTopics));
-        verify(mockInboundRateLimiter, times(0)).setRate(RATE_LIMIT);
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
     }
 
     @Test
     public void GIVEN_good_maxTotalLocalRequestRate_WHEN_getMaxTotalLocalRequestRate_THEN_return_from_config() {
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE).withValue(RATE_LIMIT);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxTotalLocalRequestRate(), is(RATE_LIMIT));
-        verify(mockInboundRateLimiter, times(1)).setTotalRate(RATE_LIMIT);
     }
 
     @Test
@@ -115,17 +106,15 @@ class RateLimitConfigurationTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE).withValue(-1);
-        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(oldConfiguration, configurationTopics));
-        verify(mockInboundRateLimiter, times(0)).setTotalRate(RATE_LIMIT);
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
     }
 
     @Test
     public void GIVEN_good_maxOutboundUpdatesPS_WHEN_getMaxOutboundUpdatesPerSecond_THEN_return_from_config() {
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC).withValue(RATE_LIMIT);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond(), is(RATE_LIMIT));
-        verify(mockIotDataPlaneClientWrapper, times(1)).setRate(RATE_LIMIT);
     }
 
     @Test
@@ -133,8 +122,7 @@ class RateLimitConfigurationTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC).withValue(-1);
-        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(oldConfiguration, configurationTopics));
-        verify(mockIotDataPlaneClientWrapper, times(0)).setRate(RATE_LIMIT);
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
     }
 }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
@@ -8,6 +8,8 @@ package com.aws.greengrass.shadowmanager.configuration;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.shadowmanager.exception.InvalidConfigurationException;
+import com.aws.greengrass.shadowmanager.ipc.InboundRateLimiter;
+import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.GGServiceTestUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
@@ -31,48 +34,62 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class RateLimitConfigurationTest extends GGServiceTestUtil {
     private Topics configurationTopics;
+    private final static ComponentConfiguration oldConfiguration = null;
     private final static int RATE_LIMIT = 500;
-
+    @Mock
+    private InboundRateLimiter mockInboundRateLimiter;
+    @Mock
+    private IotDataPlaneClientWrapper mockIotDataPlaneClientWrapper;
+    private Context context;
 
     @BeforeEach
     void beforeEach() {
-        configurationTopics = Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null);
+        context = new Context();
+        configurationTopics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
+        context.put(InboundRateLimiter.class, mockInboundRateLimiter);
+        context.put(IotDataPlaneClientWrapper.class, mockIotDataPlaneClientWrapper);
     }
 
     @AfterEach
     void afterEach() throws IOException {
-        configurationTopics.getContext().close();
+        context.close();
     }
 
 
     @Test
     public void GIVEN_default_configuration_WHEN_getMaxLocalRequestRatePerThing_THEN_return_default() {
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxLocalRequestRatePerThing(), is(DEFAULT_LOCAL_REQUESTS_RATE));
+        verify(mockInboundRateLimiter, times(1)).setRate(DEFAULT_LOCAL_REQUESTS_RATE);
     }
 
     @Test
     public void GIVEN_default_configuration_WHEN_getMaxTotalLocalRequestRate_THEN_return_default() {
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxTotalLocalRequestRate(), is(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE));
+        verify(mockInboundRateLimiter, times(1)).setTotalRate(DEFAULT_TOTAL_LOCAL_REQUESTS_RATE);
     }
 
     @Test
     public void GIVEN_default_configuration_WHEN_getMaxOutboundUpdatesPerSecond_THEN_return_default() {
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond(), is(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS));
+        verify(mockIotDataPlaneClientWrapper, times(1)).setRate(DEFAULT_MAX_OUTBOUND_SYNC_UPDATES_PS);
     }
 
     @Test
     public void GIVEN_good_maxLocalRequestRatePerThing_WHEN_getMaxLocalRequestRatePerThing_THEN_return_from_config() {
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC).withValue(RATE_LIMIT);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxLocalRequestRatePerThing(), is(RATE_LIMIT));
+        verify(mockInboundRateLimiter, times(1)).setRate(RATE_LIMIT);
     }
 
     @Test
@@ -80,15 +97,17 @@ class RateLimitConfigurationTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_LOCAL_REQUESTS_RATE_PER_THING_TOPIC).withValue(-1);
-        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(oldConfiguration, configurationTopics));
+        verify(mockInboundRateLimiter, times(0)).setRate(RATE_LIMIT);
     }
 
     @Test
     public void GIVEN_good_maxTotalLocalRequestRate_WHEN_getMaxTotalLocalRequestRate_THEN_return_from_config() {
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE).withValue(RATE_LIMIT);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxTotalLocalRequestRate(), is(RATE_LIMIT));
+        verify(mockInboundRateLimiter, times(1)).setTotalRate(RATE_LIMIT);
     }
 
     @Test
@@ -96,15 +115,17 @@ class RateLimitConfigurationTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_TOTAL_LOCAL_REQUESTS_RATE).withValue(-1);
-        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(oldConfiguration, configurationTopics));
+        verify(mockInboundRateLimiter, times(0)).setTotalRate(RATE_LIMIT);
     }
 
     @Test
     public void GIVEN_good_maxOutboundUpdatesPS_WHEN_getMaxOutboundUpdatesPerSecond_THEN_return_from_config() {
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC).withValue(RATE_LIMIT);
-        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(configurationTopics);
+        RateLimitsConfiguration rateLimitsConfiguration = RateLimitsConfiguration.from(oldConfiguration, configurationTopics);
         assertThat(rateLimitsConfiguration.getMaxOutboundUpdatesPerSecond(), is(RATE_LIMIT));
+        verify(mockIotDataPlaneClientWrapper, times(1)).setRate(RATE_LIMIT);
     }
 
     @Test
@@ -112,7 +133,8 @@ class RateLimitConfigurationTest extends GGServiceTestUtil {
         ignoreExceptionOfType(extensionContext, InvalidConfigurationException.class);
         configurationTopics.lookup(CONFIGURATION_RATE_LIMITS_TOPIC,
                 CONFIGURATION_MAX_OUTBOUND_UPDATES_PS_TOPIC).withValue(-1);
-        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(configurationTopics));
+        assertThrows(InvalidConfigurationException.class, () -> RateLimitsConfiguration.from(oldConfiguration, configurationTopics));
+        verify(mockIotDataPlaneClientWrapper, times(0)).setRate(RATE_LIMIT);
     }
 }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/configuration/RateLimitConfigurationTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class RateLimitConfigurationTest extends GGServiceTestUtil {
     private Topics configurationTopics;
-    private final static ComponentConfiguration oldConfiguration = null;
+    private final static RateLimitsConfiguration oldConfiguration = null;
     private final static int RATE_LIMIT = 500;
     @Mock
     private InboundRateLimiter mockInboundRateLimiter;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Read and trigger configuration updates from the component configuration object whenever it is updated. This PR only moves rate limits configuration. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
