### PR TITLE
fix: only read sync from sync thread

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
 
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -189,14 +189,4 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
         assertThat("sync queue is eventually empty", () -> q.isEmpty() && !s.isExecuting(),
                 eventuallyEval(is(true), Duration.ofSeconds(10)));
     }
-
-    protected void assertThatSyncQueue(Class<? extends BaseSyncStrategy> clazz, Predicate<RequestBlockingQueue> condition) {
-        BaseSyncStrategy s = kernel.getContext().get(clazz);
-        assertThat("syncing has started", s::isSyncing, eventuallyEval(is(true)));
-        RequestBlockingQueue q = s.getSyncQueue();
-
-        assertThat("sync queue meets condition",
-                () -> condition.test(q),
-                eventuallyEval(is(true), Duration.ofSeconds(10)));
-    }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
@@ -108,7 +108,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
         JsonNode updateDocument = JsonUtil.getPayloadJson(localShadowContentV1.getBytes()).get();
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
 
         // thingName has to be unique to prevent requests from being merged
         final int totalRequestCalls = 10;
@@ -133,7 +133,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -158,7 +158,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -235,7 +235,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimitsWithTotalLocalRate.yaml").mockCloud(true)
                 .mockDao(true).build());
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -274,7 +274,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
@@ -131,7 +131,8 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         when(dao.getShadowThing(anyString(), any())).thenReturn(Optional.of(new ShadowDocument(localShadowContentV1.getBytes())));
 
-        startNucleusWithConfig("rateLimits.yaml", true, true);
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
+                .mockDao(true).build());
         assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
@@ -155,7 +156,8 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         when(dao.getShadowThing(anyString(), any())).thenReturn(Optional.of(new ShadowDocument(localShadowContentV1.getBytes())));
 
-        startNucleusWithConfig("rateLimits.yaml", true, true);
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
+                .mockDao(true).build());
         assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
@@ -187,7 +189,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(15L)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30L)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -265,6 +267,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
     @Test
     void GIVEN_requests_throttled_for_thing_WHEN_request_sent_for_different_thing_THEN_request_for_different_thing_not_throttled(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, ThrottledRequestException.class);
+        ignoreExceptionOfType(context, InterruptedException.class);
 
         when(dao.getShadowThing(anyString(), any())).thenReturn(Optional.of(new ShadowDocument(localShadowContentV1.getBytes())));
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
@@ -108,7 +108,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
         JsonNode updateDocument = JsonUtil.getPayloadJson(localShadowContentV1.getBytes()).get();
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
 
         // thingName has to be unique to prevent requests from being merged
         final int totalRequestCalls = 10;
@@ -133,7 +133,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -158,7 +158,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -235,7 +235,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimitsWithTotalLocalRate.yaml").mockCloud(true)
                 .mockDao(true).build());
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -274,7 +274,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(60)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
@@ -108,7 +108,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
         JsonNode updateDocument = JsonUtil.getPayloadJson(localShadowContentV1.getBytes()).get();
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
 
         // thingName has to be unique to prevent requests from being merged
         final int totalRequestCalls = 10;
@@ -133,7 +133,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -158,7 +158,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
 
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -235,7 +235,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimitsWithTotalLocalRate.yaml").mockCloud(true)
                 .mockDao(true).build());
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
@@ -274,7 +274,7 @@ class RateLimiterTest extends NucleusLaunchUtils {
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true)
                 .mockDao(true).build());
 
-        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true)));
+        assertThat("syncing has started", () -> kernel.getContext().get(RealTimeSyncStrategy.class).isSyncing(), eventuallyEval(is(true), Duration.ofSeconds(30)));
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel, "DoAll")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -327,6 +327,10 @@ class ShadowManagerTest extends NucleusLaunchUtils {
                 .mqttConnected(true)
                 .mockCloud(false)
                 .build());
+
+        // wait for retry policy in IotDataPlaneClientFactory#waitForCryptoKeyServiceProvider to fail
+        TimeUnit.SECONDS.sleep(15L);
+
         BaseSyncStrategy syncStrategy = kernel.getContext().get(RealTimeSyncStrategy.class);
         assertThat("syncing has started", syncStrategy::isSyncing, eventuallyEval(is(true)));
         verify(wrapper, timeout(5000).atLeast(1)).getThingShadow("Thing1", "");
@@ -339,7 +343,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
             cdl.countDown();
             return new KeyManager[0];
         });
-        assertThat("request is retried with a new client", cdl.await(10, TimeUnit.SECONDS), is(true));
+        assertThat("request is retried with a new client", cdl.await(15L, TimeUnit.SECONDS), is(true));
         verify(wrapper, timeout(5000).atLeast(2)).getThingShadow("Thing1", "");
         // Once the request is processed, the sync queue should be empty.
         assertEmptySyncQueue(RealTimeSyncStrategy.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -343,7 +343,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
             cdl.countDown();
             return new KeyManager[0];
         });
-        assertThat("request is retried with a new client", cdl.await(15L, TimeUnit.SECONDS), is(true));
+        assertThat("request is retried with a new client", cdl.await(30L, TimeUnit.SECONDS), is(true));
         verify(wrapper, timeout(5000).atLeast(2)).getThingShadow("Thing1", "");
         // Once the request is processed, the sync queue should be empty.
         assertEmptySyncQueue(RealTimeSyncStrategy.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -42,7 +42,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowResponse;
 
 import javax.net.ssl.KeyManager;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -85,7 +84,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
@@ -109,6 +109,8 @@ class SyncDirectionalityTest extends NucleusLaunchUtils {
                 .resetRetryConfig(false)
                 .build());
 
+        assertSyncingHasStarted(RealTimeSyncStrategy.class);
+
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
 
         // update local shadow
@@ -157,6 +159,7 @@ class SyncDirectionalityTest extends NucleusLaunchUtils {
         // There is a race condition which can cause us to check queue is empty before having inserted any full sync
         // requests in it. This check avoids that.
         assertThat("all the sync requests are processed", cdl.await(10, TimeUnit.SECONDS), is(true));
+        assertSyncingHasStarted(RealTimeSyncStrategy.class);
         assertEmptySyncQueue(RealTimeSyncStrategy.class);
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
 
@@ -201,6 +204,7 @@ class SyncDirectionalityTest extends NucleusLaunchUtils {
                 .build());
 
         shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().build());
+        assertSyncingHasStarted(RealTimeSyncStrategy.class);
         assertEmptySyncQueue(RealTimeSyncStrategy.class);
 
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
@@ -231,10 +235,12 @@ class SyncDirectionalityTest extends NucleusLaunchUtils {
                 .resetRetryConfig(false)
                 .build());
         shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().build());
+        assertSyncingHasStarted(RealTimeSyncStrategy.class);
         assertEmptySyncQueue(RealTimeSyncStrategy.class);
 
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
         syncHandler.pushLocalUpdateSyncRequest(MOCK_THING_NAME_1, CLASSIC_SHADOW, JsonUtil.getPayloadBytes(cloudDocument));
+        assertSyncingHasStarted(RealTimeSyncStrategy.class);
         assertEmptySyncQueue(RealTimeSyncStrategy.class);
 
         TimeUnit.SECONDS.sleep(2);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -407,7 +407,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .mockCloud(true)
                 .mockDao(true)
                 .build());
-        assertThat("cloud shadow updated", cdl.await(5, TimeUnit.SECONDS), is(true));
+        assertThat("cloud shadow updated", cdl.await(10, TimeUnit.SECONDS), is(true));
         assertThat(() -> cloudUpdateThingShadowRequestCaptor.getValue(), eventuallyEval(is(notNullValue())));
         assertThat(() -> syncInformationCaptor.getValue(), eventuallyEval(is(notNullValue())));
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -687,6 +687,8 @@ class SyncTest extends NucleusLaunchUtils {
                 .mockCloud(true)
                 .build());
 
+        // verify initial full sync
+        verify(syncQueue, timeout(5000).atLeast(1)).put(any(FullShadowSyncRequest.class));
         assertEmptySyncQueue(clazz);
 
         assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -1174,6 +1174,7 @@ class SyncTest extends NucleusLaunchUtils {
             throws InterruptedException, IOException, IoTDataPlaneClientCreationException {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ConflictError.class);
+        ignoreExceptionOfType(context, InvalidRequestParametersException.class);
 
         String initialCloudState = "{\"version\":1,\"state\":{\"desired\":{}}}";
         String blockingCloudUpdate = "{\"version\":1,\"state\":{\"desired\":{\"SomeKey\":\"bar\"}}}";

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.shadowmanager.ShadowManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
+import com.aws.greengrass.shadowmanager.exception.InvalidRequestParametersException;
 import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationException;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
@@ -1261,6 +1262,7 @@ class SyncTest extends NucleusLaunchUtils {
             throws InterruptedException, IOException, IoTDataPlaneClientCreationException {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ConflictError.class);
+        ignoreExceptionOfType(context, InvalidRequestParametersException.class);
 
         String initialCloudState = "{\"version\":1,\"state\":{\"desired\":{}}}";
         String blockingCloudUpdate = "{\"version\":1,\"state\":{\"desired\":{\"SomeKey\":\"bar\"}}}";

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -1255,6 +1255,94 @@ class SyncTest extends NucleusLaunchUtils {
         assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(4L)));
     }
 
+    @ParameterizedTest
+    @ValueSource(classes = {RealTimeSyncStrategy.class, PeriodicSyncStrategy.class})
+    void GIVEN_bidirectional_update_not_fully_necessary_WHEN_full_sync_executed_THEN_update_only_one_direction(Class<? extends BaseSyncStrategy> clazz, ExtensionContext context)
+            throws InterruptedException, IOException, IoTDataPlaneClientCreationException {
+        ignoreExceptionOfType(context, InterruptedException.class);
+        ignoreExceptionOfType(context, ConflictError.class);
+
+        String initialCloudState = "{\"version\":1,\"state\":{\"desired\":{}}}";
+        String blockingCloudUpdate = "{\"version\":1,\"state\":{\"desired\":{\"SomeKey\":\"bar\"}}}";
+        String cloudUpdate = "{\"version\":2,\"state\":{\"desired\":{\"SomeKey\":\"bar\"}}}";
+        String localUpdate = "{\"state\":{\"desired\":{\"OtherKey\":\"foo\"}}}";
+        String finalCloudState = "{\"version\":3,\"state\":{\"desired\":{\"SomeKey\":\"bar\",\"OtherKey\":\"bar\"}}}";
+        String expectedLocalShadowState = "{\"state\":{\"desired\":{\"SomeKey\":\"bar\",\"OtherKey\":\"foo\"}}}";
+
+        GetThingShadowResponse initialCloudStateShadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(initialCloudStateShadowResponse.payload().asByteArray()).thenReturn(initialCloudState.getBytes(UTF_8));
+
+        GetThingShadowResponse blockingCloudStateShadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(blockingCloudStateShadowResponse.payload().asByteArray()).thenReturn(blockingCloudUpdate.getBytes(UTF_8));
+
+        GetThingShadowResponse updateCloudStateShadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(updateCloudStateShadowResponse.payload().asByteArray()).thenReturn(cloudUpdate.getBytes(UTF_8));
+
+        GetThingShadowResponse finalCloudStateShadowResponse = mock(GetThingShadowResponse.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(finalCloudStateShadowResponse.payload().asByteArray()).thenReturn(finalCloudState.getBytes(UTF_8));
+
+        CountDownLatch bidirectionalRequestsHaveBeenQueued = new CountDownLatch(1);
+
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient()
+                .getThingShadow(any(GetThingShadowRequest.class)))
+                .thenReturn(initialCloudStateShadowResponse)
+                .thenReturn(finalCloudStateShadowResponse);
+
+        lenient().when(mockUpdateThingShadowResponse.payload())
+                .thenReturn(SdkBytes.fromString("{}", UTF_8));
+        when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
+                .thenAnswer(unused -> {
+                    assertTrue(bidirectionalRequestsHaveBeenQueued.await(5000L, TimeUnit.SECONDS));
+                    return mockUpdateThingShadowResponse;
+                })
+                .thenReturn(mockUpdateThingShadowResponse);
+
+        startNucleusWithConfig(NucleusLaunchUtilsConfig.builder()
+                .configFile(getSyncConfigFile(clazz))
+                .syncClazz(clazz)
+                .mockCloud(true)
+                .build());
+
+        // wait for initial full sync to complete
+        assertThatSyncQueue(clazz, q -> q.peek() instanceof CloudUpdateSyncRequest);
+        assertEmptySyncQueue(clazz);
+
+        UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
+
+        // send a cloud update that takes a while to execute,
+        // so that subsequent requests can pile up in the queue
+        UpdateThingShadowRequest blockingRequest = new UpdateThingShadowRequest();
+        blockingRequest.setThingName(MOCK_THING_NAME_1);
+        blockingRequest.setShadowName(CLASSIC_SHADOW);
+        blockingRequest.setPayload(blockingCloudUpdate.getBytes(UTF_8));
+        updateHandler.handleRequest(blockingRequest, "DoAll");
+
+        // receive cloud update
+        UpdateThingShadowRequest updateRequest = new UpdateThingShadowRequest();
+        updateRequest.setThingName(MOCK_THING_NAME_1);
+        updateRequest.setShadowName(CLASSIC_SHADOW);
+        updateRequest.setPayload(localUpdate.getBytes(UTF_8));
+        updateHandler.handleRequest(updateRequest, "DoAll");
+
+        // receive local update
+        JsonNode cloudUpdateDocument = JsonUtil.getPayloadJson(cloudUpdate.getBytes(UTF_8)).get();
+        SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);
+        syncHandler.pushLocalUpdateSyncRequest(MOCK_THING_NAME_1, CLASSIC_SHADOW, JsonUtil.getPayloadBytes(cloudUpdateDocument));
+
+        // make sure that the requests merge as expected
+        assertThatSyncQueue(clazz, q -> q.size() == 1 && q.peek() instanceof FullShadowSyncRequest);
+        bidirectionalRequestsHaveBeenQueued.countDown();
+
+        // full sync has been popped off the queue
+        assertEmptySyncQueue(clazz);
+
+        assertLocalShadowEquals(expectedLocalShadowState);
+
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(3L)));
+        assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(3L)));
+    }
+
     private void assertLocalShadowEquals(String state) throws IOException {
         assertThat(this::getLocalShadowState, eventuallyEval(is(JsonUtil.getPayloadJson(state.getBytes(UTF_8)).get().get(SHADOW_DOCUMENT_STATE))));
     }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -749,7 +749,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .build());
 
         // we have a local shadow from the initial full sync
-        assertThat("local shadow exists", () -> localShadow.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("local shadow exists", () -> localShadow.get().isPresent(), eventuallyEval(is(true), Duration.ofSeconds(15)));
         assertEmptySyncQueue(clazz);
 
         DeleteThingShadowRequestHandler deleteHandler = shadowManager.getDeleteThingShadowRequestHandler();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -660,6 +660,7 @@ class SyncTest extends NucleusLaunchUtils {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         ignoreExceptionOfType(context, ConflictError.class);
+        ignoreExceptionOfType(context, InvalidRequestParametersException.class);
 
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
                 .thenReturn(mockUpdateThingShadowResponse);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -407,7 +407,7 @@ class SyncTest extends NucleusLaunchUtils {
                 .mockCloud(true)
                 .mockDao(true)
                 .build());
-        assertThat("cloud shadow updated", cdl.await(10, TimeUnit.SECONDS), is(true));
+        assertThat("cloud shadow updated", cdl.await(30, TimeUnit.SECONDS), is(true));
         assertThat(() -> cloudUpdateThingShadowRequestCaptor.getValue(), eventuallyEval(is(notNullValue())));
         assertThat(() -> syncInformationCaptor.getValue(), eventuallyEval(is(notNullValue())));
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -568,6 +568,8 @@ class SyncTest extends NucleusLaunchUtils {
                 .syncClazz(clazz)
                 .mockCloud(true)
                 .build());
+        // wait for initial full sync to complete
+        verify(syncQueue, timeout(5000).atLeast(1)).put(any(FullShadowSyncRequest.class));
         assertEmptySyncQueue(clazz);
 
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -96,7 +96,6 @@ public class ShadowManager extends PluginService {
     private final UpdateThingShadowRequestHandler updateThingShadowRequestHandler;
     private final GetThingShadowRequestHandler getThingShadowRequestHandler;
     private final IotDataPlaneClientWrapper iotDataPlaneClientWrapper;
-    private final ShadowWriteSynchronizeHelper synchronizeHelper;
     @Getter(AccessLevel.PACKAGE)
     private final SyncHandler syncHandler;
     private final CloudDataClient cloudDataClient;
@@ -175,7 +174,6 @@ public class ShadowManager extends PluginService {
         this.syncHandler = syncHandler;
         this.cloudDataClient = cloudDataClient;
         this.mqttClient = mqttClient;
-        this.synchronizeHelper = synchronizeHelper;
         this.deleteThingShadowRequestHandler = new DeleteThingShadowRequestHandler(dao, authorizationHandlerWrapper,
                 pubSubClientWrapper, synchronizeHelper, this.syncHandler);
         this.updateThingShadowRequestHandler = new UpdateThingShadowRequestHandler(dao, authorizationHandlerWrapper,
@@ -545,8 +543,7 @@ public class ShadowManager extends PluginService {
                         dao,
                         getUpdateThingShadowRequestHandler(),
                         getDeleteThingShadowRequestHandler(),
-                        iotDataPlaneClientWrapper,
-                        synchronizeHelper
+                        iotDataPlaneClientWrapper
                 );
                 syncHandler.start(syncContext, SyncHandler.DEFAULT_PARALLELISM);
             }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
@@ -284,22 +284,7 @@ public class CloudDataClient {
         String shadowName = shadowRequest.getShadowName();
         logger.atDebug().kv(LOG_THING_NAME_KEY, thingName).kv(LOG_SHADOW_NAME_KEY, shadowName)
                 .log("Received cloud update sync request");
-        CompletableFuture
-                // Since this callback runs in context of a CRT thread, we must not block.
-                //
-                // There is a small chance of blocking when a thing/shadow lock is obtained
-                // within this call, because the lock also surrounds an IoT dataplane call
-                // in CloudUpdateSyncRequest.
-                .runAsync(() -> syncHandler.pushLocalUpdateSyncRequest(thingName, shadowName, message.getPayload()),
-                        executorService)
-                .whenComplete((unused, e) -> {
-                    if (e != null) {
-                        logger.atError().cause(e)
-                                .kv(LOG_THING_NAME_KEY, thingName)
-                                .kv(LOG_SHADOW_NAME_KEY, shadowName)
-                                .log("Unable to queue local update sync request");
-                    }
-                });
+        syncHandler.pushLocalUpdateSyncRequest(thingName, shadowName, message.getPayload());
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
@@ -24,7 +24,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
@@ -127,7 +127,8 @@ public class RequestMerger {
                 logEvent.log("Creating full shadow sync request");
                 // Instead of a partial update, a full sync request will force a get of the latest local
                 // and remote shadows
-                return FullShadowSyncRequest.fromMerge(value.getThingName(), value.getShadowName(), value, otherValue);
+                return FullShadowSyncRequest.fromMerge(value.getThingName(), value.getShadowName(),
+                        this, value, otherValue);
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
@@ -109,7 +109,8 @@ public class RequestMerger {
         return returnRequestBasedOnDirection(value, oldValue, logEvent);
     }
 
-    private BaseSyncRequest returnRequestBasedOnDirection(SyncRequest value, SyncRequest otherValue, LogEventBuilder logEvent) {
+    private BaseSyncRequest returnRequestBasedOnDirection(SyncRequest value, SyncRequest otherValue,
+                                                          LogEventBuilder logEvent) {
         switch (direction.get()) {
             case DEVICE_TO_CLOUD:
                 logEvent.log("Creating overwrite cloud shadow sync request");

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
@@ -126,7 +126,7 @@ public class RequestMerger {
                 logEvent.log("Creating full shadow sync request");
                 // Instead of a partial update, a full sync request will force a get of the latest local
                 // and remote shadows
-                return new FullShadowSyncRequest(value.getThingName(), value.getShadowName(), value, otherValue);
+                return FullShadowSyncRequest.fromMerge(value.getThingName(), value.getShadowName(), value, otherValue);
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
@@ -56,11 +56,11 @@ public class RequestMerger {
 
         if (oldValue instanceof FullShadowSyncRequest || oldValue instanceof OverwriteCloudShadowRequest
                 || oldValue instanceof OverwriteLocalShadowRequest) {
-            return returnRequestBasedOnDirection(oldValue, logEvent);
+            return returnRequestBasedOnDirection(oldValue, value, logEvent);
         }
         if (value instanceof FullShadowSyncRequest || value instanceof OverwriteCloudShadowRequest
                 || value instanceof OverwriteLocalShadowRequest) {
-            return returnRequestBasedOnDirection(value, logEvent);
+            return returnRequestBasedOnDirection(value, oldValue, logEvent);
         }
 
         if (oldValue instanceof CloudUpdateSyncRequest && value instanceof CloudUpdateSyncRequest) {
@@ -106,10 +106,10 @@ public class RequestMerger {
                     .log("Received bi-directional updates. Converting to a full shadow sync request");
         }
 
-        return returnRequestBasedOnDirection(value, logEvent);
+        return returnRequestBasedOnDirection(value, oldValue, logEvent);
     }
 
-    private BaseSyncRequest returnRequestBasedOnDirection(SyncRequest value, LogEventBuilder logEvent) {
+    private BaseSyncRequest returnRequestBasedOnDirection(SyncRequest value, SyncRequest otherValue, LogEventBuilder logEvent) {
         switch (direction.get()) {
             case DEVICE_TO_CLOUD:
                 logEvent.log("Creating overwrite cloud shadow sync request");
@@ -126,7 +126,7 @@ public class RequestMerger {
                 logEvent.log("Creating full shadow sync request");
                 // Instead of a partial update, a full sync request will force a get of the latest local
                 // and remote shadows
-                return new FullShadowSyncRequest(value.getThingName(), value.getShadowName());
+                return new FullShadowSyncRequest(value.getThingName(), value.getShadowName(), value, otherValue);
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalDeleteSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.LocalUpdateSyncRequest;
+import com.aws.greengrass.shadowmanager.sync.model.MergedFullShadowSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.OverwriteCloudShadowRequest;
 import com.aws.greengrass.shadowmanager.sync.model.OverwriteLocalShadowRequest;
 import com.aws.greengrass.shadowmanager.sync.model.SyncRequest;
@@ -127,7 +128,7 @@ public class RequestMerger {
                 logEvent.log("Creating full shadow sync request");
                 // Instead of a partial update, a full sync request will force a get of the latest local
                 // and remote shadows
-                return FullShadowSyncRequest.fromMerge(value.getThingName(), value.getShadowName(),
+                return new MergedFullShadowSyncRequest(value.getThingName(), value.getShadowName(),
                         this, value, otherValue);
         }
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestMerger.java
@@ -125,7 +125,9 @@ public class RequestMerger {
                 return new OverwriteLocalShadowRequest(value.getThingName(), value.getShadowName());
             case BETWEEN_DEVICE_AND_CLOUD:
             default:
-                logEvent.log("Creating full shadow sync request");
+                logEvent.kv("left", value.getClass().getSimpleName())
+                        .kv("right", otherValue.getClass().getSimpleName())
+                        .log("Creating full shadow sync request by merging");
                 // Instead of a partial update, a full sync request will force a get of the latest local
                 // and remote shadows
                 return new MergedFullShadowSyncRequest(value.getThingName(), value.getShadowName(),

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudDeleteSyncRequest.java
@@ -141,7 +141,7 @@ public class CloudDeleteSyncRequest extends BaseSyncRequest {
      * @return true.
      */
     @Override
-    public boolean isUpdateNecessary(SyncContext context) {
+    boolean isUpdateNecessary(SyncContext context) {
         return true;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequest.java
@@ -177,7 +177,7 @@ public class CloudUpdateSyncRequest extends BaseSyncRequest {
      * @throws UnknownShadowException   if the shadow sync information is missing
      */
     @Override
-    public boolean isUpdateNecessary(SyncContext context) throws SkipSyncRequestException, UnknownShadowException {
+    boolean isUpdateNecessary(SyncContext context) throws SkipSyncRequestException, UnknownShadowException {
         Optional<ShadowDocument> shadowDocument = context.getDao().getShadowThing(getThingName(), getShadowName());
 
         //TODO: store this information in a return object to avoid unnecessary calls to DAO.

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -42,6 +42,14 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
     private static final Logger logger = LogManager.getLogger(FullShadowSyncRequest.class);
 
     /**
+     * If this full sync request is the product of merging other requests,
+     * in {@link com.aws.greengrass.shadowmanager.sync.RequestMerger},
+     * those merged requests will show up here.
+     */
+    @Getter
+    private final List<SyncRequest> mergedRequests;
+
+    /**
      * Create a full sync request as the result of a merge. This allows us to preserve the
      * individual requests that were merged, to drive decisions in {@link FullShadowSyncRequest#execute(SyncContext)}
      * if we indeed need a full sync.
@@ -68,14 +76,6 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
         }
         return new FullShadowSyncRequest(thingName, shadowName, requests);
     }
-
-    /**
-     * If this full sync request is the product of merging other requests,
-     * in {@link com.aws.greengrass.shadowmanager.sync.RequestMerger},
-     * those merged requests will show up here.
-     */
-    @Getter
-    private final List<SyncRequest> mergedRequests;
 
     /**
      * Ctr for FullShadowSyncRequest.

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -59,10 +59,12 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
      *
      * @param thingName      thing name
      * @param shadowName     shadow name
+     * @param merger         merger
      * @param mergedRequests sync requests that are being merged
      * @return full sync request
      */
-    public static FullShadowSyncRequest fromMerge(String thingName, String shadowName, RequestMerger merger, SyncRequest... mergedRequests) {
+    public static FullShadowSyncRequest fromMerge(String thingName, String shadowName,
+                                                  RequestMerger merger, SyncRequest... mergedRequests) {
         if (mergedRequests == null || mergedRequests.length == 0) {
             return new FullShadowSyncRequest(thingName, shadowName);
         }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -58,7 +58,10 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
         List<SyncRequest> requests = new ArrayList<>();
         for (SyncRequest req : mergedRequests) {
             if (req instanceof FullShadowSyncRequest) {
-                requests.addAll(((FullShadowSyncRequest) req).getMergedRequests());
+                FullShadowSyncRequest fullSyncReq = (FullShadowSyncRequest) req;
+                if (fullSyncReq.getMergedRequests() != null) {
+                    requests.addAll(fullSyncReq.getMergedRequests());
+                }
             } else {
                 requests.add(req);
             }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -55,7 +55,7 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
      * @return true.
      */
     @Override
-    public boolean isUpdateNecessary(SyncContext context) {
+    boolean isUpdateNecessary(SyncContext context) {
         return true;
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequest.java
@@ -137,7 +137,7 @@ public class LocalDeleteSyncRequest extends BaseSyncRequest {
      * @return true.
      */
     @Override
-    public boolean isUpdateNecessary(SyncContext context) {
+    boolean isUpdateNecessary(SyncContext context) {
         return true;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -187,7 +187,7 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
      * @throws SkipSyncRequestException if unable to deserialize cloud shadow update payload,
      */
     @Override
-    public boolean isUpdateNecessary(SyncContext context) throws SkipSyncRequestException, UnknownShadowException {
+    boolean isUpdateNecessary(SyncContext context) throws SkipSyncRequestException, UnknownShadowException {
         //TODO: store this information in a return object to avoid unnecessary calls to DAO.
         ShadowDocument shadowDocument;
         try {

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequest.java
@@ -99,96 +99,83 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
     @Override
     public void execute(SyncContext context) throws SkipSyncRequestException, ConflictError,
             UnknownShadowException {
-        // synchronizing access to shadow sync information because it is accessed by multiple threads.
-        // In this method, shadow sync information is accessed within context of the sync thread.
-        // The other place is `isUpdateNecessary(SyncContext)`, which runs on the Nucleus'
-        // MqttClient event loop thread.
-        //
-        // Other types of sync requests don't need this lock because their implementation of
-        // `isUpdateNecessary(SyncContext)` does not access shadow sync information.
-        //
-        // The check for shadow sync information in this class' `isUpdateNecessary(SyncContext)`
-        // prevents unnecessary full syncs,
-        // (see https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/106).
-        synchronized (context.getSynchronizeHelper().getThingShadowLock(this)) {
-            ShadowDocument shadowDocument;
+        ShadowDocument shadowDocument;
+        try {
+            shadowDocument = new ShadowDocument(updateDocument);
+        } catch (IOException | InvalidRequestParametersException e) {
+            throw new SkipSyncRequestException(e);
+        }
+
+        SyncInformation currentSyncInformation = context.getDao()
+                .getShadowSyncInformation(getThingName(), getShadowName())
+                .orElseThrow(() -> new UnknownShadowException("Shadow not found in sync table"));
+
+        if (!isUpdateNecessary(context, shadowDocument, currentSyncInformation)) {
+            logger.atDebug()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .log("Local shadow already contains update payload. No sync is necessary");
+            return;
+        }
+
+        long cloudUpdateVersion = shadowDocument.getVersion();
+        long currentCloudVersion = currentSyncInformation.getCloudVersion();
+        long currentLocalVersion = currentSyncInformation.getLocalVersion();
+
+        // Expected sequential cloud update, routing update to local shadow
+        if (cloudUpdateVersion == currentCloudVersion + 1) {
             try {
-                shadowDocument = new ShadowDocument(updateDocument);
-            } catch (IOException | InvalidRequestParametersException e) {
+                updateRequestWithLocalVersion(currentLocalVersion);
+
+                UpdateThingShadowRequest request = new UpdateThingShadowRequest();
+                request.setThingName(getThingName());
+                request.setShadowName(getShadowName());
+                request.setPayload(JsonUtil.getPayloadBytes(shadowDocument.toJson(false)));
+
+                UpdateThingShadowHandlerResponse response =
+                        context.getUpdateHandler().handleRequest(request, SHADOW_MANAGER_NAME);
+
+                byte[] updatedDocument = response.getCurrentDocument();
+                long updateTime = Instant.now().getEpochSecond();
+                long localUpdatedVersion = getUpdatedVersion(response.getUpdateThingShadowResponse().getPayload())
+                        .orElse(currentLocalVersion + 1);
+                context.getDao().updateSyncInformation(SyncInformation.builder()
+                        .thingName(getThingName())
+                        .shadowName(getShadowName())
+                        .lastSyncedDocument(updatedDocument)
+                        .cloudUpdateTime(updateTime)
+                        .localVersion(localUpdatedVersion)
+                        .cloudVersion(cloudUpdateVersion)
+                        .lastSyncTime(updateTime)
+                        .cloudDeleted(false)
+                        .build());
+                logger.atDebug()
+                        .kv(LOG_THING_NAME_KEY, getThingName())
+                        .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                        .kv(LOG_LOCAL_VERSION_KEY, localUpdatedVersion)
+                        .kv(LOG_CLOUD_VERSION_KEY, cloudUpdateVersion)
+                        .log("Successfully updated local shadow");
+            } catch (ShadowManagerDataException | UnauthorizedError | InvalidArgumentsError | ServiceError
+                     | IOException e) {
+                logger.atDebug()
+                        .kv(LOG_THING_NAME_KEY, getThingName())
+                        .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                        .kv(LOG_LOCAL_VERSION_KEY, currentLocalVersion)
+                        .kv(LOG_CLOUD_VERSION_KEY, cloudUpdateVersion)
+                        .log("Skipping update for local shadow");
                 throw new SkipSyncRequestException(e);
             }
 
-            SyncInformation currentSyncInformation = context.getDao()
-                    .getShadowSyncInformation(getThingName(), getShadowName())
-                    .orElseThrow(() -> new UnknownShadowException("Shadow not found in sync table"));
-
-            if (!isUpdateNecessary(context, shadowDocument, currentSyncInformation)) {
-                logger.atDebug()
-                        .kv(LOG_THING_NAME_KEY, getThingName())
-                        .kv(LOG_SHADOW_NAME_KEY, getShadowName())
-                        .log("Local shadow already contains update payload. No sync is necessary");
-                return;
-            }
-
-            long cloudUpdateVersion = shadowDocument.getVersion();
-            long currentCloudVersion = currentSyncInformation.getCloudVersion();
-            long currentLocalVersion = currentSyncInformation.getLocalVersion();
-
-            // Expected sequential cloud update, routing update to local shadow
-            if (cloudUpdateVersion == currentCloudVersion + 1) {
-                try {
-                    updateRequestWithLocalVersion(currentLocalVersion);
-
-                    UpdateThingShadowRequest request = new UpdateThingShadowRequest();
-                    request.setThingName(getThingName());
-                    request.setShadowName(getShadowName());
-                    request.setPayload(JsonUtil.getPayloadBytes(shadowDocument.toJson(false)));
-
-                    UpdateThingShadowHandlerResponse response =
-                            context.getUpdateHandler().handleRequest(request, SHADOW_MANAGER_NAME);
-
-                    byte[] updatedDocument = response.getCurrentDocument();
-                    long updateTime = Instant.now().getEpochSecond();
-                    long localUpdatedVersion = getUpdatedVersion(response.getUpdateThingShadowResponse().getPayload())
-                            .orElse(currentLocalVersion + 1);
-                    context.getDao().updateSyncInformation(SyncInformation.builder()
-                            .thingName(getThingName())
-                            .shadowName(getShadowName())
-                            .lastSyncedDocument(updatedDocument)
-                            .cloudUpdateTime(updateTime)
-                            .localVersion(localUpdatedVersion)
-                            .cloudVersion(cloudUpdateVersion)
-                            .lastSyncTime(updateTime)
-                            .cloudDeleted(false)
-                            .build());
-                    logger.atDebug()
-                            .kv(LOG_THING_NAME_KEY, getThingName())
-                            .kv(LOG_SHADOW_NAME_KEY, getShadowName())
-                            .kv(LOG_LOCAL_VERSION_KEY, localUpdatedVersion)
-                            .kv(LOG_CLOUD_VERSION_KEY, cloudUpdateVersion)
-                            .log("Successfully updated local shadow");
-                } catch (ShadowManagerDataException | UnauthorizedError | InvalidArgumentsError | ServiceError
-                         | IOException e) {
-                    logger.atDebug()
-                            .kv(LOG_THING_NAME_KEY, getThingName())
-                            .kv(LOG_SHADOW_NAME_KEY, getShadowName())
-                            .kv(LOG_LOCAL_VERSION_KEY, currentLocalVersion)
-                            .kv(LOG_CLOUD_VERSION_KEY, cloudUpdateVersion)
-                            .log("Skipping update for local shadow");
-                    throw new SkipSyncRequestException(e);
-                }
-
-                // edge case where might have missed sync update from cloud
-            } else if (cloudUpdateVersion > currentCloudVersion + 1) {
-                logger.atDebug()
-                        .kv(LOG_THING_NAME_KEY, getThingName())
-                        .kv(LOG_SHADOW_NAME_KEY, getShadowName())
-                        .kv(LOG_LOCAL_VERSION_KEY, currentSyncInformation.getLocalVersion())
-                        .kv(LOG_CLOUD_VERSION_KEY, currentSyncInformation.getCloudVersion())
-                        .kv(LOG_UPDATED_CLOUD_VERSION_KEY, cloudUpdateVersion)
-                        .log("Unable to update local shadow since some update(s) were missed from the cloud");
-                throw new ConflictError("Missed update(s) from the cloud");
-            }
+            // edge case where might have missed sync update from cloud
+        } else if (cloudUpdateVersion > currentCloudVersion + 1) {
+            logger.atDebug()
+                    .kv(LOG_THING_NAME_KEY, getThingName())
+                    .kv(LOG_SHADOW_NAME_KEY, getShadowName())
+                    .kv(LOG_LOCAL_VERSION_KEY, currentSyncInformation.getLocalVersion())
+                    .kv(LOG_CLOUD_VERSION_KEY, currentSyncInformation.getCloudVersion())
+                    .kv(LOG_UPDATED_CLOUD_VERSION_KEY, cloudUpdateVersion)
+                    .log("Unable to update local shadow since some update(s) were missed from the cloud");
+            throw new ConflictError("Missed update(s) from the cloud");
         }
     }
 
@@ -201,25 +188,19 @@ public class LocalUpdateSyncRequest extends BaseSyncRequest {
      */
     @Override
     public boolean isUpdateNecessary(SyncContext context) throws SkipSyncRequestException, UnknownShadowException {
-        // synchronizing access to shadow sync information because it is accessed by multiple threads.
-        // In this method, shadow sync information is accessed within context of the Nucleus'
-        // MqttClient event loop thread.
-        // The other place is the 'execute' method of this class, which runs on the sync thread.
-        synchronized (context.getSynchronizeHelper().getThingShadowLock(this)) {
-            //TODO: store this information in a return object to avoid unnecessary calls to DAO.
-            ShadowDocument shadowDocument;
-            try {
-                shadowDocument = new ShadowDocument(updateDocument);
-            } catch (IOException | InvalidRequestParametersException e) {
-                throw new SkipSyncRequestException(e);
-            }
-
-            SyncInformation currentSyncInformation = context.getDao()
-                    .getShadowSyncInformation(getThingName(), getShadowName())
-                    .orElseThrow(() -> new UnknownShadowException("Shadow not found in sync table"));
-
-            return isUpdateNecessary(context, shadowDocument, currentSyncInformation);
+        //TODO: store this information in a return object to avoid unnecessary calls to DAO.
+        ShadowDocument shadowDocument;
+        try {
+            shadowDocument = new ShadowDocument(updateDocument);
+        } catch (IOException | InvalidRequestParametersException e) {
+            throw new SkipSyncRequestException(e);
         }
+
+        SyncInformation currentSyncInformation = context.getDao()
+                .getShadowSyncInformation(getThingName(), getShadowName())
+                .orElseThrow(() -> new UnknownShadowException("Shadow not found in sync table"));
+
+        return isUpdateNecessary(context, shadowDocument, currentSyncInformation);
     }
 
     private boolean isUpdateNecessary(SyncContext context, ShadowDocument shadowDocument,

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
@@ -129,16 +129,14 @@ public class MergedFullShadowSyncRequest extends FullShadowSyncRequest {
     private static List<SyncRequest> flatten(List<SyncRequest> mergedRequests) {
         return mergedRequests.stream()
                 .flatMap(r -> {
-                    if (r instanceof MergedFullShadowSyncRequest) {
-                        MergedFullShadowSyncRequest other = (MergedFullShadowSyncRequest) r;
-                        if (other.getMergedRequests() == null) {
-                            return Stream.empty();
-                        } else {
-                            return other.getMergedRequests().stream();
-                        }
-                    } else {
+                    if (!(r instanceof MergedFullShadowSyncRequest)) {
                         return Stream.of(r);
                     }
+                    MergedFullShadowSyncRequest other = (MergedFullShadowSyncRequest) r;
+                    if (other.getMergedRequests() == null) {
+                        return Stream.empty();
+                    }
+                    return other.getMergedRequests().stream();
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.sync.model;
+
+import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
+import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
+import com.aws.greengrass.shadowmanager.sync.RequestMerger;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A {@link FullShadowSyncRequest} that was created by merging other {@link SyncRequest}s
+ * together. This class keeps track of all such merged requests.
+ *
+ * <p>When this sync request is executed, it will look through the merged requests
+ * and determine if a full sync is truly needed, based on {@link SyncRequest#isUpdateNecessary(SyncContext)}.
+ */
+public class MergedFullShadowSyncRequest extends FullShadowSyncRequest {
+
+    /**
+     * List of individual {@link SyncRequest}s that were merged together to become a full sync request.
+     */
+    @Getter
+    private final List<SyncRequest> mergedRequests = new ArrayList<>();
+    private final RequestMerger merger;
+
+    /**
+     * Creates a new MergedFullShadowSyncRequest.
+     *
+     * @param thingName      thing name
+     * @param shadowName     shadow name
+     * @param merger         merger
+     * @param mergedRequests requests that were merged to become a full sync request
+     */
+    public MergedFullShadowSyncRequest(String thingName, String shadowName,
+                                       RequestMerger merger, SyncRequest... mergedRequests) {
+        super(thingName, shadowName);
+        this.merger = Objects.requireNonNull(merger);
+        if (mergedRequests != null && mergedRequests.length > 0) {
+            this.mergedRequests.addAll(flatten(Arrays.asList(mergedRequests)));
+        }
+    }
+
+    @Override
+    public void execute(SyncContext context)
+            throws RetryableException, SkipSyncRequestException, InterruptedException, UnknownShadowException {
+        super.setContext(context);
+
+        List<SyncRequest> necessaryMergedUpdates = getNecessaryMergedRequests(context);
+        if (!necessaryMergedUpdates.isEmpty()
+                && (necessaryMergedUpdates.stream().allMatch(r -> r instanceof CloudUpdateSyncRequest)
+                || necessaryMergedUpdates.stream().allMatch(r -> r instanceof LocalUpdateSyncRequest))) {
+            SyncRequest consolidatedUpdateRequest = necessaryMergedUpdates.stream().reduce(merger::merge).get();
+            consolidatedUpdateRequest.execute(context);
+            return;
+        }
+
+        super.execute(context);
+    }
+
+    /**
+     * Create a list of all the merged requests that require execution,
+     * as deemed by {@link SyncRequest#isUpdateNecessary(SyncContext)}.
+     *
+     * @param context sync context
+     * @return sync requests
+     * @throws RetryableException       When error occurs in sync operation indicating a request needs to be retried
+     * @throws SkipSyncRequestException When error occurs in sync operation indicating a request needs to be skipped.
+     * @throws UnknownShadowException   When shadow not found in the sync table.
+     */
+    private List<SyncRequest> getNecessaryMergedRequests(SyncContext context)
+            throws RetryableException, UnknownShadowException, SkipSyncRequestException {
+        List<SyncRequest> necessaryUpdates = new ArrayList<>();
+        for (SyncRequest request : mergedRequests) {
+            if (request.isUpdateNecessary(context)) {
+                necessaryUpdates.add(request);
+            }
+        }
+        return necessaryUpdates;
+    }
+
+    /**
+     * Returns a new list that matches the input, but all {@link MergedFullShadowSyncRequest}s
+     * are replaced (flat-mapped) with their {@link MergedFullShadowSyncRequest#mergedRequests}.
+     *
+     * @param mergedRequests sync requests
+     * @return sync requests
+     */
+    private static List<SyncRequest> flatten(List<SyncRequest> mergedRequests) {
+        return mergedRequests.stream()
+                .flatMap(r -> {
+                    if (r instanceof MergedFullShadowSyncRequest) {
+                        MergedFullShadowSyncRequest other = (MergedFullShadowSyncRequest) r;
+                        if (other.getMergedRequests() == null) {
+                            return Stream.empty();
+                        } else {
+                            return other.getMergedRequests().stream();
+                        }
+                    } else {
+                        return Stream.of(r);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
  * together. This class keeps track of all such merged requests.
  *
  * <p>When this sync request is executed, it will look through the merged requests
- * and determine if a full sync is truly needed, based on {@link SyncRequest#isUpdateNecessary(SyncContext)}.
+ * and determine if a full sync is truly needed, based on {@link BaseSyncRequest#isUpdateNecessary(SyncContext)}.
  */
 public class MergedFullShadowSyncRequest extends FullShadowSyncRequest {
 
@@ -70,7 +70,7 @@ public class MergedFullShadowSyncRequest extends FullShadowSyncRequest {
 
     /**
      * Create a list of all the merged requests that require execution,
-     * as deemed by {@link SyncRequest#isUpdateNecessary(SyncContext)}.
+     * as deemed by {@link BaseSyncRequest#isUpdateNecessary(SyncContext)}.
      *
      * @param context sync context
      * @return sync requests
@@ -82,7 +82,10 @@ public class MergedFullShadowSyncRequest extends FullShadowSyncRequest {
             throws RetryableException, UnknownShadowException, SkipSyncRequestException {
         List<SyncRequest> necessaryUpdates = new ArrayList<>();
         for (SyncRequest request : mergedRequests) {
-            if (request.isUpdateNecessary(context)) {
+            if (!(request instanceof BaseSyncRequest)) {
+                continue;
+            }
+            if (((BaseSyncRequest) request).isUpdateNecessary(context)) {
                 necessaryUpdates.add(request);
             }
         }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/MergedFullShadowSyncRequest.java
@@ -63,6 +63,12 @@ public class MergedFullShadowSyncRequest extends FullShadowSyncRequest {
             throws RetryableException, SkipSyncRequestException, InterruptedException, UnknownShadowException {
         super.setContext(context);
 
+        if (getMergedRequests().stream().anyMatch(r -> r.getClass().equals(FullShadowSyncRequest.class))) {
+            // If a full sync has been directly requested, not due to merging of requests, respect it.
+            super.execute(context);
+            return;
+        }
+
         List<SyncRequest> necessaryMergedUpdates = getNecessaryMergedRequests(context);
         if (necessaryMergedUpdates.isEmpty()) {
             logger.atDebug()

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequest.java
@@ -76,7 +76,7 @@ public class OverwriteCloudShadowRequest extends BaseSyncRequest {
      * @return true.
      */
     @Override
-    public boolean isUpdateNecessary(SyncContext context) {
+    boolean isUpdateNecessary(SyncContext context) {
         return true;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequest.java
@@ -76,7 +76,7 @@ public class OverwriteLocalShadowRequest extends BaseSyncRequest {
      * @return true.
      */
     @Override
-    public boolean isUpdateNecessary(SyncContext context) {
+    boolean isUpdateNecessary(SyncContext context) {
         return true;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncContext.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncContext.java
@@ -9,7 +9,6 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDAO;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
-import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
@@ -20,5 +19,4 @@ public class SyncContext {
     UpdateThingShadowRequestHandler updateHandler;
     DeleteThingShadowRequestHandler deleteHandler;
     IotDataPlaneClientWrapper iotDataPlaneClientWrapper;
-    ShadowWriteSynchronizeHelper synchronizeHelper;
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/SyncRequest.java
@@ -30,15 +30,4 @@ public interface SyncRequest {
     void execute(SyncContext context) throws RetryableException, SkipSyncRequestException,
             UnknownShadowException, InterruptedException;
 
-    /**
-     * Check if an update is necessary or not.
-     *
-     * @param context context object containing useful objects for requests to use when executing.
-     * @return true if an update is necessary; Else false.
-     * @throws RetryableException       When error occurs in sync operation indicating a request needs to be retried
-     * @throws SkipSyncRequestException When error occurs in sync operation indicating a request needs to be skipped.
-     * @throws UnknownShadowException   When shadow not found in the sync table.
-     */
-    boolean isUpdateNecessary(SyncContext context) throws RetryableException, SkipSyncRequestException,
-            UnknownShadowException;
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
-import com.aws.greengrass.shadowmanager.exception.SkipSyncRequestException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -285,23 +285,6 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
         }
 
         try {
-            if (!request.isUpdateNecessary(context)) {
-                logger.atDebug()
-                        .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
-                        .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
-                        .addKeyValue("type", request.getClass())
-                        .log("Ignoring sync request since update is not necessary");
-                return;
-            }
-        } catch (SkipSyncRequestException | RetryableException | UnknownShadowException e) {
-            logger.atWarn(SYNC_EVENT_TYPE)
-                    .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
-                    .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())
-                    .log("Ignoring sync request since update is not necessary");
-            return;
-        }
-
-        try {
             logger.atDebug(SYNC_EVENT_TYPE)
                     .addKeyValue(LOG_THING_NAME_KEY, request.getThingName())
                     .addKeyValue(LOG_SHADOW_NAME_KEY, request.getShadowName())

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/CloudUpdateSyncRequestTest.java
@@ -14,7 +14,6 @@ import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
-import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.BeforeAll;
@@ -96,7 +95,6 @@ class CloudUpdateSyncRequestTest {
         baseDocumentJson = JsonUtil.getPayloadJson(BASE_DOCUMENT).get();
         lenient().when(mockContext.getDao()).thenReturn(mockDao);
         lenient().when(mockContext.getIotDataPlaneClientWrapper()).thenReturn(mockIotDataPlaneClientWrapper);
-        lenient().when(mockContext.getSynchronizeHelper()).thenReturn(new ShadowWriteSynchronizeHelper());
         lenient().when(mockDao.getShadowSyncInformation(anyString(), anyString())).thenReturn(Optional.of(SyncInformation.builder().build()));
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -18,7 +18,6 @@ import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
-import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -104,8 +103,6 @@ class FullShadowSyncRequestTest {
     private UpdateThingShadowRequestHandler mockUpdateThingShadowRequestHandler;
     @Mock
     private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
-    @Mock
-    private ShadowWriteSynchronizeHelper mockSynchronizeHelper;
     @Captor
     private ArgumentCaptor<SyncInformation> syncInformationCaptor;
     @Captor
@@ -126,7 +123,7 @@ class FullShadowSyncRequestTest {
     void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(syncInformationCaptor.capture())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
-                mockIotDataPlaneClientWrapper, mockSynchronizeHelper);
+                mockIotDataPlaneClientWrapper);
         JsonUtil.loadSchema();
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -131,7 +131,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_updated_local_and_cloud_document_WHEN_execute_THEN_updates_local_and_cloud_document() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_updated_local_and_cloud_document_WHEN_execute_THEN_updates_local_and_cloud_document() throws Exception {
         long epochSeconds = Instant.now().getEpochSecond();
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         JsonNode expectedMergedDocument = JsonUtil.getPayloadJson(MERGED_DOCUMENT).get();
@@ -192,7 +192,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_updated_cloud_document_and_no_local_document_WHEN_execute_THEN_deletes_cloud_document() throws RetryableException, SkipSyncRequestException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_updated_cloud_document_and_no_local_document_WHEN_execute_THEN_deletes_cloud_document() throws Exception {
         long epochSeconds = Instant.now().getEpochSecond();
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         GetThingShadowResponse response = GetThingShadowResponse.builder()
@@ -238,7 +238,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_same_cloud_document_and_local_document_WHEN_execute_THEN_does_not_update_local_and_cloud_document() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_same_cloud_document_and_local_document_WHEN_execute_THEN_does_not_update_local_and_cloud_document() throws Exception {
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         GetThingShadowResponse response = GetThingShadowResponse.builder()
                 .payload(SdkBytes.fromByteArray(CLOUD_DOCUMENT))
@@ -268,7 +268,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_nonexistent_cloud_document_and_existent_local_document_WHEN_execute_THEN_deletes_local_document(ExtensionContext context) throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_nonexistent_cloud_document_and_existent_local_document_WHEN_execute_THEN_deletes_local_document(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         long epochSeconds = Instant.now().getEpochSecond();
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
@@ -315,7 +315,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_local_document_first_sync_and_existent_cloud_document_WHEN_execute_THEN_updates_local_document() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_local_document_first_sync_and_existent_cloud_document_WHEN_execute_THEN_updates_local_document() throws Exception {
         long epochSeconds = Instant.now().getEpochSecond();
         JsonNode expectedMergedDocument = JsonUtil.getPayloadJson(CLOUD_DOCUMENT).get();
         ((ObjectNode) expectedMergedDocument).remove(SHADOW_DOCUMENT_VERSION);
@@ -369,7 +369,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_cloud_document_first_sync_and_existent_local_document_WHEN_execute_THEN_updates_cloud_document(ExtensionContext context) throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_cloud_document_first_sync_and_existent_local_document_WHEN_execute_THEN_updates_cloud_document(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
         long epochSeconds = Instant.now().getEpochSecond();
         JsonNode expectedMergedDocument = JsonUtil.getPayloadJson(LOCAL_DOCUMENT).get();
@@ -423,7 +423,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_non_existent_cloud_document_and_non_existent_local_document_WHEN_execute_THEN_updates_sync_info_only(ExtensionContext context) throws RetryableException, SkipSyncRequestException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_non_existent_cloud_document_and_non_existent_local_document_WHEN_execute_THEN_updates_sync_info_only(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
         when(mockIotDataPlaneClientWrapper.getThingShadow(anyString(), anyString())).thenThrow(ResourceNotFoundException.class);
@@ -1042,7 +1042,7 @@ class FullShadowSyncRequestTest {
 
 
     @Test
-    void GIVEN_updated_local_and_cloud_with_delta_document_WHEN_execute_THEN_updates_local_and_cloud_document() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_updated_local_and_cloud_with_delta_document_WHEN_execute_THEN_updates_local_and_cloud_document() throws Exception {
         long epochSeconds = Instant.now().getEpochSecond();
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         JsonNode expectedMergedDocument = JsonUtil.getPayloadJson(MERGED_DOCUMENT).get();
@@ -1103,7 +1103,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_updated_local_after_delete_WHEN_execute_THEN_updates_cloud_document(ExtensionContext context) throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_updated_local_after_delete_WHEN_execute_THEN_updates_cloud_document(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
 
         long epochSeconds = Instant.now().getEpochSecond();
@@ -1164,7 +1164,7 @@ class FullShadowSyncRequestTest {
     }
 
     @Test
-    void GIVEN_updated_cloud_document_after_delete_WHEN_execute_THEN_updates_local_document() throws RetryableException, SkipSyncRequestException, IOException, InterruptedException, IoTDataPlaneClientCreationException {
+    void GIVEN_updated_cloud_document_after_delete_WHEN_execute_THEN_updates_local_document() throws Exception {
         long epochSeconds = Instant.now().getEpochSecond();
         long epochSecondsMinus60 = Instant.now().minusSeconds(60).getEpochSecond();
         final byte[] CLOUD_DOCUMENT = ("{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Pink Floyd\", \"SomethingNew\": true}}, "

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalDeleteSyncRequestTest.java
@@ -13,7 +13,6 @@ import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
-import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.core.JsonParseException;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,7 +92,7 @@ class LocalDeleteSyncRequestTest {
                 .thenReturn(new DeleteThingShadowResponse());
 
         syncContext = new SyncContext(mockDao, mock(UpdateThingShadowRequestHandler.class),
-                mockDeleteThingShadowRequestHandler, mock(IotDataPlaneClientWrapper.class), mock(ShadowWriteSynchronizeHelper.class));
+                mockDeleteThingShadowRequestHandler, mock(IotDataPlaneClientWrapper.class));
     }
 
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/LocalUpdateSyncRequestTest.java
@@ -17,7 +17,6 @@ import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
-import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import org.hamcrest.Matchers;
@@ -92,7 +91,7 @@ class LocalUpdateSyncRequestTest {
     @BeforeEach
     void setup() throws IOException {
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler,
-                mock(DeleteThingShadowRequestHandler.class), mock(IotDataPlaneClientWrapper.class), new ShadowWriteSynchronizeHelper());
+                mock(DeleteThingShadowRequestHandler.class), mock(IotDataPlaneClientWrapper.class));
         JsonUtil.loadSchema();
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteCloudShadowRequestTest.java
@@ -15,7 +15,6 @@ import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
-import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -64,8 +63,6 @@ class OverwriteCloudShadowRequestTest {
     private UpdateThingShadowRequestHandler mockUpdateThingShadowRequestHandler;
     @Mock
     private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
-    @Mock
-    private ShadowWriteSynchronizeHelper mockSynchronizeHelper;
     @Captor
     private ArgumentCaptor<SyncInformation> syncInformationCaptor;
     @Captor
@@ -81,7 +78,7 @@ class OverwriteCloudShadowRequestTest {
     void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(any())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
-                mockIotDataPlaneClientWrapper, mockSynchronizeHelper);
+                mockIotDataPlaneClientWrapper);
         JsonUtil.loadSchema();
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/OverwriteLocalShadowRequestTest.java
@@ -15,7 +15,6 @@ import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
-import com.aws.greengrass.shadowmanager.util.ShadowWriteSynchronizeHelper;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -71,8 +70,6 @@ class OverwriteLocalShadowRequestTest {
     private DeleteThingShadowRequestHandler mockDeleteThingShadowRequestHandler;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private UpdateThingShadowHandlerResponse mockUpdateThingShadowHandlerResponse;
-    @Mock
-    private ShadowWriteSynchronizeHelper mockSynchronizeHelper;
     @Captor
     private ArgumentCaptor<SyncInformation> syncInformationCaptor;
     @Captor
@@ -86,7 +83,7 @@ class OverwriteLocalShadowRequestTest {
     void setup() throws IOException {
         lenient().when(mockDao.updateSyncInformation(any())).thenReturn(true);
         syncContext = new SyncContext(mockDao, mockUpdateThingShadowRequestHandler, mockDeleteThingShadowRequestHandler,
-                mockIotDataPlaneClientWrapper, mockSynchronizeHelper);
+                mockIotDataPlaneClientWrapper);
         JsonUtil.loadSchema();
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
@@ -45,7 +45,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -79,7 +78,6 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         mockSyncContext = mock(SyncContext.class);
         mockRetryer = mock(Retryer.class);
         mockFullShadowSyncRequest = mock(FullShadowSyncRequest.class);
-        lenient().when(mockFullShadowSyncRequest.isUpdateNecessary(any())).thenReturn(true);
         strategy = defaultTestInstance();
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

:warning: This change undoes the (unreleased) fix in https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/166, which introduces a bug where the IPC thread could potentially be blocked, and takes a different approach by restricting sync info to being read by only one thread.

This change adjusts where `SyncRequest#isUpdateNecessary` is called, so that it is only called when a `SyncRequest` is executing on a sync thread.  This is different than previous behavior, where an IPC or MQTT CRT thread could call this method, to read shadow sync information from the local database to make a decision on whether or not the SyncRequest should be put on the queue.  This ensures that shadow sync information is only read and written to the local database from a single thread.

Since "unnecessary" requests aren't being filtered before being put on the RequestBlockingQueue anymore, there needs to be a filtering mechanism when the `SyncRequest` executes.  Otherwise, the behavior fixed in https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/106 will regress.

This behavior already works for requests that are not merged into a full sync by RequestMerger, because `SyncRequest`s already check `isUpdateNecessary` at the beginning.  To make it work for full syncs, we need to maintain a "history" of all requests that were merged together for a particular full sync request.  Then, when the full sync executes, it can look through these "sub-requests", filter out the unnecessary ones, merge them all together, and execute the result.  All of this behavior is wrapped in a new `MergedFullShadowSyncRequest` class.


The rest of the changes in the PR are cleanup from reverting https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/166:
* remove synchronization blocks from all SyncRequests
* undo handling MQTT messages asynchronously
* remove SynchronizationHelper from SyncContext

along with a bunch of flaky test fixes.

**Why is this change necessary:**
To address a customer issue where cloud updates were being dropped due to a race condition when reading outdated sync information from the IPC thread. (more details of the original issue in https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/166)

**How was this change tested:**
Integration tests

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
