### PR TITLE
fix: validate connection to DB after migration

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDAOImplTest.java
@@ -80,7 +80,6 @@ class ShadowManagerDAOImplTest {
         database = new ShadowManagerDatabase(kernel);
         database.install();
         JsonUtil.loadSchema();
-        database.open();
         dao = new ShadowManagerDAOImpl(database);
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
@@ -13,8 +13,9 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
 import com.aws.greengrass.shadowmanager.exception.ShadowManagerDataException;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import org.flywaydb.core.internal.exception.FlywaySqlException;
 import org.apache.commons.io.FileUtils;
+import org.flywaydb.core.internal.exception.FlywaySqlException;
+import org.h2.jdbcx.JdbcConnectionPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -185,9 +185,9 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
         assertNotNull(c, "connection should not be null");
         assertThat("connection is not closed", c.isClosed(), is(false));
         c.close();
+        JdbcConnectionPool pool = db.getPool();
         db.close();
-        assertThat("active connections", db.getPool().getActiveConnections(), is(0));
-        assertThrows(IllegalStateException.class, () -> db.getPool().getConnection());
+        assertThat("active connections", pool.getActiveConnections(), is(0));
     }
 
     @Test

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerDatabaseTest.java
@@ -80,7 +80,6 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         db = new ShadowManagerDatabase(rootDir);
         db.install();
-        db.open();
     }
 
     @AfterEach
@@ -126,7 +125,6 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
     @Test
     void GIVEN_migrations_WHEN_install_THEN_shadow_manager_database_installs_and_starts_successfully() throws Exception {
         // GIVEN
-        db.open();
         assertNotNull(db.getPool());
 
         // WHEN
@@ -158,7 +156,6 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
         Path source = Paths.get(getClass().getResource("database/corrupted.mv.db").toURI());
         Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
         // GIVEN
-        db.open();
         assertNotNull(db.getPool());
 
         // WHEN
@@ -196,7 +193,6 @@ class ShadowManagerDatabaseTest extends NucleusLaunchUtils {
     @Test
     void GIVEN_shadow_manager_database_open_WHEN_closed_and_opened_THEN_shadow_manager_database_can_return_connections() throws Exception {
         db.close();
-        db.open();
         Connection c = assertDoesNotThrow(() -> db.getPool().getConnection());
         assertNotNull(c, "connection should not be null");
         assertThat("connection is not closed", c.isClosed(), is(false));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.iotdataplane.model.GetThingShadowResponse;
 
-import javax.net.ssl.KeyManager;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +52,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.KeyManager;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_THING_NAME;
@@ -66,7 +66,6 @@ import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_STR
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNCHRONIZATION_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_SYNC_DIRECTION_TOPIC;
 import static com.aws.greengrass.shadowmanager.model.Constants.CONFIGURATION_THING_NAME_TOPIC;
-
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.github.grantwest.eventually.EventuallyLambdaMatcher.eventuallyEval;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -169,6 +169,9 @@ class ShadowManagerTest extends NucleusLaunchUtils {
                 .configFile(DEFAULT_CONFIG)
                 .mqttConnected(false)
                 .build());
+        // Validate that shadow manager will continue to work properly even if it is reinstalled.
+        shadowManager.requestReinstall();
+        Thread.sleep(1000);
         shadowManager.startSyncingShadows(ShadowManager.StartSyncInfo.builder().build());
         ShadowManagerDAOImpl impl = kernel.getContext().get(ShadowManagerDAOImpl.class);
         createThingShadowSyncInfo(impl, THING_NAME);

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -474,8 +474,6 @@ public class ShadowManager extends PluginService {
     @SuppressWarnings({"PMD.AvoidCatchingGenericException"})
     public void startup() {
         try {
-            database.open();
-
             reportState(State.RUNNING);
             setupSync();
         } catch (Exception e) {
@@ -484,13 +482,14 @@ public class ShadowManager extends PluginService {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     protected void shutdown() throws InterruptedException {
         try {
             stopSyncingShadows(true);
             pubSubIntegrator.unsubscribe();
             inboundRateLimiter.clear();
             database.close();
-        } catch (IOException e) {
+        } catch (Exception e) {
             logger.atError()
                     .setEventType(LogEvents.DATABASE_CLOSE_ERROR.code())
                     .setCause(e)

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImpl.java
@@ -77,12 +77,11 @@ public class ShadowManagerDAOImpl implements ShadowManagerDAO {
     }
 
     private JdbcConnectionPool getPool() {
-        JdbcConnectionPool pool = database.getPool();
-        if (pool == null) {
+        if (!database.isInitialized()) {
             throw new ShadowManagerDataException("Database pool not initialized. Shadow manager most likely isn't "
                     + "running yet. Wait for Shadow manager to be running.");
         }
-        return pool;
+        return database.getPool();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/shadowmanager/exception/ShadowManagerDataException.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/exception/ShadowManagerDataException.java
@@ -11,4 +11,8 @@ public class ShadowManagerDataException extends RuntimeException {
     public ShadowManagerDataException(final Throwable ex) {
         super(ex);
     }
+
+    public ShadowManagerDataException(final String s) {
+        super(s);
+    }
 }

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
@@ -93,6 +93,7 @@ class ShadowManagerDAOImplTest {
         lenient().when(mockDatabase.getDbWriteThreadPool()).thenReturn(es);
         when(mockDatabase.getPool()).thenReturn(mockPool);
         when(mockPool.getConnection()).thenReturn(mockConnection);
+        when(mockDatabase.isInitialized()).thenReturn(true);
         JsonUtil.loadSchema();
     }
     @AfterEach

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -617,7 +617,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         verify(mockCloudDataClient, times(1)).updateSubscriptions(anySet());
         verify(mockSyncHandler, times(1)).start(any(SyncContext.class), anyInt());
 
-        verify(mockDatabase, times(1)).open();
         verify(mockDao, times(1)).deleteSyncInformation("foo", "bar");
 
         ArgumentCaptor<SyncInformation> captor = ArgumentCaptor.forClass(SyncInformation.class);

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -97,7 +97,6 @@ import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -645,13 +644,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         verify(mockDatabase, atMostOnce()).close();
         verify(mockInboundRateLimiter, atMostOnce()).clear();
         verify(mockPubSubClientWrapper, atMostOnce()).unsubscribe(any());
-    }
-
-    @Test
-    void GIVEN_shadow_manager_db_WHEN_shutdown_throws_io_exception_THEN_catches_exception(ExtensionContext extensionContext) throws IOException {
-        ignoreExceptionOfType(extensionContext, IOException.class);
-        doThrow(IOException.class).when(mockDatabase).close();
-        assertDoesNotThrow(() -> shadowManager.shutdown());
     }
 
     @Test

--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>aws-greengrass-testing-standalone</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**
#186.

**Description of changes:**
Most likely fixes #186 as we are closing the threadpool when the database closes, but the database can technically re-open and in that case the threadpool couldn't be used as it was already shutdown.

Additionally, validates that we are able to get a connection to the database after migration is performed. If we cannot get a connection, then migration is considered a failure and the DB will be deleted and recreated.

**Why is this change necessary:**

**How was this change tested:**
Added a scenario to a test which fails without this change when requesting a reinstall for shadow manager.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
