### PR TITLE
fix: support empty state document

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -1498,7 +1498,6 @@ class SyncTest extends NucleusLaunchUtils {
     }
 
     private void assertLocalShadowEquals(String state) throws IOException {
-        System.out.println(getLocalShadowState());
         assertThat(this::getLocalShadowState, eventuallyEval(is(JsonUtil.getPayloadJson(state.getBytes(UTF_8)).get().get(SHADOW_DOCUMENT_STATE))));
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -1427,7 +1427,9 @@ class SyncTest extends NucleusLaunchUtils {
 
         String initialCloudState = "{\"version\":1,\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
         String initialLocalState = "{\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
-        String localUpdate1 = "{\"state\":{}}";
+        String localUpdate1 = "{\"state\":{}}}";
+        String localUpdate2 = "{\"state\":{\"desired\":{\"SomeKey\":\"foo\"}}}";
+        String localUpdate3 = "{\"state\":null}}";
         String finalLocalState = "{\"state\":{}}";
 
         UpdateThingShadowRequest updateRequest1 = new UpdateThingShadowRequest();
@@ -1435,8 +1437,20 @@ class SyncTest extends NucleusLaunchUtils {
         updateRequest1.setShadowName(CLASSIC_SHADOW);
         updateRequest1.setPayload(localUpdate1.getBytes(UTF_8));
 
+        UpdateThingShadowRequest updateRequest2 = new UpdateThingShadowRequest();
+        updateRequest2.setThingName(MOCK_THING_NAME_1);
+        updateRequest2.setShadowName(CLASSIC_SHADOW);
+        updateRequest2.setPayload(localUpdate2.getBytes(UTF_8));
+
+        UpdateThingShadowRequest updateRequest3 = new UpdateThingShadowRequest();
+        updateRequest3.setThingName(MOCK_THING_NAME_1);
+        updateRequest3.setShadowName(CLASSIC_SHADOW);
+        updateRequest3.setPayload(localUpdate3.getBytes(UTF_8));
+
         when(mockUpdateThingShadowResponse.payload())
-                .thenReturn(SdkBytes.fromString("{\"version\": 2}", UTF_8));
+                .thenReturn(SdkBytes.fromString("{\"version\": 2}", UTF_8))
+                .thenReturn(SdkBytes.fromString("{\"version\": 3}", UTF_8))
+                .thenReturn(SdkBytes.fromString("{\"version\": 4}", UTF_8));
         when(iotDataPlaneClientFactory.getIotDataPlaneClient().updateThingShadow(cloudUpdateThingShadowRequestCaptor.capture()))
                 .thenReturn(mockUpdateThingShadowResponse);
 
@@ -1466,6 +1480,20 @@ class SyncTest extends NucleusLaunchUtils {
         assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
         assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(2L)));
         assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(2L)));
+        assertLocalShadowEquals(localUpdate1);
+
+        updateHandler.handleRequest(updateRequest2, "DoAll");
+        assertEmptySyncQueue(clazz);
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(3L)));
+        assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(3L)));
+        assertLocalShadowEquals(localUpdate2);
+
+        updateHandler.handleRequest(updateRequest3, "DoAll");
+        assertEmptySyncQueue(clazz);
+        assertThat("sync info exists", () -> syncInfo.get().isPresent(), eventuallyEval(is(true)));
+        assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(4L)));
+        assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(4L)));
         assertLocalShadowEquals(finalLocalState);
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -60,7 +60,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -60,6 +60,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -84,6 +85,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -1481,6 +1483,7 @@ class SyncTest extends NucleusLaunchUtils {
         assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(2L)));
         assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(2L)));
         assertLocalShadowEquals(localUpdate1);
+        assertCloudUpdateEquals(localUpdate1);
 
         updateHandler.handleRequest(updateRequest2, "DoAll");
         assertEmptySyncQueue(clazz);
@@ -1488,6 +1491,7 @@ class SyncTest extends NucleusLaunchUtils {
         assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(3L)));
         assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(3L)));
         assertLocalShadowEquals(localUpdate2);
+        assertCloudUpdateEquals(localUpdate2);
 
         updateHandler.handleRequest(updateRequest3, "DoAll");
         assertEmptySyncQueue(clazz);
@@ -1495,6 +1499,13 @@ class SyncTest extends NucleusLaunchUtils {
         assertThat("cloud version", () -> syncInfo.get().get().getCloudVersion(), eventuallyEval(is(4L)));
         assertThat("local version", () -> syncInfo.get().get().getLocalVersion(), eventuallyEval(is(4L)));
         assertLocalShadowEquals(finalLocalState);
+        assertCloudUpdateEquals(finalLocalState);
+    }
+
+    private void assertCloudUpdateEquals(String state) throws IOException {
+        ShadowDocument expected = new ShadowDocument(state.getBytes(UTF_8), false);
+        ShadowDocument actual = new ShadowDocument(cloudUpdateThingShadowRequestCaptor.getValue().payload().asByteArray());
+        assertEquals(expected.toJson(false), actual.toJson(false));
     }
 
     private void assertLocalShadowEquals(String state) throws IOException {

--- a/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowState.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowState.java
@@ -58,6 +58,11 @@ public class ShadowState {
      */
     @SuppressWarnings({"PMD.ForLoopCanBeForeach", "PMD.NullAssignment"})
     public void update(JsonNode updatedStateNode) {
+        if (isNullOrMissing(updatedStateNode)) {
+            this.desired = null;
+            this.reported = null;
+            return;
+        }
         for (final Iterator<String> i = updatedStateNode.fieldNames(); i.hasNext(); ) {
             final String field = i.next();
             final JsonNode value = updatedStateNode.get(field);

--- a/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
@@ -102,11 +102,24 @@ public final class JsonUtil {
     }
 
     public static boolean isNullOrMissing(JsonNode node) {
-        return node == null || node.isNull() || node.isMissingNode() || node.isObject() && node.isEmpty();
+        return node == null || isMissing(node);
     }
 
+    public static boolean isMissing(JsonNode node) {
+        return node.isNull() || node.isMissingNode() || node.isObject() && node.isEmpty();
+    }
+
+    /**
+     * Determine if a node represents an empty state document.
+     *
+     * @param node node
+     * @return true if node is null, empty, or has a null or empty state node
+     */
     public static boolean isEmptyStateDocument(JsonNode node) {
-        return isNullOrMissing(node) || node.isObject() && isNullOrMissing(node.get(SHADOW_DOCUMENT_STATE));
+        return isNullOrMissing(node)
+                || node.isObject()
+                && node.get(SHADOW_DOCUMENT_STATE) != null
+                && isMissing(node.get(SHADOW_DOCUMENT_STATE));
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
@@ -105,6 +105,10 @@ public final class JsonUtil {
         return node == null || node.isNull() || node.isMissingNode() || node.isObject() && node.isEmpty();
     }
 
+    public static boolean isEmptyStateDocument(JsonNode node) {
+        return isNullOrMissing(node) || node.isObject() && isNullOrMissing(node.get(SHADOW_DOCUMENT_STATE));
+    }
+
     /**
      * Validates that the state node depth is no deeper than the max depth for shadows (6).
      *

--- a/src/main/resources/json/schema/update_payload_schema.json
+++ b/src/main/resources/json/schema/update_payload_schema.json
@@ -11,7 +11,7 @@
     },
     "state": {
       "description": "The state node containing the desired, reported, and delta shadow state.",
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "reported": {
           "description": "The shadow document state reported by the components.",

--- a/src/main/resources/json/schema/update_payload_schema.json
+++ b/src/main/resources/json/schema/update_payload_schema.json
@@ -32,6 +32,9 @@
         },
         {
           "required": [ "desired" ]
+        },
+        {
+          "additionalProperties": false
         }
       ]
     },

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
@@ -37,6 +37,7 @@ class JsonMergerTest {
     private final static String MERGED_NODE_WITH_UPDATED_ARRAY_NODE_STRING = "[\"SomeValue3\", \"SomeValue4\"]";
     private final static String PATCH_NODE_WITH_ARRAY_VALUE_NODE_STRING = "[\"SomeValue3\", \"SomeValue4\"]";
     private final static String EMPTY_DOCUMENT = "{}";
+    private final static String NULL_DOCUMENT = "null";
     private static JsonNode sourceNodeWithArray;
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")
@@ -45,7 +46,8 @@ class JsonMergerTest {
                 Arguments.of("GIVEN patch with new node, THEN add new field in source node", SOURCE_NODE_STRING, PATCH_NODE_WITH_NEW_FIELD_STRING, MERGED_NODE_WITH_NEW_FIELD_STRING),
                 Arguments.of("GIVEN patch with null nodes, THEN removes all null nodes in source node", SOURCE_NODE_STRING, PATCH_NODE_WITH_NULL_FIELD_STRING, MERGED_NODE_WITHOUT_NULL_FIELD_STRING),
                 Arguments.of("GIVEN patch with new nodes in an array node, THEN replaces all the elements in the source with the elements in the patch", SOURCE_NODE_WITH_ARRAY_NODE_STRING, PATCH_NODE_WITH_ARRAY_VALUE_NODE_STRING, MERGED_NODE_WITH_UPDATED_ARRAY_NODE_STRING),
-                Arguments.of("GIVEN patch will empty state, THEN source node is cleared", SOURCE_NODE_STRING, EMPTY_DOCUMENT, EMPTY_DOCUMENT)
+                Arguments.of("GIVEN patch with empty state, THEN source node is cleared", SOURCE_NODE_STRING, EMPTY_DOCUMENT, EMPTY_DOCUMENT),
+                Arguments.of("GIVEN patch with null state, THEN source node is cleared", SOURCE_NODE_STRING, NULL_DOCUMENT, EMPTY_DOCUMENT)
         );
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
@@ -36,6 +36,7 @@ class JsonMergerTest {
     private final static String MERGED_NODE_WITHOUT_NULL_FIELD_STRING = "{\"id\": 100,\"SomeObjectKey\":{}}";
     private final static String MERGED_NODE_WITH_UPDATED_ARRAY_NODE_STRING = "[\"SomeValue3\", \"SomeValue4\"]";
     private final static String PATCH_NODE_WITH_ARRAY_VALUE_NODE_STRING = "[\"SomeValue3\", \"SomeValue4\"]";
+    private final static String EMPTY_DOCUMENT = "{}";
     private static JsonNode sourceNodeWithArray;
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")
@@ -43,8 +44,9 @@ class JsonMergerTest {
         return Stream.of(
                 Arguments.of("GIVEN patch with new node, THEN add new field in source node", SOURCE_NODE_STRING, PATCH_NODE_WITH_NEW_FIELD_STRING, MERGED_NODE_WITH_NEW_FIELD_STRING),
                 Arguments.of("GIVEN patch with null nodes, THEN removes all null nodes in source node", SOURCE_NODE_STRING, PATCH_NODE_WITH_NULL_FIELD_STRING, MERGED_NODE_WITHOUT_NULL_FIELD_STRING),
-                Arguments.of("GIVEN patch with new nodes in an array node, THEN replaces all the elements in the source with the elements in the patch", SOURCE_NODE_WITH_ARRAY_NODE_STRING, PATCH_NODE_WITH_ARRAY_VALUE_NODE_STRING, MERGED_NODE_WITH_UPDATED_ARRAY_NODE_STRING)
-                );
+                Arguments.of("GIVEN patch with new nodes in an array node, THEN replaces all the elements in the source with the elements in the patch", SOURCE_NODE_WITH_ARRAY_NODE_STRING, PATCH_NODE_WITH_ARRAY_VALUE_NODE_STRING, MERGED_NODE_WITH_UPDATED_ARRAY_NODE_STRING),
+                Arguments.of("GIVEN patch will empty state, THEN source node is cleared", SOURCE_NODE_STRING, EMPTY_DOCUMENT, EMPTY_DOCUMENT)
+        );
     }
 
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
@@ -47,7 +47,9 @@ class JsonMergerTest {
                 Arguments.of("GIVEN patch with null nodes, THEN removes all null nodes in source node", SOURCE_NODE_STRING, PATCH_NODE_WITH_NULL_FIELD_STRING, MERGED_NODE_WITHOUT_NULL_FIELD_STRING),
                 Arguments.of("GIVEN patch with new nodes in an array node, THEN replaces all the elements in the source with the elements in the patch", SOURCE_NODE_WITH_ARRAY_NODE_STRING, PATCH_NODE_WITH_ARRAY_VALUE_NODE_STRING, MERGED_NODE_WITH_UPDATED_ARRAY_NODE_STRING),
                 Arguments.of("GIVEN patch with empty state, THEN source node is cleared", SOURCE_NODE_STRING, EMPTY_DOCUMENT, EMPTY_DOCUMENT),
-                Arguments.of("GIVEN patch with null state, THEN source node is cleared", SOURCE_NODE_STRING, NULL_DOCUMENT, EMPTY_DOCUMENT)
+                Arguments.of("GIVEN patch with null state, THEN source node is cleared", SOURCE_NODE_STRING, NULL_DOCUMENT, EMPTY_DOCUMENT),
+                Arguments.of("GIVEN empty source and non-empty patch, THEN patch is the result", EMPTY_DOCUMENT, SOURCE_NODE_STRING, SOURCE_NODE_STRING),
+                Arguments.of("GIVEN null source and non-empty patch, THEN patch is the result", NULL_DOCUMENT, SOURCE_NODE_STRING, SOURCE_NODE_STRING)
         );
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
@@ -48,9 +48,7 @@ class JsonMergerTest {
                 Arguments.of("GIVEN patch with new nodes in an array node, THEN replaces all the elements in the source with the elements in the patch", SOURCE_NODE_WITH_ARRAY_NODE_STRING, PATCH_NODE_WITH_ARRAY_VALUE_NODE_STRING, MERGED_NODE_WITH_UPDATED_ARRAY_NODE_STRING),
                 Arguments.of("GIVEN patch with empty state, THEN source node is cleared", SOURCE_NODE_STRING, EMPTY_DOCUMENT, EMPTY_DOCUMENT),
                 Arguments.of("GIVEN patch with null state, THEN source node is cleared", SOURCE_NODE_STRING, NULL_DOCUMENT, EMPTY_DOCUMENT),
-                Arguments.of("GIVEN empty source and non-empty patch, THEN patch is the result", EMPTY_DOCUMENT, SOURCE_NODE_STRING, SOURCE_NODE_STRING),
-                Arguments.of("GIVEN null source and non-empty patch, THEN patch is the result", NULL_DOCUMENT, SOURCE_NODE_STRING, SOURCE_NODE_STRING)
-        );
+                Arguments.of("GIVEN empty source and non-empty patch, THEN patch is the result", EMPTY_DOCUMENT, SOURCE_NODE_STRING, SOURCE_NODE_STRING));
     }
 
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
@@ -59,6 +59,7 @@ class JsonUtilTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "{\"state\": null}",
             "{\"state\": {}}",
             "{\"state\": {\"desired\":" + NAME_A + ", \"reported\":" + NAME_B + ", \"delta\":" + NAME_A + "}}",
             "{\"state\": {\"desired\":" + NAME_A + ", \"reported\":" + NAME_A + "}}",

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
@@ -42,7 +42,6 @@ class JsonUtilTest {
     @ValueSource(strings={
             "{\"version\": 1}",
             "{}",
-            "{\"state\": {}}",
             "{\"state\": {\"reported\": 1}}",
             "{\"state\": {\"desired\": 1}}",
             "{\"state\": {\"delta\": 1}}",
@@ -60,6 +59,7 @@ class JsonUtilTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "{\"state\": {}}",
             "{\"state\": {\"desired\":" + NAME_A + ", \"reported\":" + NAME_B + ", \"delta\":" + NAME_A + "}}",
             "{\"state\": {\"desired\":" + NAME_A + ", \"reported\":" + NAME_A + "}}",
             "{\"state\": {\"desired\":" + NAME_A + "}}",
@@ -74,7 +74,7 @@ class JsonUtilTest {
             "{\"version\": 1, \"state\": {\"reported\":" + NAME_A + "}}",
             "{\"version\": 1, \"state\": {\"reported\":" + NAME_A + ", \"desired\": null}}",
     })
-    void GIVEN_valid_request_WHEN_validatePayloadSchema_THEN_does_not_throw(String json) throws IOException {
+    void GIVEN_valid_request_WHEN_validatePayloadSchema_THEN_does_not_throw(String json) {
         assertDoesNotThrow(() -> {
             validatePayloadSchema(getPayloadJson(json.getBytes(StandardCharsets.UTF_8)).get());
         });

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonUtilTest.java
@@ -13,11 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
 import static com.aws.greengrass.shadowmanager.util.JsonUtil.getPayloadJson;
 import static com.aws.greengrass.shadowmanager.util.JsonUtil.validatePayloadSchema;
@@ -26,6 +29,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
@@ -127,5 +131,25 @@ class JsonUtilTest {
         assertThat(thrown.getErrorMessage(), is(notNullValue()));
         assertThat(thrown.getErrorMessage().getErrorCode(), is(400));
         assertThat(thrown.getErrorMessage().getMessage(), is("JSON contains too many levels of nesting; maximum is 6"));
+    }
+
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    private static Stream<Arguments> emptyStateDocuments() {
+        return Stream.of(
+                Arguments.of("{\"state\": null}", true),
+                Arguments.of("{\"state\": {}}", true),
+                Arguments.of("{}", true),
+                Arguments.of("null", true),
+                Arguments.of("{\"state\": {\"field\":1}}", false),
+                Arguments.of("{\"field\":1}", false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyStateDocuments")
+    void GIVEN_empty_state_document_WHEN_check_is_empty_state_document_THEN_return_true(String json, boolean emptyDocumentExpected) throws IOException {
+        assertEquals(emptyDocumentExpected,
+                JsonUtil.isEmptyStateDocument(getPayloadJson(json.getBytes(StandardCharsets.UTF_8)).get()),
+                String.format("%s %sexpected to be empty", json, emptyDocumentExpected ? "" : "not "));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Support an empty shadow document,`{"state": {}}`.

**Why is this change necessary:**
According to https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-document.html#device-shadow-empty-fields, `{}` is a valid shadow document.

**How was this change tested:**
New unit and integration tests

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
