### PR TITLE
fix: set correct strategy when the config is updated

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -15,6 +15,8 @@ import com.aws.greengrass.shadowmanager.model.LogEvents;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
+import com.aws.greengrass.shadowmanager.sync.strategy.PeriodicSyncStrategy;
+import com.aws.greengrass.shadowmanager.sync.strategy.RealTimeSyncStrategy;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Pair;
 import org.flywaydb.core.api.FlywayException;
@@ -39,6 +41,7 @@ import static com.aws.greengrass.shadowmanager.TestUtils.THING_NAME;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_CLASSIC_SHADOW_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_NAMED_SHADOWS_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SHADOW_DOCUMENTS_TOPIC;
+import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_STRATEGY_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNCHRONIZATION_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNC_DIRECTION_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_THING_NAME_TOPIC;
@@ -46,6 +49,7 @@ import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_THI
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -209,5 +213,36 @@ class ShadowManagerTest extends NucleusLaunchUtils {
         kernel.getContext().waitForPublishQueueToClear();
 
         assertThat(syncHandler.getSyncDirection(), is(Direction.DEVICE_TO_CLOUD));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.CloseResource")
+    void GIVEN_shadow_manager_WHEN_strategy_config_resets_THEN_respond_to_config_updates(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, SkipSyncRequestException.class);
+        MqttClient mqttClient = mock(MqttClient.class);
+        lenient().when(mqttClient.connected()).thenReturn(false);
+
+
+        kernel.getContext().put(MqttClient.class, mqttClient);
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder()
+                .configFile("periodic_sync.yaml")
+                .mqttConnected(false)
+                .syncClazz(PeriodicSyncStrategy.class)
+                .build());
+
+        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
+        assertThat(syncHandler.getOverallSyncStrategy(), instanceOf(PeriodicSyncStrategy.class));
+
+        shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC).remove();
+        kernel.getContext().waitForPublishQueueToClear();
+        assertThat(syncHandler.getOverallSyncStrategy(), instanceOf(RealTimeSyncStrategy.class));
+
+        Map<String, Object> periodicStrategy = new HashMap<>();
+        periodicStrategy.put("delay", "30");
+        periodicStrategy.put("type","periodic");
+        shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_STRATEGY_TOPIC).replaceAndWait(periodicStrategy);
+        kernel.getContext().waitForPublishQueueToClear();
+        assertThat(syncHandler.getOverallSyncStrategy(), instanceOf(PeriodicSyncStrategy.class));
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -102,6 +102,7 @@ public class ShadowManager extends PluginService {
     private final CloudDataClient cloudDataClient;
     private final MqttClient mqttClient;
     private final PubSubIntegrator pubSubIntegrator;
+    private final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
     public final MqttClientConnectionEvents callbacks = new MqttClientConnectionEvents() {
         @Override
         public void onConnectionInterrupted(int errorCode) {
@@ -111,7 +112,7 @@ public class ShadowManager extends PluginService {
         @Override
         public void onConnectionResumed(boolean sessionPresent) {
             if (inState(State.RUNNING)) {
-                startSyncingShadows(StartSyncInfo.builder().startSyncStrategy(true).startSyncStrategy(true)
+                startSyncingShadows(StartSyncInfo.builder().startSyncStrategy(true)
                         .updateCloudSubscriptions(true).build());
 
             }
@@ -240,7 +241,7 @@ public class ShadowManager extends PluginService {
 
         inboundRateLimiter.clear();
         config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((what, newv) -> {
-            if (what.equals(WhatHappened.timestampUpdated)) {
+            if (what.equals(WhatHappened.timestampUpdated) || what.equals(WhatHappened.interiorAdded)) {
                 return;
             }
             if (installConfig.configureSynchronizeConfig) {
@@ -409,7 +410,6 @@ public class ShadowManager extends PluginService {
                 .setEventType("config")
                 .kv("syncStrategy", strategy.getType().getCode())
                 .log();
-        final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
         currentStrategy.set(replaceStrategyIfNecessary(currentStrategy.get(), strategy));
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When the strategy config is updated from periodic to real time (can also happen during reset), overall sync strategy is not set to real time. This fix properly updates the strategy after comparing with the current strategy. 

**Why is this change necessary:**

**How was this change tested:**
Added an integration test that fails without this fix. 

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
