### PR TITLE
test: fix integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <nucleus.version>2.5.0-SNAPSHOT</nucleus.version>
         <junit.version>5.6.2</junit.version>
         <mockito.version>4.3.1</mockito.version>
-        <lombok.version>1.18.10</lombok.version>
+        <lombok.version>1.18.26</lombok.version>
         <hamcrest.core.version>2.2</hamcrest.core.version>
         <hamcrest.eventually.version>0.0.3</hamcrest.eventually.version>
         <flyway.version>6.5.5</flyway.version>
@@ -541,7 +541,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,6 +80,7 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
     @AfterEach
     void close() throws IOException {
         db.close();
+        FileUtils.deleteDirectory(rootDir.toFile());
     }
 
     @Test
@@ -186,11 +188,11 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
 
         final String[] things = new String[numThings];
         for (int i = 0; i < numThings; i++) {
-            things[i] = UUID.randomUUID().toString();
+            things[i] = "thing-"+i;
         }
         final String[] shadows = new String[numShadows];
         for (int i = 0; i < numShadows; i++) {
-            shadows[i] = UUID.randomUUID().toString();
+            shadows[i] = "shadow-"+i;
         }
 
         List<Long> sizes = Collections.synchronizedList(new ArrayList<>());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.security.SecurityService;
+import com.aws.greengrass.shadowmanager.ShadowManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationException;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
@@ -169,6 +170,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
                 .configFile(DEFAULT_CONFIG)
                 .mqttConnected(false)
                 .build());
+        shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().build());
         ShadowManagerDAOImpl impl = kernel.getContext().get(ShadowManagerDAOImpl.class);
         createThingShadowSyncInfo(impl, THING_NAME);
         createThingShadowSyncInfo(impl, THING_NAME2);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncDirectionalityTest.java
@@ -110,7 +110,7 @@ class SyncDirectionalityTest extends NucleusLaunchUtils {
                 .build());
 
         assertSyncingHasStarted(RealTimeSyncStrategy.class);
-
+        assertEmptySyncQueue(RealTimeSyncStrategy.class);
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();
 
         // update local shadow

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/periodic_sync.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/periodic_sync.yaml
@@ -22,9 +22,7 @@ services:
     dependencies:
       - DoAll
   DoAll:
-    lifecycle:
-      startup: echo "Running"
-      shutdown: echo "Stopping"
+    lifecycle: {}
     dependencies:
       - aws.greengrass.ShadowManager
     configuration:

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/sync.yaml
@@ -15,9 +15,7 @@ services:
     dependencies:
       - DoAll
   DoAll:
-    lifecycle:
-      startup: echo "Running"
-      shutdown: echo "Stopping"
+    lifecycle: {}
     dependencies:
       - aws.greengrass.ShadowManager
     configuration:

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandler.java
@@ -87,7 +87,7 @@ public class DeleteThingShadowRequestHandler extends BaseRequestHandler {
         return translateExceptions(() -> {
             String thingName = request.getThingName();
             String shadowName = request.getShadowName();
-            logger.atTrace("ipc-update-thing-shadow-request").log();
+            logger.atTrace("ipc-delete-thing-shadow-request").log();
 
             ShadowRequest shadowRequest = new ShadowRequest(thingName, shadowName);
             try {
@@ -118,7 +118,7 @@ public class DeleteThingShadowRequestHandler extends BaseRequestHandler {
                     logger.atDebug()
                             .kv(LOG_THING_NAME_KEY, thingName)
                             .kv(LOG_SHADOW_NAME_KEY, shadowName)
-                            .log("Successfully delete shadow");
+                            .log("Successfully deleted shadow the local shadow");
 
                     JsonNode responseNode = ResponseMessageBuilder.builder()
                             .withVersion(deletedShadowDocument.get().getVersion())

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandler.java
@@ -118,7 +118,7 @@ public class DeleteThingShadowRequestHandler extends BaseRequestHandler {
                     logger.atDebug()
                             .kv(LOG_THING_NAME_KEY, thingName)
                             .kv(LOG_SHADOW_NAME_KEY, shadowName)
-                            .log("Successfully deleted shadow the local shadow");
+                            .log("Successfully deleted the local shadow");
 
                     JsonNode responseNode = ResponseMessageBuilder.builder()
                             .withVersion(deletedShadowDocument.get().getVersion())

--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>RELEASE</version>
+            <version>1.18.26</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixing the issues in the integration tests that are caused due to timeout and race condition especially in the sync tests for realtime and periodic sync strategies. 
- Countdown latches are added wherever applicable to avoid premature ending of tests.
- Actual testing in some sync test scenarios starts after the initial full shadow sync is performed. This ensures that the assertions (especially for  shadow versions) can be made in a definite way.


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
