### PR TITLE
test: check that requests are retried when the crypto key service is still loading

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -293,7 +293,6 @@ class ShadowManagerTest extends NucleusLaunchUtils {
         BaseSyncStrategy syncStrategy = kernel.getContext().get(RealTimeSyncStrategy.class);
         assertThat("syncing has started", syncStrategy::isSyncing, eventuallyEval(is(true)));
         verify(wrapper, timeout(5000).atLeast(1)).getThingShadow("Thing1", "");
-        verify(securityService, timeout(5000).atLeast(3)).getDeviceIdentityKeyManagers();
 
         // This test ensures that the request is retried again as the we're not mocking cloud and data plane client
         // creation fails. If the data plane client creation succeeds, the request is processed once again.

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -271,8 +271,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
         ignoreExceptionOfType(context, RetryableException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
-        IotDataPlaneClientFactory factory = spy(kernel.getContext().get(IotDataPlaneClientFactory.class));
-        kernel.getContext().put(IotDataPlaneClientFactory.class, factory);
+        IotDataPlaneClientFactory factory = kernel.getContext().get(IotDataPlaneClientFactory.class);
         IotDataPlaneClientWrapper wrapper = spy(new FakeIotDataPlaneClientWrapper(factory));
         kernel.getContext().put(IotDataPlaneClientWrapper.class, wrapper);
 
@@ -281,8 +280,8 @@ class ShadowManagerTest extends NucleusLaunchUtils {
                 .mqttConnected(true)
                 .mockCloud(false)
                 .build());
-        BaseSyncStrategy syncStragy = kernel.getContext().get(RealTimeSyncStrategy.class);
-        assertThat("syncing has started", s::isSyncing, eventuallyEval(is(true)));
+        BaseSyncStrategy syncStrategy = kernel.getContext().get(RealTimeSyncStrategy.class);
+        assertThat("syncing has started", syncStrategy::isSyncing, eventuallyEval(is(true)));
         verify(wrapper, timeout(5000).atLeast(1)).getThingShadow("Thing1", "");
 
         CountDownLatch cdl = new CountDownLatch(1);
@@ -294,6 +293,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
         kernel.getContext().put(SecurityService.class, ss);
         assertThat("request is retried with a new client",cdl.await(10, TimeUnit.SECONDS), is(true));
         verify(wrapper, timeout(5000).atLeast(2)).getThingShadow("Thing1", "");
+        assertEmptySyncQueue(RealTimeSyncStrategy.class);
     }
 
     static class FakeIotDataPlaneClientWrapper extends  IotDataPlaneClientWrapper{

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -281,7 +281,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
                 .mqttConnected(true)
                 .mockCloud(false)
                 .build());
-        BaseSyncStrategy s = kernel.getContext().get(RealTimeSyncStrategy.class);
+        BaseSyncStrategy syncStragy = kernel.getContext().get(RealTimeSyncStrategy.class);
         assertThat("syncing has started", s::isSyncing, eventuallyEval(is(true)));
         verify(wrapper, timeout(5000).atLeast(1)).getThingShadow("Thing1", "");
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -285,7 +285,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
         assertThat("syncing has started", s::isSyncing, eventuallyEval(is(true)));
         verify(wrapper, timeout(5000).atLeast(1)).getThingShadow("Thing1", "");
 
-        CountDownLatch cdl=new CountDownLatch(1);
+        CountDownLatch cdl = new CountDownLatch(1);
         SecurityService ss= mock(SecurityService.class);
         when(ss.getDeviceIdentityKeyManagers()).thenAnswer((invocation)->{
             cdl.countDown();

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.shadowmanager.sync;
 
 import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationException;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.iotdataplane.IotDataPlaneClient;
 import software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest;
 import software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowResponse;
 import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowRequest;
@@ -58,12 +57,10 @@ public class IotDataPlaneClientWrapper {
      * @param shadowName The shadow name associated with the sync shadow update
      * @throws IoTDataPlaneClientCreationException when the iot data plane client is not created
      */
-    @SuppressWarnings("PMD.CloseResource")
     public DeleteThingShadowResponse deleteThingShadow(String thingName, String shadowName)
             throws IoTDataPlaneClientCreationException {
-        IotDataPlaneClient client = iotDataPlaneClientFactory.getIotDataPlaneClient();
         rateLimiter.acquire();
-        return client.deleteThingShadow(DeleteThingShadowRequest.builder()
+        return iotDataPlaneClientFactory.getIotDataPlaneClient().deleteThingShadow(DeleteThingShadowRequest.builder()
                 .thingName(thingName)
                 .shadowName(shadowName)
                 .build());
@@ -77,12 +74,10 @@ public class IotDataPlaneClientWrapper {
      * @param payload    The update payload
      * @throws IoTDataPlaneClientCreationException when the iot data plane client is not created
      */
-    @SuppressWarnings("PMD.CloseResource")
     public UpdateThingShadowResponse updateThingShadow(String thingName, String shadowName, byte[] payload)
             throws IoTDataPlaneClientCreationException {
-        IotDataPlaneClient client = iotDataPlaneClientFactory.getIotDataPlaneClient();
         rateLimiter.acquire();
-        return client.updateThingShadow(UpdateThingShadowRequest.builder()
+        return iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(UpdateThingShadowRequest.builder()
                 .thingName(thingName)
                 .shadowName(shadowName)
                 .payload(SdkBytes.fromByteArray(payload)).build());
@@ -95,12 +90,10 @@ public class IotDataPlaneClientWrapper {
      * @param shadowName The shadow name associated with the sync shadow update
      * @throws IoTDataPlaneClientCreationException when the iot data plane client is not created
      */
-    @SuppressWarnings("PMD.CloseResource")
     public GetThingShadowResponse getThingShadow(String thingName, String shadowName)
             throws IoTDataPlaneClientCreationException {
-        IotDataPlaneClient client = iotDataPlaneClientFactory.getIotDataPlaneClient();
         rateLimiter.acquire();
-        return client.getThingShadow(GetThingShadowRequest.builder()
+        return iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(GetThingShadowRequest.builder()
                 .thingName(thingName)
                 .shadowName(shadowName).build());
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapper.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.shadowmanager.sync;
 
 import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationException;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.iotdataplane.IotDataPlaneClient;
 import software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowRequest;
 import software.amazon.awssdk.services.iotdataplane.model.DeleteThingShadowResponse;
 import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowRequest;
@@ -57,10 +58,12 @@ public class IotDataPlaneClientWrapper {
      * @param shadowName The shadow name associated with the sync shadow update
      * @throws IoTDataPlaneClientCreationException when the iot data plane client is not created
      */
+    @SuppressWarnings("PMD.CloseResource")
     public DeleteThingShadowResponse deleteThingShadow(String thingName, String shadowName)
             throws IoTDataPlaneClientCreationException {
+        IotDataPlaneClient client = iotDataPlaneClientFactory.getIotDataPlaneClient();
         rateLimiter.acquire();
-        return iotDataPlaneClientFactory.getIotDataPlaneClient().deleteThingShadow(DeleteThingShadowRequest.builder()
+        return client.deleteThingShadow(DeleteThingShadowRequest.builder()
                 .thingName(thingName)
                 .shadowName(shadowName)
                 .build());
@@ -74,10 +77,12 @@ public class IotDataPlaneClientWrapper {
      * @param payload    The update payload
      * @throws IoTDataPlaneClientCreationException when the iot data plane client is not created
      */
+    @SuppressWarnings("PMD.CloseResource")
     public UpdateThingShadowResponse updateThingShadow(String thingName, String shadowName, byte[] payload)
             throws IoTDataPlaneClientCreationException {
+        IotDataPlaneClient client = iotDataPlaneClientFactory.getIotDataPlaneClient();
         rateLimiter.acquire();
-        return iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(UpdateThingShadowRequest.builder()
+        return client.updateThingShadow(UpdateThingShadowRequest.builder()
                 .thingName(thingName)
                 .shadowName(shadowName)
                 .payload(SdkBytes.fromByteArray(payload)).build());
@@ -90,10 +95,12 @@ public class IotDataPlaneClientWrapper {
      * @param shadowName The shadow name associated with the sync shadow update
      * @throws IoTDataPlaneClientCreationException when the iot data plane client is not created
      */
+    @SuppressWarnings("PMD.CloseResource")
     public GetThingShadowResponse getThingShadow(String thingName, String shadowName)
             throws IoTDataPlaneClientCreationException {
+        IotDataPlaneClient client = iotDataPlaneClientFactory.getIotDataPlaneClient();
         rateLimiter.acquire();
-        return iotDataPlaneClientFactory.getIotDataPlaneClient().getThingShadow(GetThingShadowRequest.builder()
+        return client.getThingShadow(GetThingShadowRequest.builder()
                 .thingName(thingName)
                 .shadowName(shadowName).build());
     }

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapperTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/IotDataPlaneClientWrapperTest.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowReque
 import software.amazon.awssdk.services.iotdataplane.model.UpdateThingShadowResponse;
 import vendored.com.google.common.util.concurrent.RateLimiter;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
@@ -54,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -216,5 +218,29 @@ class IotDataPlaneClientWrapperTest {
         GetThingShadowRequest getThingShadowRequest = getThingShadowRequestArgumentCaptor.getValue();
         assertThat(getThingShadowRequest.thingName(), is(THING_NAME));
         assertThat(getThingShadowRequest.shadowName(), is(SHADOW_NAME));
+    }
+
+    @Test
+    void GIVEN_invalid_client_creation_WHEN_get_thing_shadow_THEN_throw_IoTDataPlaneClientCreationException() throws IoTDataPlaneClientCreationException {
+        reset(iotDataPlaneClientFactory);
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()).thenThrow(IoTDataPlaneClientCreationException.class);
+        IotDataPlaneClientWrapper iotDataPlaneClientWrapper = new IotDataPlaneClientWrapper(iotDataPlaneClientFactory);
+        assertThrows(IoTDataPlaneClientCreationException.class, () -> iotDataPlaneClientWrapper.getThingShadow(THING_NAME, SHADOW_NAME));
+    }
+
+    @Test
+    void GIVEN_invalid_client_creation_WHEN_update_thing_shadow_THEN_throw_IoTDataPlaneClientCreationException() throws IoTDataPlaneClientCreationException {
+        reset(iotDataPlaneClientFactory);
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()).thenThrow(IoTDataPlaneClientCreationException.class);
+        IotDataPlaneClientWrapper iotDataPlaneClientWrapper = new IotDataPlaneClientWrapper(iotDataPlaneClientFactory);
+        assertThrows(IoTDataPlaneClientCreationException.class, () -> iotDataPlaneClientWrapper.updateThingShadow(THING_NAME, SHADOW_NAME,"".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void GIVEN_invalid_client_creation_WHEN_delete_thing_shadow_THEN_throw_IoTDataPlaneClientCreationException() throws IoTDataPlaneClientCreationException {
+        reset(iotDataPlaneClientFactory);
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()).thenThrow(IoTDataPlaneClientCreationException.class);
+        IotDataPlaneClientWrapper iotDataPlaneClientWrapper = new IotDataPlaneClientWrapper(iotDataPlaneClientFactory);
+        assertThrows(IoTDataPlaneClientCreationException.class, () -> iotDataPlaneClientWrapper.deleteThingShadow(THING_NAME, SHADOW_NAME));
     }
 }


### PR DESCRIPTION
…add tests

**Issue #, if available:**
Addressing comments from #135 
- Add integ test without mocking cloud to verify that the requests fail when the client does not exist and then retried along with the creation of a new client. 

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
