### PR TITLE
fix: default to classic shadow name in requests

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/DeleteThingShadowRequestHandler.java
@@ -90,6 +90,7 @@ public class DeleteThingShadowRequestHandler extends BaseRequestHandler {
             logger.atTrace("ipc-delete-thing-shadow-request").log();
 
             ShadowRequest shadowRequest = new ShadowRequest(thingName, shadowName);
+            shadowName = shadowRequest.getShadowName();
             try {
                 Validator.validateShadowRequest(shadowRequest);
             } catch (InvalidRequestParametersException e) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/GetThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/GetThingShadowRequestHandler.java
@@ -75,6 +75,8 @@ public class GetThingShadowRequestHandler extends BaseRequestHandler {
         return translateExceptions(() -> {
             String thingName = request.getThingName();
             String shadowName = request.getShadowName();
+            ShadowRequest shadowRequest = new ShadowRequest(thingName, shadowName);
+            shadowName = shadowRequest.getShadowName();
 
             try {
                 logger.atTrace("ipc-get-thing-shadow-request")
@@ -82,7 +84,6 @@ public class GetThingShadowRequestHandler extends BaseRequestHandler {
                         .kv(LOG_SHADOW_NAME_KEY, shadowName)
                         .log();
 
-                ShadowRequest shadowRequest = new ShadowRequest(thingName, shadowName);
                 Validator.validateShadowRequest(shadowRequest);
                 authorizationHandlerWrapper.doAuthorization(GET_THING_SHADOW, serviceName, shadowRequest);
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/UpdateThingShadowRequestHandler.java
@@ -94,6 +94,8 @@ public class UpdateThingShadowRequestHandler extends BaseRequestHandler {
         return translateExceptions(() -> {
             String thingName = request.getThingName();
             String shadowName = request.getShadowName();
+            ShadowRequest shadowRequest = new ShadowRequest(thingName, shadowName);
+            shadowName = shadowRequest.getShadowName();
             byte[] updatedDocumentRequestBytes = request.getPayload();
             ShadowDocument currentDocument = null;
             Optional<String> clientToken = Optional.empty();
@@ -103,7 +105,6 @@ public class UpdateThingShadowRequestHandler extends BaseRequestHandler {
                     .kv(LOG_SHADOW_NAME_KEY, shadowName)
                     .log();
 
-            ShadowRequest shadowRequest = new ShadowRequest(thingName, shadowName);
             try {
                 Validator.validateShadowRequest(shadowRequest);
             } catch (InvalidRequestParametersException e) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Read the "shadowName" from the shadow request object which defaults the shadow to classic shadow if it isn't provided. This prevents ugly error messages when the customer-provided shadow name is null for any reason.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
