### PR TITLE
test: remove assertNotEmptySyncQueue check

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -188,16 +188,4 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
         assertThat("sync queue is eventually empty", () -> q.isEmpty() && !s.isExecuting(),
                 eventuallyEval(is(true), Duration.ofSeconds(10)));
     }
-
-    protected void assertNotEmptySyncQueue(Class<? extends BaseSyncStrategy> clazz) {
-        BaseSyncStrategy s = kernel.getContext().get(clazz);
-
-        assertThat("syncing has started", s::isSyncing, eventuallyEval(is(true)));
-
-        RequestBlockingQueue q = s.getSyncQueue();
-
-        // queue is eventually empty (full syncs are added and then eventually removed)
-        assertThat("sync queue is eventually not empty", () -> !q.isEmpty(),
-                eventuallyEval(is(true), Duration.ofSeconds(10)));
-    }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowRespo
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -139,11 +140,13 @@ class SyncDirectionalityTest extends NucleusLaunchUtils {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, ResourceNotFoundError.class);
-
+        CountDownLatch cdl = new CountDownLatch(4); // 4 shadows in the config file
         // no shadow exists in cloud
-        when(iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(any(GetThingShadowRequest.class)))
-                .thenThrow(ResourceNotFoundException.class);
-
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()
+                .getThingShadow(any(GetThingShadowRequest.class))).thenAnswer(invocation -> {
+            cdl.countDown();
+            throw ResourceNotFoundException.builder().build();
+        });
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder()
                 .configFile("sync_directionality_fromcloudonly.yaml")
                 .mockCloud(true)
@@ -152,9 +155,8 @@ class SyncDirectionalityTest extends NucleusLaunchUtils {
         shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().build());
         // There is a race condition which can cause us to check queue is empty before having inserted any full sync
         // requests in it. This check avoids that.
-        assertNotEmptySyncQueue(RealTimeSyncStrategy.class);
+        assertThat("all the sync requests are processed", cdl.await(10, TimeUnit.SECONDS), is(true));
         assertEmptySyncQueue(RealTimeSyncStrategy.class);
-
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
 
         // update local shadow

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -403,7 +403,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .syncClazz(clazz)
                 .mockCloud(true)
                 .build());
-
+        assertEmptySyncQueue(clazz);
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
 
         // update local shadow


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix two tests with possible race conditions. 
- In the tests GIVEN_cloud_sync_not_enabled_WHEN_local_update_THEN_does_not_sync_shadow_to_cloud, we check  if the sync queue is not empty right before checking if it's empty. It is not always guaranteed that both of them will hold true due to timing of the tests. So, remove checking if the queue is not empty completely instead check if the certain number of requests (all) are processed from that queue.
- In the GIVEN_synced_shadow_WHEN_local_update_THEN_cloud_updates, before making an IPC request, this change will make sure that all the requests before that are processed. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
