### PR TITLE
feat: store thing shadow sync configurations as a map

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ThingShadow.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ThingShadow.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.model.configuration;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+@Builder
+public class ThingShadow {
+    private final String thingName;
+    private final String shadowName;
+
+    @Override
+    public boolean equals(Object o) {
+        // If the object is compared with itself then return true
+        if (o == this) {
+            return true;
+        }
+        // Check if o is an instance of ThingShadow or not "null instanceof [type]" also returns false
+        if (!(o instanceof ThingShadow)) {
+            return false;
+        }
+
+        // typecast o to ThingShadow so that we can compare data members
+        ThingShadow newThingShadow = (ThingShadow) o;
+
+        // Compare the data members and return accordingly
+        return Objects.equals(this.thingName, newThingShadow.thingName)
+            && Objects.equals(this.shadowName, newThingShadow.shadowName);
+    }
+
+    @SuppressWarnings("PMD.UselessOverridingMethod")
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(toString());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s-%s", thingName, shadowName);
+    }
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ThingShadowSyncConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/configuration/ThingShadowSyncConfiguration.java
@@ -47,4 +47,15 @@ public class ThingShadowSyncConfiguration {
     public String toString() {
         return String.format("%s-%s", thingName, shadowName);
     }
+
+    /**
+     * Returns a (thingName, shadowName) key from the sync configuration.
+     * @return ThingShadow the corresponding pair of (thingName, shadowName)
+     */
+    public ThingShadow toThingShadow() {
+        return ThingShadow.builder()
+            .thingName(thingName)
+            .shadowName(shadowName)
+            .build();
+    }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.shadowmanager.sync;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.shadowmanager.model.configuration.ThingShadow;
 import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfiguration;
 import com.aws.greengrass.shadowmanager.sync.model.BaseSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.CloudDeleteSyncRequest;
@@ -32,7 +33,7 @@ import lombok.Synchronized;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Stream;
@@ -63,7 +64,7 @@ public class SyncHandler {
      */
     // TODO: [GG-36231]: Figure out a better way to set this configuration in only one place.
     @Setter
-    private Set<ThingShadowSyncConfiguration> syncConfigurations;
+    private Map<ThingShadow, ThingShadowSyncConfiguration> syncConfigurations;
 
     /**
      * The sync strategy for all shadows.
@@ -219,8 +220,9 @@ public class SyncHandler {
      * @return true if the shadow is supposed to be synced; Else false.
      */
     private boolean isShadowSynced(String thingName, String shadowName) {
-        return this.syncConfigurations != null && this.syncConfigurations
-                .contains(ThingShadowSyncConfiguration.builder().shadowName(shadowName).thingName(thingName).build());
+        return this.syncConfigurations != null && this.syncConfigurations.containsKey(
+            ThingShadow.builder().thingName(thingName).shadowName(shadowName).build()
+        );
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.shadowmanager.sync;
 
 
+import com.aws.greengrass.shadowmanager.model.configuration.ThingShadow;
 import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfiguration;
 import com.aws.greengrass.shadowmanager.sync.model.BaseSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.CloudDeleteSyncRequest;
@@ -30,9 +31,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -133,8 +134,9 @@ class SyncHandlerTest {
         when(context.getDao().listSyncedShadows()).thenReturn(shadows);
 
         doNothing().when(mockSyncStrategy).putSyncRequest(syncRequestCaptor.capture());
-        Set<ThingShadowSyncConfiguration> syncConfigurations = new HashSet<>();
-        syncConfigurations.add(ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build());
+        Map<ThingShadow, ThingShadowSyncConfiguration> syncConfigurations = new HashMap<>();
+        ThingShadowSyncConfiguration syncConfig = ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build();
+        syncConfigurations.put(syncConfig.toThingShadow(), syncConfig);
         syncHandler.setSyncConfigurations(syncConfigurations);
 
         // WHEN
@@ -152,8 +154,9 @@ class SyncHandlerTest {
         when(context.getDao().listSyncedShadows()).thenReturn(shadows);
 
         doNothing().when(mockSyncStrategy).putSyncRequest(syncRequestCaptor.capture());
-        Set<ThingShadowSyncConfiguration> syncConfigurations = new HashSet<>();
-        syncConfigurations.add(ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build());
+        Map<ThingShadow, ThingShadowSyncConfiguration> syncConfigurations = new HashMap<>();
+        ThingShadowSyncConfiguration syncConfig = ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build();
+        syncConfigurations.put(syncConfig.toThingShadow(), syncConfig);
         syncHandler.setSyncConfigurations(syncConfigurations);
 
         // WHEN
@@ -171,8 +174,9 @@ class SyncHandlerTest {
         when(context.getDao().listSyncedShadows()).thenReturn(shadows);
 
         doNothing().when(mockSyncStrategy).putSyncRequest(syncRequestCaptor.capture());
-        Set<ThingShadowSyncConfiguration> syncConfigurations = new HashSet<>();
-        syncConfigurations.add(ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build());
+        Map<ThingShadow, ThingShadowSyncConfiguration> syncConfigurations = new HashMap<>();
+        ThingShadowSyncConfiguration syncConfig = ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build();
+        syncConfigurations.put(syncConfig.toThingShadow(), syncConfig);
         syncHandler.setSyncConfigurations(syncConfigurations);
 
         // WHEN
@@ -190,8 +194,9 @@ class SyncHandlerTest {
         when(context.getDao().listSyncedShadows()).thenReturn(shadows);
 
         doNothing().when(mockSyncStrategy).putSyncRequest(syncRequestCaptor.capture());
-        Set<ThingShadowSyncConfiguration> syncConfigurations = new HashSet<>();
-        syncConfigurations.add(ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build());
+        Map<ThingShadow, ThingShadowSyncConfiguration> syncConfigurations = new HashMap<>();
+        ThingShadowSyncConfiguration syncConfig = ThingShadowSyncConfiguration.builder().thingName("a").shadowName("1").build();
+        syncConfigurations.put(syncConfig.toThingShadow(), syncConfig);
         syncHandler.setSyncConfigurations(syncConfigurations);
 
         // WHEN


### PR DESCRIPTION
**Description of changes:**
The ThingShadowSyncConfiguration object represents the sync configuration of a thing shadow. Currently, all thing shadows parsed from the component configuration are stored as a set of ThingShadowSyncConfiguration. Different parts of the ShadowManager rely on the set properties, such as uniqueness of elements and the equality method of ThingShadowSyncConfiguration, to identify whether a specific (thing, shadow) pair exists in the configuration.

However, we plan to introduce more attributes to ThingShadowSyncConfiguration in the near future, which would make this approach less feasible since it's unclear how the equality operator should work in that case. For example, if a new attribute is added, the set.contains((thing, shadow)) approach that is currently used won't work anymore.

To address this issue, this commit changes the data structure that stores all the ThingShadowSyncConfigurations from a Set<ThingShadowSyncConfiguration> to a Map<ThingShadow, ThingShadowSyncConfiguration>. The ThingShadow object contains only the pair (thingName, shadowName), while the ThingShadowSyncConfiguration contains all the configurations of ThingShadowSyncConfiguration. This new approach will enable us to add more attributes to the ThingShadowSyncConfiguration in the future without affecting the way how ShadowManager checks if a pair of (thing, shadow) exists in the configuration.

**Why is this change necessary:**
Because of the "add on interaction" feature that we want to introduce in the near future.

**How was this change tested:**
Unit / integration tests.

**Checklist:**
 - [x] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
