### PR TITLE
fix: remove and recreate DB in the case of corruption

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
+import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.flywaydb.core.internal.exception.FlywaySqlException;
@@ -151,10 +152,10 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
     @Test
     void GIVEN_corrupted_db_WHEN_install_THEN_shadow_manager_database_reinstalls_and_starts_successfully(ExtensionContext context)
             throws Exception {
+        ignoreExceptionOfType(context, ShadowManagerDataException.class);
         ignoreExceptionOfType(context, FlywaySqlException.class);
         Path dest = Paths.get(rootDir.toString()+"/shadow.mv.db");
         Path source = Paths.get(getClass().getResource("database/corrupted.mv.db").toURI());
-        Files.deleteIfExists(dest);
         Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
         // GIVEN
         db.open();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
@@ -12,11 +12,13 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,7 +30,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -49,6 +53,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -70,7 +75,7 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
     ShadowManagerDatabase db;
 
     @BeforeEach
-    void initializeShadowManagerDatabase() {
+    void initializeShadowManagerDatabase() throws IOException {
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         db = new ShadowManagerDatabase(rootDir);
         db.install();
@@ -119,6 +124,38 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
 
     @Test
     void GIVEN_migrations_WHEN_install_THEN_shadow_manager_database_installs_and_starts_successfully() throws Exception {
+        // GIVEN
+        db.open();
+        assertNotNull(db.getPool());
+
+        // WHEN
+        db.install();
+
+        // THEN
+        List<String> tables = loadTables(db.getPool().getConnection());
+        // flyway installed
+        assertThat(tables, hasItem(equalToIgnoringCase("flyway_schema_history")));
+
+        // expected tables
+        assertThat(tables, hasItems(equalToIgnoringCase("documents"),
+                equalToIgnoringCase("sync")));
+
+        // tables loaded by migrations provided as test resources
+        assertThat(tables, hasItems(equalToIgnoringCase("foo"),
+                equalToIgnoringCase("baz")));
+
+        // table removed from migration
+        assertThat(tables, not(hasItem(equalToIgnoringCase("bar"))));
+    }
+
+    @Test
+    void GIVEN_corrupted_db_WHEN_install_THEN_shadow_manager_database_reinstalls_and_starts_successfully(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, FlywaySqlException.class);
+        Path dest = Paths.get(rootDir.toString()+"/shadow.mv.db");
+        Path source = Paths.get(getClass().getResource("database/corrupted.mv.db").toURI());
+        Files.deleteIfExists(dest);
+        Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
         // GIVEN
         db.open();
         assertNotNull(db.getPool());

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/database/corrupted.mv.db
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/database/corrupted.mv.db
@@ -1,0 +1,1 @@
+H:2,block:2,blockSize:1000,chunk:1,clean:1,created:18777a5e99a,format:1,version:1,fletcher:7c9677e7

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -53,7 +53,6 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Synchronized;
-import org.flywaydb.core.api.FlywayException;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -21,6 +21,7 @@ import com.aws.greengrass.shadowmanager.configuration.ComponentConfiguration;
 import com.aws.greengrass.shadowmanager.configuration.RateLimitsConfiguration;
 import com.aws.greengrass.shadowmanager.configuration.ShadowDocSizeConfiguration;
 import com.aws.greengrass.shadowmanager.exception.InvalidConfigurationException;
+import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowIPCHandler;
 import com.aws.greengrass.shadowmanager.ipc.DeleteThingShadowRequestHandler;
 import com.aws.greengrass.shadowmanager.ipc.GetThingShadowIPCHandler;
@@ -236,7 +237,7 @@ public class ShadowManager extends PluginService {
                 database.install();
                 JsonUtil.loadSchema();
             }
-        } catch (FlywayException | IOException e) {
+        } catch (ShadowManagerDataException | IOException e) {
             serviceErrored(e);
             return;
         }

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
@@ -76,6 +76,7 @@ public class ShadowManagerDatabase implements Closeable {
      * @throws ShadowManagerDataException if flyway migration fails
      */
     @Synchronized
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
     public void install() throws ShadowManagerDataException {
         try {
             if (!isMigrationSuccessful()) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
@@ -79,7 +79,8 @@ public class ShadowManagerDatabase implements Closeable {
     @Synchronized
     public void install() throws ShadowManagerDataException {
         try {
-            if (!isMigrationSuccessful()) {
+            boolean isMigrationSuccessful = migrateAndGetResult();
+            if (!isMigrationSuccessful) {
                 logger.atWarn().log("Failed to migrate the existing shadow manager DB. "
                         + "Removing it and creating a new one.");
                 deleteDB(databasePath);
@@ -98,7 +99,7 @@ public class ShadowManagerDatabase implements Closeable {
         flyway.migrate();
     }
 
-    private boolean isMigrationSuccessful() {
+    private boolean migrateAndGetResult() {
         try {
             migrateDB();
             return true;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When shadow manager DB is corrupted, the component goes into BROKEN state. The database file must be deleted for the component to create a new database and continue working. This change automates this deletion when the migration of DB fails due to corruption.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
