### PR TITLE
fix: respect sync direction when queueing full sync on conflict

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.strategy.BaseSyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.PeriodicSyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.RealTimeSyncStrategy;
@@ -61,6 +62,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
     AuthorizationHandlerWrapper mockAuthorizationHandlerWrapper;
     @Mock
     ShadowManagerDatabase mockShadowManagerDatabase;
+    private final DirectionWrapper direction = new DirectionWrapper();
 
     @Deprecated()
     public void startNucleusWithConfig(String configFile) throws InterruptedException {
@@ -130,10 +132,10 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
                     .build();
             SyncStrategy syncStrategy;
             if (RealTimeSyncStrategy.class.equals(config.getSyncClazz())) {
-                syncStrategy = new RealTimeSyncStrategy(es, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), retryConfig, queue);
+                syncStrategy = new RealTimeSyncStrategy(es, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), retryConfig, queue, direction);
                 kernel.getContext().put(RealTimeSyncStrategy.class, (RealTimeSyncStrategy) syncStrategy);
             } else {
-                syncStrategy = new PeriodicSyncStrategy(ses, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), 3, retryConfig, queue);
+                syncStrategy = new PeriodicSyncStrategy(ses, ((RealTimeSyncStrategy) realTimeSyncStrategy).getRetryer(), 3, retryConfig, queue, direction);
                 kernel.getContext().put(PeriodicSyncStrategy.class, (PeriodicSyncStrategy) syncStrategy);
 
             }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.strategy.BaseSyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.PeriodicSyncStrategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.RealTimeSyncStrategy;
@@ -220,22 +221,22 @@ class ShadowManagerTest extends NucleusLaunchUtils {
                 .configFile(DEFAULT_CONFIG)
                 .mqttConnected(false)
                 .build());
-        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
+        DirectionWrapper direction = kernel.getContext().get(DirectionWrapper.class);
         shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC)
                 .lookup(CONFIGURATION_SYNC_DIRECTION_TOPIC).withValue(Direction.DEVICE_TO_CLOUD.getCode());
         kernel.getContext().waitForPublishQueueToClear();
-        assertThat(syncHandler.getSyncDirection(), is(Direction.DEVICE_TO_CLOUD));
+        assertThat(direction.get(), is(Direction.DEVICE_TO_CLOUD));
 
         shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC)
                 .lookup(CONFIGURATION_SYNC_DIRECTION_TOPIC).remove();
         kernel.getContext().waitForPublishQueueToClear();
-        assertThat(syncHandler.getSyncDirection(), is(Direction.BETWEEN_DEVICE_AND_CLOUD));
+        assertThat(direction.get(), is(Direction.BETWEEN_DEVICE_AND_CLOUD));
 
         shadowManager.getConfig().lookupTopics(CONFIGURATION_CONFIG_KEY, CONFIGURATION_SYNCHRONIZATION_TOPIC)
                 .lookup(CONFIGURATION_SYNC_DIRECTION_TOPIC).withValue(Direction.DEVICE_TO_CLOUD.getCode());
         kernel.getContext().waitForPublishQueueToClear();
 
-        assertThat(syncHandler.getSyncDirection(), is(Direction.DEVICE_TO_CLOUD));
+        assertThat(direction.get(), is(Direction.DEVICE_TO_CLOUD));
     }
 
     @Test

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
@@ -13,7 +13,7 @@ import com.aws.greengrass.shadowmanager.model.LogEvents;
 import com.aws.greengrass.shadowmanager.sync.model.BaseSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.CloudDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
-import com.aws.greengrass.shadowmanager.sync.model.Direction;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalUpdateSyncRequest;
@@ -21,19 +21,24 @@ import com.aws.greengrass.shadowmanager.sync.model.OverwriteCloudShadowRequest;
 import com.aws.greengrass.shadowmanager.sync.model.OverwriteLocalShadowRequest;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import lombok.Setter;
 
 import java.io.IOException;
+import javax.inject.Inject;
+
 
 /**
- * Merge requests that can be combined together. Falls back to FullSync if requests cannot be combined in a
+ * Merge requests that can be combined. Falls back to FullSync if requests cannot be combined in a
  * meaningful way.
  */
 public class RequestMerger {
     private static final Logger logger = LogManager.getLogger(RequestMerger.class);
 
-    @Setter
-    private Direction syncDirection = Direction.BETWEEN_DEVICE_AND_CLOUD;
+    private final DirectionWrapper direction;
+
+    @Inject
+    public RequestMerger(DirectionWrapper direction) {
+        this.direction = direction;
+    }
 
     /**
      * Merge two requests into one.
@@ -105,7 +110,7 @@ public class RequestMerger {
     }
 
     private BaseSyncRequest returnRequestBasedOnDirection(SyncRequest value, LogEventBuilder logEvent) {
-        switch (syncDirection) {
+        switch (direction.get()) {
             case DEVICE_TO_CLOUD:
                 logEvent.log("Creating overwrite cloud shadow sync request");
                 // Instead of a partial update, an overwrite cloud shadow sync request will force the device to

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/DirectionWrapper.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/DirectionWrapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.function.Supplier;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DirectionWrapper implements Supplier<Direction> {
+
+    private volatile Direction direction = Direction.BETWEEN_DEVICE_AND_CLOUD;
+
+    @Override
+    public Direction get() {
+        return direction;
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.util.RetryUtils;
@@ -36,10 +37,11 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
      * @param retryer   The retryer object.
      * @param interval  The interval at which to sync the shadows.
      * @param syncQueue The sync queue from the previous strategy if any.
+     * @param  direction  The sync direction
      */
     public PeriodicSyncStrategy(ScheduledExecutorService ses, Retryer retryer, long interval,
-                                RequestBlockingQueue syncQueue) {
-        super(retryer, syncQueue);
+                                RequestBlockingQueue syncQueue, DirectionWrapper direction) {
+        super(retryer, syncQueue, direction);
         this.syncExecutorService = ses;
         this.interval = interval;
     }
@@ -52,10 +54,12 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
      * @param interval    The interval at which to sync the shadows.
      * @param retryConfig The retryer configuration.
      * @param syncQueue   The sync queue from the previous strategy if any.
+     * @param  direction  The sync direction
      */
     public PeriodicSyncStrategy(ScheduledExecutorService ses, Retryer retryer, long interval,
-                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
-        super(retryer, retryConfig, syncQueue);
+                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue,
+                                DirectionWrapper direction) {
+        super(retryer, retryConfig, syncQueue, direction);
         this.syncExecutorService = ses;
         this.interval = interval;
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
 import com.aws.greengrass.util.RetryUtils;
@@ -36,9 +37,11 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
      * @param executorService executor service.
      * @param retryer         The retryer object.
      * @param syncQueue       The sync queue from the previous strategy if any.
+     * @param direction       The sync direction
      */
-    public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer, RequestBlockingQueue syncQueue) {
-        super(retryer, syncQueue);
+    public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer, RequestBlockingQueue syncQueue,
+                                DirectionWrapper direction) {
+        super(retryer, syncQueue, direction);
         this.syncExecutorService = executorService;
         this.syncThreadEnd = new CountDownLatch(1);
     }
@@ -50,10 +53,12 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
      * @param retryer         The retryer object.
      * @param retryConfig     The retryer configuration.
      * @param syncQueue       The sync queue from the previous strategy if any.
+     * @param direction       The sync direction
      */
     public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer,
-                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue) {
-        super(retryer, retryConfig, syncQueue);
+                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue,
+                                DirectionWrapper direction) {
+        super(retryer, retryConfig, syncQueue, direction);
         this.syncExecutorService = executorService;
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactory.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactory.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.Strategy;
 
 import java.util.concurrent.ExecutorService;
@@ -22,6 +23,7 @@ public class SyncStrategyFactory {
     private final Retryer retryer;
     private final ExecutorService syncExecutorService;
     private final ScheduledExecutorService syncScheduledExecutorService;
+    private final DirectionWrapper direction;
 
     /**
      * Constructor for SyncStrategyFactory to maintain sync strategy clients.
@@ -29,12 +31,14 @@ public class SyncStrategyFactory {
      * @param retryer                  The retryer object.
      * @param executorService          The executor service object.
      * @param scheduledExecutorService The scheduled executor service object.
+     * @param direction               The sync direction
      */
     public SyncStrategyFactory(Retryer retryer, ExecutorService executorService,
-                               ScheduledExecutorService scheduledExecutorService) {
+                               ScheduledExecutorService scheduledExecutorService, DirectionWrapper direction) {
         this.retryer = retryer;
         this.syncExecutorService = executorService;
         this.syncScheduledExecutorService = scheduledExecutorService;
+        this.direction = direction;
     }
 
     /**
@@ -49,10 +53,10 @@ public class SyncStrategyFactory {
         switch (syncStrategy.getType()) {
             case PERIODIC:
                 return new PeriodicSyncStrategy(syncScheduledExecutorService, retryer, syncStrategy.getDelay(),
-                        syncQueue);
+                        syncQueue, direction);
             case REALTIME:
             default:
-                return new RealTimeSyncStrategy(syncExecutorService, retryer, syncQueue);
+                return new RealTimeSyncStrategy(syncExecutorService, retryer, syncQueue, direction);
         }
     }
 }

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestMergerTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.shadowmanager.sync;
 import com.aws.greengrass.shadowmanager.sync.model.CloudDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalUpdateSyncRequest;
@@ -50,16 +51,18 @@ class RequestMergerTest {
 
     static LocalDeleteSyncRequest localDeleteSyncRequest = mock(LocalDeleteSyncRequest.class, "localDelete");
 
+    private final DirectionWrapper direction = new DirectionWrapper();
+
     @BeforeEach
     void setup() {
-        merger = new RequestMerger();
+        merger = new RequestMerger(direction);
     }
 
     @ParameterizedTest
     @MethodSource("overridingRequests")
     void GIVEN_overriding_requests_WHEN_merge_THEN_return_overriding_request(SyncRequest old, SyncRequest value,
             SyncRequest expected, Direction direction) {
-        merger.setSyncDirection(direction);
+        this.direction.setDirection(direction);
         assertThat(merger.merge(old, value), is(instanceOf(expected.getClass())));
     }
 
@@ -84,7 +87,7 @@ class RequestMergerTest {
     @MethodSource("nonMergingRequests")
     void GIVEN_non_mergable_request_WHEN_merge_THEN_return_full_shadow_sync(SyncRequest request1,
             SyncRequest request2, Direction direction) {
-        merger.setSyncDirection(direction);
+        this.direction.setDirection(direction);
         switch (direction) {
             case BETWEEN_DEVICE_AND_CLOUD:
                 assertThat(merger.merge(request1, request2), is(instanceOf(FullShadowSyncRequest.class)));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactoryTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
+import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.Strategy;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.StrategyType;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -35,16 +36,18 @@ class SyncStrategyFactoryTest {
     @Mock
     ScheduledExecutorService mockScheduledExecutorService;
 
+    DirectionWrapper direction = new DirectionWrapper();
+
     @Test
     void GIVEN_periodic_sync_strategy_WHEN_getSyncStrategy_THEN_gets_the_correct_sync_strategy_type() {
-        SyncStrategyFactory factory = new SyncStrategyFactory(mockRetryer, mockSyncExecutorService, mockScheduledExecutorService);
+        SyncStrategyFactory factory = new SyncStrategyFactory(mockRetryer, mockSyncExecutorService, mockScheduledExecutorService, direction);
         SyncStrategy syncStrategy = factory.createSyncStrategy(Strategy.builder().type(StrategyType.PERIODIC).delay(10L).build(), mockRequestBlockingQueue);
         assertThat(syncStrategy, is(instanceOf(PeriodicSyncStrategy.class)));
     }
 
     @Test
     void GIVEN_realTime_sync_strategy_WHEN_getSyncStrategy_THEN_gets_the_correct_sync_strategy_type() {
-        SyncStrategyFactory factory = new SyncStrategyFactory(mockRetryer, mockSyncExecutorService, mockScheduledExecutorService);
+        SyncStrategyFactory factory = new SyncStrategyFactory(mockRetryer, mockSyncExecutorService, mockScheduledExecutorService, direction);
         SyncStrategy syncStrategy = factory.createSyncStrategy(Strategy.builder().type(StrategyType.REALTIME).build(), mockRequestBlockingQueue);
         assertThat(syncStrategy, is(instanceOf(RealTimeSyncStrategy.class)));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Changes the type of request enqueued when a conflict is detected from a `FullShadowSyncRequest`, to one of `OverwriteCloudShadowRequest`/`OverwriteLocalShadowRequest`/`FullShadowSyncRequest`, based on the sync direction.

Also refactors so that sync direction is wrapped in a class which is injected wherever needed.  This means that all usages will have the same reference to direction, rather than needing to ensure setters are called.

**Why is this change necessary:**
To prevent full syncs from happening when a conflict is detected, when sync direction is not BETWEEN_DEVICE_AND_CLOUD.

**How was this change tested:**
new unit tests

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
