### PR TITLE
fix: drop reported delta in update shadow

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
@@ -43,6 +43,8 @@ import static com.aws.greengrass.shadowmanager.model.Constants.LOG_LOCAL_VERSION
 import static com.aws.greengrass.shadowmanager.model.Constants.LOG_SHADOW_NAME_KEY;
 import static com.aws.greengrass.shadowmanager.model.Constants.LOG_THING_NAME_KEY;
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_METADATA;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_STATE;
+import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_STATE_DELTA;
 import static com.aws.greengrass.shadowmanager.util.JsonUtil.isNullOrMissing;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.UPDATE_THING_SHADOW;
 
@@ -129,6 +131,14 @@ public class UpdateThingShadowRequestHandler extends BaseRequestHandler {
                             .orElseThrow(() ->
                                     new InvalidRequestParametersException(ErrorMessage
                                             .createInvalidPayloadJsonMessage("")));
+
+                    // drop "delta" from the state (if we have a state).
+                    // delta isn't valid for users to set.
+                    if (updateDocumentRequest.has(SHADOW_DOCUMENT_STATE)
+                            && updateDocumentRequest.get(SHADOW_DOCUMENT_STATE).isObject()) {
+                        ((ObjectNode) updateDocumentRequest.get(SHADOW_DOCUMENT_STATE))
+                                .remove(SHADOW_DOCUMENT_STATE_DELTA);
+                    }
                     // Validate the payload schema
                     JsonUtil.validatePayloadSchema(updateDocumentRequest);
 

--- a/src/test/resources/com/aws/greengrass/shadowmanager/ipc/json_shadow_examples/bad_update_document_with_delta_node.json
+++ b/src/test/resources/com/aws/greengrass/shadowmanager/ipc/json_shadow_examples/bad_update_document_with_delta_node.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "clientToken": "device",
+  "state": {
+    "desired": {
+      "a": 1
+    },
+    "delta": {
+      "something": {}
+    }
+  }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Specifying "delta" as part of an update request was allowed, but this does not work when reporting the shadow to IoT Core.

```
InvalidRequestException: State contains an invalid node: 'delta' (Service: IotDataPlane, Status Code: 400
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
