### PR TITLE
fix: shadow1 UATs

### DIFF
--- a/uat/custom-components/src/main/resources/recipes/ShadowComponentPong.yaml
+++ b/uat/custom-components/src/main/resources/recipes/ShadowComponentPong.yaml
@@ -15,7 +15,7 @@ ComponentConfiguration:
     Operation: "NoOp"
     ThingName: "testThing"
     ShadowName: "testShadow"
-    ShadowDocument: "{\"id\": 1, \"name\": \"The_Beatles\"}"
+    ShadowDocument: ""
     PageSize: ""
     NextToken: ""
     OperationTimeout: 0

--- a/uat/custom-components/src/main/resources/recipes/ShadowReactiveComponentPing.yaml
+++ b/uat/custom-components/src/main/resources/recipes/ShadowReactiveComponentPing.yaml
@@ -46,5 +46,5 @@ Manifests:
     Lifecycle:
       Setenv:
         SubscribeTopic: "{configuration:/SubscribeTopic}"
-      Startup:
-        java -Dlog.level=INFO -DcomponentName="ShadowReactiveComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/UpdateDocumentRequest1}"
+      Run: >-
+        java -Dlog.level=INFO -DcomponentName="ShadowReactiveComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/UpdateDocumentRequest1}" "{configuration:/ExpectedShadowDocument1}" "{configuration:/ExpectedShadowDocument2}"

--- a/uat/custom-components/src/main/resources/recipes/ShadowReactiveComponentPong.yaml
+++ b/uat/custom-components/src/main/resources/recipes/ShadowReactiveComponentPong.yaml
@@ -46,5 +46,5 @@ Manifests:
     Lifecycle:
       Setenv:
         SubscribeTopic: "{configuration:/SubscribeTopic}"
-      Startup: >-
-        java -Dlog.level=INFO -DcomponentName="ShadowReactiveComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/UpdateDocumentRequest1}"
+      Run: >-
+        java -Dlog.level=INFO -DcomponentName="ShadowReactiveComponent" -jar {artifacts:path}/custom-components.jar "{configuration:/ThingName}" "{configuration:/ShadowName}" "{configuration:/UpdateDocumentRequest1}" "{configuration:/ExpectedShadowDocument1}" "{configuration:/ExpectedShadowDocument2}"

--- a/uat/testing-features/src/main/resources/greengrass/features/shadow-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/shadow-1.feature
@@ -395,6 +395,7 @@ Feature: Greengrass V2 ShadowManager
            }
         }
         """
+        Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
         When I install the component ShadowComponentPong from local store with configuration
         """
         {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix ShadowReactive custom component recipes which is used in 7 UATs of shadow manager.

- Run jar from Run lifecyle but not start up
- Fix number of arguments passed to the run command. 
- Use response objects  as supported by v2 clients instead of `CompletableFuture` objects. 

**Why is this change necessary:**
**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
