### PR TITLE
fix: update all core thing sync configurations when the core thing na…

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/coreThing.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/coreThing.yaml
@@ -1,0 +1,51 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.ShadowManager:
+    configuration:
+      synchronize:
+        coreThing:
+          classic: true
+          namedShadows:
+            - "coreShadow-0"
+            - "coreShadow-1"
+        shadowDocuments:
+          - thingName: Thing1
+            classic: true
+
+  main:
+    dependencies:
+      - DoAll
+  DoAll:
+    lifecycle:
+      startup: echo "Running"
+      shutdown: echo "Stopping"
+    dependencies:
+      - aws.greengrass.ShadowManager
+    configuration:
+      accessControl:
+        aws.greengrass.ShadowManager:
+          policyId1:
+            policyDescription: access to CRUD shadow operations
+            operations:
+              - 'aws.greengrass#GetThingShadow'
+              - 'aws.greengrass#UpdateThingShadow'
+              - 'aws.greengrass#DeleteThingShadow'
+            resources:
+              - '*'
+          policyId2:
+            policyDescription: access to list named shadows
+            operations:
+              - 'aws.greengrass#ListNamedShadowsForThing'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId3:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+            resources:
+              - '*'


### PR DESCRIPTION
…me changes

**Issue #, if available:**

**Description of changes:**
When the core thing name changes in the device configuration, we want all of the shadow sync configurations of the core thing to be updated.
For eg, for the core thing named `coreThing`, 3 shadows are configured in the shadow manager component as follows.

- coreThing-
- coreThing-nameShadow1
- coreThing-nameShadow2

Now, when the core thing name is updated to `newCoreThing`, we want the shadows to be updated as follows
- newCoreThing-
- newCoreThing-nameShadow1
- newCoreThing-nameShadow2
But that's not the case as we're updating only one of the above shadows as seen [here](https://github.com/aws-greengrass/aws-greengrass-shadow-manager/blob/9bc5c2495003cdc51a87efa8f027abdd0f1ed136/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java#L449). 

This change in the PR updates all the shadow sync configurations of a coreThing when it changes. 


**Why is this change necessary:**

**How was this change tested:**
Added an integration test to verify the same. 
**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
