### PR TITLE
chore: exclude uat from top level uber jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,7 @@
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
                                         <exclude>org/h2/server/web/*</exclude>
+                                        <exclude>uat/*</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
**Description of changes:**
Excludes the `uat` folder's contents from getting included into the final uber jar

**Why is this change necessary:**
We are bloating the project with test related code if we don't do it.
