### PR TITLE
fix: properly handle when shadow contains a key named state set to null

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/JsonUtil.java
@@ -130,7 +130,11 @@ public final class JsonUtil {
     public static boolean isNullStateDocument(JsonNode node) {
         return node != null
                 && (node.isNull()
-                || node.isObject() && isNullStateDocument(node.get(SHADOW_DOCUMENT_STATE)));
+                || node.isObject() && isJsonNull(node.get(SHADOW_DOCUMENT_STATE)));
+    }
+
+    private static boolean isJsonNull(JsonNode node) {
+        return node != null && node.isNull();
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/JsonMergerTest.java
@@ -55,7 +55,11 @@ class JsonMergerTest {
                 Arguments.of("GIVEN empty state patch, THEN source node is unaffected", SOURCE_STATE_NODE_STRING, EMPTY_STATE_DOCUMENT, SOURCE_STATE_NODE_STRING),
                 Arguments.of("GIVEN null state patch, THEN source node is cleared", SOURCE_STATE_NODE_STRING, NULL_STATE_DOCUMENT, EMPTY_STATE_DOCUMENT),
                 Arguments.of("GIVEN empty source and non-empty state patch, THEN patch is the result", EMPTY_STATE_DOCUMENT, SOURCE_STATE_NODE_STRING, SOURCE_STATE_NODE_STRING),
-                Arguments.of("GIVEN null source and non-empty state patch, THEN patch is the result", NULL_STATE_DOCUMENT, SOURCE_STATE_NODE_STRING, SOURCE_STATE_NODE_STRING));
+                Arguments.of("GIVEN null source and non-empty state patch, THEN patch is the result", NULL_STATE_DOCUMENT, SOURCE_STATE_NODE_STRING, SOURCE_STATE_NODE_STRING),
+                Arguments.of("GIVEN state patch containing null state subkey, THEN state subkey is removed",
+                        "{\"state\":{\"key\":\"v\",\"state\":\"abc\"}}", "{\"state\": {\"state\":null}}",
+                        "{\"state\":{\"key\":\"v\"}}")
+                );
     }
 
 


### PR DESCRIPTION
**Issue #, if available:**
#198 

**Description of changes:**
Previous PRs fixing null handling introduced an issue where shadows which contain the literal key `state` due to a mistakenly recursive call when checking if state is null or empty. This change fixes that problem by removing the recursive call and checking if literally JSON's null value. 

**Why is this change necessary:**

**How was this change tested:**
Added a new test case which fails without the change and works properly with the change.

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
