### PR TITLE
fix(sync): synchronize access to shadow sync info

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -10,8 +10,10 @@ import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.shadowmanager.ShadowManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
+import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationException;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
@@ -632,6 +634,8 @@ class SyncTest extends NucleusLaunchUtils {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, ConflictError.class);
+        ignoreExceptionOfType(context, InvalidRequestParametersException.class);
+        ignoreExceptionOfType(context, SkipSyncRequestException.class);
 
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
                 .thenReturn(mockUpdateThingShadowResponse);

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
@@ -85,16 +85,13 @@ public class CloudUpdateSyncRequest extends BaseSyncRequest {
     @Override
     public void execute(SyncContext context) throws RetryableException, SkipSyncRequestException,
             ConflictException, UnknownShadowException, InterruptedException {
-        // synchronizing access to shadow sync information because it is accessed by multiple threads.
-        // In this method, shadow sync information is accessed within context of the sync thread.
-        // The other place is `isUpdateNecessary(SyncContext)`, which runs on the IPC thread.
+        // Synchronizing because shadow sync information is read/written by multiple threads:
+        // * during sync request execution (SyncRequest#execute)
+        // * during IPC request processing (SyncRequest#isUpdateNecessary(SyncContext)
         //
-        // Other types of sync requests don't need this lock because their implementation of
-        // `isUpdateNecessary(SyncContext)` does not access shadow sync information.
-        //
-        // The check for shadow sync information in this class' `isUpdateNecessary(SyncContext)`
-        // prevents unnecessary full syncs,
-        // (see https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/106).
+        // NOTE: checking the sync table during IPC request processing when deciding if a sync request should
+        //       be queued is required to prevent excessive full syncs
+        //       https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/106.
         synchronized (context.getSynchronizeHelper().getThingShadowLock(this)) {
             Optional<ShadowDocument> shadowDocument = context.getDao().getShadowThing(getThingName(), getShadowName());
 
@@ -190,9 +187,9 @@ public class CloudUpdateSyncRequest extends BaseSyncRequest {
      */
     @Override
     public boolean isUpdateNecessary(SyncContext context) throws SkipSyncRequestException, UnknownShadowException {
-        // synchronizing access to shadow sync information because it is accessed by multiple threads.
-        // In this method, shadow sync information is accessed within context of an IPC thread.
-        // The other place is the 'execute' method of this class, which runs on the sync thread.
+        // Synchronizing because shadow sync information is read/written by multiple threads:
+        // * during sync request execution (SyncRequest#execute)
+        // * during IPC request processing (SyncRequest#isUpdateNecessary(SyncContext)
         synchronized (context.getSynchronizeHelper().getThingShadowLock(this)) {
             Optional<ShadowDocument> shadowDocument = context.getDao().getShadowThing(getThingName(), getShadowName());
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -104,8 +104,6 @@ class FullShadowSyncRequestTest {
     private UpdateThingShadowRequestHandler mockUpdateThingShadowRequestHandler;
     @Mock
     private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
-    @Mock
-    private ShadowWriteSynchronizeHelper mockSynchronizeHelper;
     @Captor
     private ArgumentCaptor<SyncInformation> syncInformationCaptor;
     @Captor
@@ -126,7 +124,7 @@ class FullShadowSyncRequestTest {
     void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
-                mockIotDataPlaneClientWrapper, mockSynchronizeHelper);
+                mockIotDataPlaneClientWrapper, new ShadowWriteSynchronizeHelper());
         JsonUtil.loadSchema();
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
@@ -93,7 +93,8 @@ class LocalDeleteSyncRequestTest {
                 .thenReturn(new DeleteThingShadowResponse());
 
         syncContext = new SyncContext(mockDao, mock(UpdateThingShadowRequestHandler.class),
-                mockDeleteThingShadowRequestHandler, mock(IotDataPlaneClientWrapper.class), mock(ShadowWriteSynchronizeHelper.class));
+                mockDeleteThingShadowRequestHandler, mock(IotDataPlaneClientWrapper.class),
+                new ShadowWriteSynchronizeHelper());
     }
 
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
@@ -64,8 +64,6 @@ class OverwriteCloudShadowRequestTest {
     private UpdateThingShadowRequestHandler mockUpdateThingShadowRequestHandler;
     @Mock
     private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
-    @Mock
-    private ShadowWriteSynchronizeHelper mockSynchronizeHelper;
     @Captor
     private ArgumentCaptor<SyncInformation> syncInformationCaptor;
     @Captor
@@ -81,7 +79,7 @@ class OverwriteCloudShadowRequestTest {
     void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(any())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
-                mockIotDataPlaneClientWrapper, mockSynchronizeHelper);
+                mockIotDataPlaneClientWrapper, new ShadowWriteSynchronizeHelper());
         JsonUtil.loadSchema();
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
@@ -71,8 +71,6 @@ class OverwriteLocalShadowRequestTest {
     private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private UpdateThingShadowHandlerResponse mockUpdateThingShadowHandlerResponse;
-    @Mock
-    private ShadowWriteSynchronizeHelper mockSynchronizeHelper;
     @Captor
     private ArgumentCaptor<SyncInformation> syncInformationCaptor;
     @Captor
@@ -86,7 +84,7 @@ class OverwriteLocalShadowRequestTest {
     void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(any())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
-                mockIotDataPlaneClientWrapper, mockSynchronizeHelper);
+                mockIotDataPlaneClientWrapper, new ShadowWriteSynchronizeHelper());
         JsonUtil.loadSchema();
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This is a follow-up to https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/166.  This PR increases the scope to all types of sync requests, rather than just local&cloud updates, as all of them read and write to the sync table in at least one way.


**Why is this change necessary:**

**How was this change tested:**

There's a bunch of test cases needed. Would like to do these in a follow up PR so we can get some UAT runs in in the meanwhile.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
