### PR TITLE
fix: handle out-of-order cloud updates

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -94,6 +94,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("PMD.ExcessiveClassLength")
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class SyncTest extends NucleusLaunchUtils {
     public static final String MOCK_THING_NAME_1 = "Thing1";
@@ -1155,5 +1156,3 @@ class SyncTest extends NucleusLaunchUtils {
         assertThat(shadowDocument.toJson(false).get(SHADOW_DOCUMENT_STATE), is(JsonUtil.getPayloadJson(state.getBytes(UTF_8)).get().get(SHADOW_DOCUMENT_STATE)));
     }
 }
-
-

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -84,10 +84,12 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
 
         if (JsonUtil.hasVersion(oldValueJson) && JsonUtil.hasVersion(newValueJson)
                 && JsonUtil.getVersion(oldValueJson) > JsonUtil.getVersion(newValueJson)) {
-            // updates received out of order,
-            // merge newer version into older version
             oldValueJson = updateDocJson.get();
             newValueJson = currDocJson.get();
+            logger.atDebug()
+                    .log("Version {} received after version {}. Merging version {} into version {}",
+                            JsonUtil.getVersion(oldValueJson), JsonUtil.getVersion(newValueJson),
+                            JsonUtil.getVersion(newValueJson), JsonUtil.getVersion(oldValueJson));
         }
 
         JsonMerger.merge(oldValueJson, newValueJson);

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -82,8 +82,8 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
         JsonNode oldValueJson = currDocJson.get();
         JsonNode newValueJson = updateDocJson.get();
 
-        if (JsonUtil.hasVersion(oldValueJson) && JsonUtil.hasVersion(newValueJson) &&
-                JsonUtil.getVersion(oldValueJson) > JsonUtil.getVersion(newValueJson)) {
+        if (JsonUtil.hasVersion(oldValueJson) && JsonUtil.hasVersion(newValueJson)
+                && JsonUtil.getVersion(oldValueJson) > JsonUtil.getVersion(newValueJson)) {
             // updates received out of order,
             // merge newer version into older version
             oldValueJson = updateDocJson.get();

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -206,7 +206,7 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
 
     private void updateSyncInformationVersion(SyncContext context, ShadowDocument shadowDocument,
                                               SyncInformation currentSyncInformation) {
-        if (currentSyncInformation.getCloudVersion() != shadowDocument.getVersion()) {
+        if (currentSyncInformation.getCloudVersion() < shadowDocument.getVersion()) {
             try {
                 long updateTime = Instant.now().getEpochSecond();
                 context.getDao().updateSyncInformation(SyncInformation.builder()

--- a/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
@@ -269,4 +269,12 @@ public final class JsonUtil {
         }
         return result;
     }
+
+    public static boolean hasVersion(JsonNode document) {
+        return document.has(SHADOW_DOCUMENT_VERSION) && document.get(SHADOW_DOCUMENT_VERSION).isIntegralNumber();
+    }
+
+    public static long getVersion(JsonNode document) {
+        return document.get(SHADOW_DOCUMENT_VERSION).asLong();
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

When cloud updates are received over MQTT, there is a (small) chance that we can receive updates out-of-order.  Also, with the proposal of https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/166, cloud updates would be processed asynchronously, further increasing the chances of out-of-order processing.  

Functionally, when we receive out-of-order cloud updates (say, B then A), this is automatically detected and a ConflictError is thrown.  This causes a full sync, which puts the local shadow in sync with the cloud.

The first issue however, is when we receive the other out of order message (A, from the above example) after the conflict has been dealt with.  This update has the incorrect, previous cloud version, and will be written to the sync table.  Effectively, this will cause unnecessary full syncs, as more conflicts will be detected due to the discrepancy in cloud versions.

This change proposes that updates to the sync table will only be committed for new versions when a cloud update is received.

A second issue is when the out of order messages are merged together. Currently, the old version is merged into the new version, causing the merged document to have the older version.  This change addresses this by comparing versions before selecting merge order.

**Why is this change necessary:**

See above description

**How was this change tested:**

New integration tests

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
