### PR TITLE
feat: run uats against release candidate

### DIFF
--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -84,15 +84,14 @@
                 <executions>
                     <execution>
                         <id>copy-artifact-to-classpath</id>
-                        <phase>package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipTests}</skip>
-                            <target name="copy only uat jar">
-                                <copy file="${project.basedir}/target/${project.artifactId}-${project.version}.jar"
-                                      tofile="${project.basedir}/target/classes/greengrass/artifacts/componentArtifact.jar"/>
+                            <target name="copy component under test artifact">
+                                <copy file="../../target/aws.greengrass.ShadowManager.jar"
+                                      tofile="${project.basedir}/target/classes/greengrass/artifacts/aws.greengrass.ShadowManager.jar"/>
                             </target>
                         </configuration>
                     </execution>
@@ -205,10 +204,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.aws.greengrass.testing.launcher.TestLauncher</mainClass>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>greengrass/artifacts/componentArtifact.jar</resource>
-                                    <file>${project.basedir}/target/classes/greengrass/artifacts/componentArtifact.jar</file>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/uat/testing-features/src/main/java/com/aws/greengrass/ShadowSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/ShadowSteps.java
@@ -112,6 +112,7 @@ public class ShadowSteps {
         return String.format("e2e-%d-%s", System.currentTimeMillis(), UUID.randomUUID().toString());
     }
 
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     private void canGetShadow(final String thingName, final String shadowName, final String stateString,
                               final int timeoutSeconds, final boolean shouldNotExist, final long version)
             throws IOException, InterruptedException {

--- a/uat/testing-features/src/main/resources/greengrass/features/shadow-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/shadow-1.feature
@@ -9,7 +9,7 @@ Feature: Greengrass V2 ShadowManager
         And I start an assertion server
         Given I create a Greengrass deployment with components
             | aws.greengrass.Cli        | LATEST |
-            | aws.greengrass.ShadowManager | LATEST |
+            | aws.greengrass.ShadowManager |  classpath:/greengrass/recipes/recipe.yaml |
         And I deploy the Greengrass deployment configuration
         Then the Greengrass deployment is COMPLETED on the device after 2 minutes
         Then I verify the aws.greengrass.ShadowManager component is RUNNING using the greengrass-cli
@@ -43,6 +43,7 @@ Feature: Greengrass V2 ShadowManager
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         Then I get 1 assertions with context "Retrieved matching shadow document"
 
+    @unstable
     Scenario: Shadow-1-T2: As a developer, I can use the Greengrass local shadow service to UPDATE a shadow from my component.
         When I install the component ShadowComponentPing from local store with configuration
         """
@@ -85,6 +86,7 @@ Feature: Greengrass V2 ShadowManager
         Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         Then I get 1 assertions with context "Retrieved matching shadow document"
 
+    @unstable
     Scenario: Shadow-1-T3: As a developer, I can use the Greengrass local shadow service to DELETE a shadow from my component.
         When I install the component ShadowComponentPing from local store with configuration
         """

--- a/uat/testing-features/src/main/resources/greengrass/features/shadow-2.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/shadow-2.feature
@@ -9,10 +9,11 @@ Feature: Shadow-2
     When I add random shadow for MyThing with name MyThingNamedShadow in context
     When I add random shadow for MyThing2 with name MyThingNamedShadow2 in context
 
+  @unstable
   Scenario Outline: Shadow-2-T1-<strategy>: As a developer, I can sync a local named shadow to the cloud.
     When I create a Greengrass deployment with components
       | aws.greengrass.Nucleus       | LATEST |
-      | aws.greengrass.ShadowManager | LATEST |
+      | aws.greengrass.ShadowManager | classpath:/greengrass/recipes/recipe.yaml |
       | aws.greengrass.Cli       | LATEST |
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.ShadowManager configuration to:
         """

--- a/uat/testing-features/src/main/resources/greengrass/features/shadow-6.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/shadow-6.feature
@@ -10,7 +10,7 @@ Feature: Shadow-6
   @stable @functional
   Scenario: Shadow-6-T1: As a customer I can reset the strategy field and merge it back again and it should work correctly.
     When I create a Greengrass deployment with components
-      | aws.greengrass.ShadowManager | LATEST |
+      | aws.greengrass.ShadowManager |  classpath:/greengrass/recipes/recipe.yaml |
       | aws.greengrass.Cli           | LATEST |
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.ShadowManager configuration to:
       """

--- a/uat/testing-features/src/main/resources/greengrass/recipes/recipe.yaml
+++ b/uat/testing-features/src/main/resources/greengrass/recipes/recipe.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: aws.greengrass.ShadowManager
+ComponentDescription: AWS Greengrass Shadow Manager
+ComponentPublisher: AWS
+ComponentVersion: '2.4.0'
+ComponentType: 'aws.greengrass.plugin'
+Manifests:
+  - Artifacts:
+      - URI: "classpath:/greengrass/artifacts/aws.greengrass.ShadowManager.jar"
+        Permission:
+          Read: ALL
+          Execute: ALL


### PR DESCRIPTION
**Description of changes:**
Modify the uat setup so that the tests run against the current version of the code and not against the artifact already deployed in production.

**Why is this change necessary:**
Required to effectively test uats on our release pipeline

**How was this change tested:**
Ran the uats