### PR TITLE
fix: return empty rather than null in update response

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
@@ -241,7 +241,9 @@ public class UpdateThingShadowRequestHandler extends BaseRequestHandler {
                             .withVersion(updatedDocument.getVersion())
                             .withClientToken(clientToken)
                             .withTimestamp(Instant.now())
-                            .withState(updateDocumentRequest.get("state"))
+                            // explicitly convert to shadow document to return valid state.
+                            // this is to prevent edge cases like returning null
+                            .withState(new ShadowDocument(updateDocumentRequest, false).getState().toJson())
                             .withMetadata(metadata)
                             .build();
                     byte[] responseNodeBytes = JsonUtil.getPayloadBytes(responseNode);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Follow-up to https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/193 and https://github.com/aws-greengrass/aws-greengrass-shadow-manager/pull/192.  

When updating a shadow locally with `{"state": null}`, ensure the update response state is `{}`, rather than `null`, because `null` is not a valid shadow state document.

Also refactored logic from `ShadowDocument` constructors into `setFields` methods while I was at it.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
