### PR TITLE
test: add assertion client and validate get shadow assertions in tests 

### DIFF
--- a/uat/custom-components/pom.xml
+++ b/uat/custom-components/pom.xml
@@ -59,5 +59,16 @@
             <version>1.7.30</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.9</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/uat/custom-components/src/main/java/com/aws/greengrass/utils/Client.java
+++ b/uat/custom-components/src/main/java/com/aws/greengrass/utils/Client.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.utils;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.client.HttpClients;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class Client implements AutoCloseable {
+    private final CloseableHttpClient httpClient;
+
+    public Client() {
+        httpClient = HttpClients.custom()
+                .setRetryHandler(new DefaultHttpRequestRetryHandler(5, false)).build();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (httpClient != null) {
+            httpClient.close();
+        }
+    }
+
+    public void sendAssertion(boolean success, String context, String message) throws IOException {
+        int defaultPort = (int) Double.parseDouble(System.getProperty("serverPort"));
+        sendAssertionWithCustomizedPort(success, context, message, defaultPort);
+    }
+
+    public void sendAssertionWithCustomizedPort(boolean success, String context, String message, int port)
+            throws IOException {
+        HttpPost httpPost = new HttpPost(
+                "http://localhost:" + port + "/assert");
+        httpPost.setEntity(new ByteArrayEntity(
+                (String.format("{\"success\": %s, \"context\": \"%s\", \"message\": \"%s\"}", success, context,
+                        message)).getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_JSON));
+        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+            response.getStatusLine().getStatusCode();
+        }
+    }
+}

--- a/uat/custom-components/src/main/resources/recipes/ShadowComponentPing.yaml
+++ b/uat/custom-components/src/main/resources/recipes/ShadowComponentPing.yaml
@@ -39,4 +39,4 @@ Manifests:
       - URI: classpath:/local-store/artifacts/custom-components.jar
     Lifecycle:
       Run: >-
-        java -Dlog.level=INFO -DcomponentName="ShadowComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/Operation}" "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/ShadowDocument}" "{configuration:/PageSize}" "{configuration:/NextToken}" "{configuration:/OperationTimeout}"
+        java -Dlog.level=INFO -DserverPort={configuration:/assertionServerPort} -DcomponentName="ShadowComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/Operation}" "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/ShadowDocument}" "{configuration:/PageSize}" "{configuration:/NextToken}" "{configuration:/OperationTimeout}"

--- a/uat/custom-components/src/main/resources/recipes/ShadowComponentPong.yaml
+++ b/uat/custom-components/src/main/resources/recipes/ShadowComponentPong.yaml
@@ -40,4 +40,4 @@ Manifests:
       - URI: classpath:/local-store/artifacts/custom-components.jar
     Lifecycle:
       Run: >-
-        java -Dlog.level=INFO -DcomponentName="ShadowComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/Operation}" "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/ShadowDocument}" "{configuration:/PageSize}" "{configuration:/NextToken}" "{configuration:/OperationTimeout}"
+        java -Dlog.level=INFO -DserverPort={configuration:/assertionServerPort} -DcomponentName="ShadowComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/Operation}" "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/ShadowDocument}" "{configuration:/PageSize}" "{configuration:/NextToken}" "{configuration:/OperationTimeout}"

--- a/uat/testing-features/src/main/resources/greengrass/features/shadow-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/shadow-1.feature
@@ -6,6 +6,7 @@ Feature: Greengrass V2 ShadowManager
     Background:
         Given my device is registered as a Thing
         And my device is running Greengrass
+        And I start an assertion server
         Given I create a Greengrass deployment with components
             | aws.greengrass.Cli        | LATEST |
             | aws.greengrass.ShadowManager | LATEST |
@@ -16,6 +17,7 @@ Feature: Greengrass V2 ShadowManager
     Scenario: Shadow-1-T1: As a developer, I can use the Greengrass local shadow service to UPDATE and GET a shadow from my component.
         When I install the component ShadowComponentPing from local store with configuration
             | key                    | value             |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation              | UpdateThingShadow |
             | ThingName              | testThing         |
             | ShadowName             | testShadow        |
@@ -23,15 +25,18 @@ Feature: Greengrass V2 ShadowManager
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         When I install the component ShadowComponentPong from local store with configuration
             | key                    | value             |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation              | GetThingShadow |
             | ThingName              | testThing         |
             | ShadowName             | testShadow        |
             | ShadowDocument         | {\"state\":{\"reported\":{\"color\":{\"r\":255,\"g\":255,\"b\":255},\"SomeKey\":\"SomeValue\"}}}         |
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+        Then I get 1 assertions with context "Retrieved matching shadow document"
 
     Scenario: Shadow-1-T2: As a developer, I can use the Greengrass local shadow service to UPDATE a shadow from my component.
         When I install the component ShadowComponentPing from local store with configuration
             | key                    | value              |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation              | UpdateThingShadow  |
             | ThingName              | testThing          |
             | ShadowName             | testShadow         |
@@ -39,6 +44,7 @@ Feature: Greengrass V2 ShadowManager
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         When I install the component ShadowComponentPong from local store with configuration
             | key                    | value             |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation              | UpdateThingShadow |
             | ThingName              | testThing         |
             | ShadowName             | testShadow        |
@@ -46,15 +52,18 @@ Feature: Greengrass V2 ShadowManager
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         And I update the component ShadowComponentPing with configuration
             | key            | value                    |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation      | GetThingShadow           |
             | ThingName      | testThing                |
             | ShadowName     | testShadow               |
             | ShadowDocument | {\"version\":2,\"state\":{\"reported\":{\"color\":{\"r\":255,\"g\":0,\"b\":0},\"SomeKey\":\"SomeOtherValue\"}}}  |
         Then the Greengrass deployment is COMPLETED on the device after 2 minutes
+        Then I get 1 assertions with context "Retrieved matching shadow document"
 
     Scenario: Shadow-1-T3: As a developer, I can use the Greengrass local shadow service to DELETE a shadow from my component.
         When I install the component ShadowComponentPing from local store with configuration
             | key                    | value                                                                                                     |
+            | assertionServerPort    | ${assertionServerPort}                                                                                    |
             | Operation              | UpdateThingShadow                                                                                         |
             | ThingName              | testThing                                                                                                 |
             | ShadowName             | testShadow                                                                                                |
@@ -62,12 +71,14 @@ Feature: Greengrass V2 ShadowManager
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         When I install the component ShadowComponentPong from local store with configuration
             | key            | value             |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation      | DeleteThingShadow |
             | ThingName      | testThing         |
             | ShadowName     | testShadow        |
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         And I update the component ShadowComponentPing with configuration
             | key            | value          |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation      | GetThingShadow |
             | ThingName      | testThing      |
             | ShadowName     | testShadow     |
@@ -76,12 +87,14 @@ Feature: Greengrass V2 ShadowManager
     Scenario: Shadow-1-T4: As a developer, I can use the Greengrass local shadow service to LIST Named Shadows from my component.
         When I install the component ShadowComponentPong from local store with configuration
             | key                    | value                                                                                                          |
+            | assertionServerPort    | ${assertionServerPort}                                                                                         |
             | Operation              | SetupListNamedShadowTest                                                                                       |
             | ThingName              | testThing                                                                                                      |
             | ShadowDocument         | {\"state\":{\"reported\":{\"color\":{\"r\":255,\"g\":255,\"b\":255},\"SomeKey\":\"SomeValue\"}}}               |
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         When I install the component ShadowComponentPing from local store with configuration
             | key       | value                    |
+            | assertionServerPort    | ${assertionServerPort} |
             | Operation | ListNamedShadowsForThing |
             | ThingName | testThing                |
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
@@ -89,18 +102,21 @@ Feature: Greengrass V2 ShadowManager
     Scenario: Shadow-1-T5: As a developer, I can use the Greengrass local shadow service to LIST Named Shadows from my component with pageSize and nextToken.
         When I install the component ShadowComponentPong from local store with configuration
             | key                    | value                                                                                                          |
+            | assertionServerPort    | ${assertionServerPort}                                                                                         |
             | Operation              | SetupListNamedShadowTest                                                                                       |
             | ThingName              | testThing                                                                                                      |
             | ShadowDocument         | {\"state\":{\"reported\":{\"color\":{\"r\":255,\"g\":255,\"b\":255},\"SomeKey\":\"SomeValue\"}}}               |
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         When I install the component ShadowComponentPing from local store with configuration
-            | key       | value                    |
+            | key       | value
+            | assertionServerPort    | ${assertionServerPort}   |
             | Operation | ListNamedShadowsForThing |
             | ThingName | testThing                |
             | PageSize  | 2                        |
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         And I update the component ShadowComponentPing with configuration
             | key       | value                    |
+            | assertionServerPort    | ${assertionServerPort}   |
             | Operation | ListNamedShadowsForThing |
             | ThingName | testThing                |
             | nextToken | 1uTRLnjIlNrqirv+CtW3bg== |


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Add assertion client in custom components and send assertions in the get shadow operation. 
- Assertions in delete and list will be added in  next PR and shadow-1-3 to shadow-1-13 will be updated accordingly. Assertions for update won't be added. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
