### PR TITLE
fix: retain null fields in sync node merger

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -16,6 +16,7 @@ import com.aws.greengrass.shadowmanager.ShadowManager;
 import com.aws.greengrass.shadowmanager.ShadowManagerDAOImpl;
 import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
+import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
 import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 import org.mockito.Mock;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
@@ -81,7 +83,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
         startNucleusWithConfig(configFile, expectedState, mockDatabase, false, true);
     }
 
-    void startNucleusWithConfig(NucleusLaunchUtilsConfig config) throws InterruptedException {
+    private CountDownLatch setup(NucleusLaunchUtilsConfig config) {
         CountDownLatch shadowManagerRunning = new CountDownLatch(1);
         AtomicBoolean isSyncMocked = new AtomicBoolean(false);
         kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
@@ -130,12 +132,12 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
                     .retryableExceptions(Collections.singletonList(RetryableException.class))
                     .build();
             Retryer retryer =  (retryConfig1, request, context) ->
-            RetryUtils.runWithRetry(retryConfig,
-                () -> {
-                    request.execute(context);
-                    return null;
-                },
-                "test-setup", LogManager.getLogger(getClass()));
+                    RetryUtils.runWithRetry(retryConfig,
+                            () -> {
+                                request.execute(context);
+                                return null;
+                            },
+                            "test-setup", LogManager.getLogger(getClass()));
             SyncHandler.setRetryer(retryer);
             SyncStrategy syncStrategy;
             if (RealTimeSyncStrategy.class.equals(config.getSyncClazz())) {
@@ -149,6 +151,29 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
             syncHandler.setOverallSyncStrategy(syncStrategy);
             isSyncMocked.set(true);
         }
+        return shadowManagerRunning;
+    }
+
+    void startNucleusWithConfig(NucleusLaunchUtilsConfig config) throws InterruptedException {
+        CountDownLatch shadowManagerRunning = setup(config);
+        kernel.launch();
+        assertTrue(shadowManagerRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
+    }
+
+    void startNucleusWithConfigAndLocalShadowState(NucleusLaunchUtilsConfig config, String thingName,
+                                                   String shadowName, String localShadowState)
+            throws InterruptedException {
+        CountDownLatch shadowManagerRunning = setup(config);
+
+        kernel.getContext().get(ShadowManagerDatabase.class).install();
+        ShadowManagerDAOImpl dao = kernel.getContext().get(ShadowManagerDAOImpl.class);
+        dao.updateShadowThing(thingName, shadowName, localShadowState.getBytes(StandardCharsets.UTF_8), 0);
+        dao.updateSyncInformation(SyncInformation.builder()
+                .thingName(thingName)
+                .shadowName(shadowName)
+                .lastSyncedDocument(localShadowState.getBytes(StandardCharsets.UTF_8))
+                .localVersion(0)
+                .build());
 
         kernel.launch();
         assertTrue(shadowManagerRunning.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -131,13 +131,10 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
                     .maxRetryInterval(Duration.ofSeconds(1))
                     .retryableExceptions(Collections.singletonList(RetryableException.class))
                     .build();
-            Retryer retryer =  (retryConfig1, request, context) ->
-                    RetryUtils.runWithRetry(retryConfig,
-                            () -> {
-                                request.execute(context);
-                                return null;
-                            },
-                            "test-setup", LogManager.getLogger(getClass()));
+            Retryer retryer =  (retryConfig1, request, context) -> RetryUtils.runWithRetry(retryConfig, () -> {
+                    request.execute(context);
+                    return null;
+                }, "test-setup", LogManager.getLogger(getClass()));
             SyncHandler.setRetryer(retryer);
             SyncStrategy syncStrategy;
             if (RealTimeSyncStrategy.class.equals(config.getSyncClazz())) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequest.java
@@ -172,13 +172,13 @@ public class FullShadowSyncRequest extends BaseSyncRequest {
         long cloudDocumentVersion = cloudShadowDocument.get().getVersion();
 
         // If the cloud document version is different from the last sync, that means the local document needed
-        // some updates. So we go ahead an update the local shadow document.
+        // some updates. So we go ahead and update the local shadow document.
         if (!isDocVersionSame(cloudShadowDocument.get(), syncInformation, DataOwner.CLOUD)) {
             localDocumentVersion = updateLocalDocumentAndGetUpdatedVersion(updateDocument,
                     Optional.of(localDocumentVersion));
         }
         // If the local document version is different from the last sync, that means the cloud document needed
-        // some updates. So we go ahead an update the cloud shadow document.
+        // some updates. So we go ahead and update the cloud shadow document.
         if (!isDocVersionSame(localShadowDocument.get(), syncInformation, DataOwner.LOCAL)) {
             cloudDocumentVersion = updateCloudDocumentAndGetUpdatedVersion(updateDocument,
                     Optional.of(cloudDocumentVersion));

--- a/src/main/java/com/aws/greengrass/shadowmanager/util/JsonMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/JsonMerger.java
@@ -65,19 +65,6 @@ public final class JsonMerger {
                 + " Json objects whose underlying node are the same type."));
     }
 
-    private static void removeDeletedFields(final ObjectNode source, final ObjectNode patch) {
-        final Iterator<String> fieldNames = source.fieldNames();
-        while (fieldNames.hasNext()) {
-            final String field = fieldNames.next();
-            final JsonNode patchValue = patch.get(field);
-
-            // If the patch value is null then the field has been deleted, remove from source
-            if (isNullOrMissing(patchValue)) {
-                source.remove(field);
-            }
-        }
-    }
-
     private static void merge(final ObjectNode source, final ObjectNode patch) {
         final Iterator<String> fieldNames = patch.fieldNames();
         while (fieldNames.hasNext()) {
@@ -117,6 +104,19 @@ public final class JsonMerger {
             // If sourceValue and patchValue are not objects then we just update the source field
             // to point the new patch value.
             source.set(field, patchValue);
+        }
+    }
+
+    private static void removeDeletedFields(final ObjectNode source, final ObjectNode patch) {
+        final Iterator<String> fieldNames = source.fieldNames();
+        while (fieldNames.hasNext()) {
+            final String field = fieldNames.next();
+            final JsonNode patchValue = patch.get(field);
+
+            // If the patch value is null then the field has been deleted, remove from source
+            if (isNullOrMissing(patchValue)) {
+                source.remove(field);
+            }
         }
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/util/JsonMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/JsonMerger.java
@@ -26,7 +26,7 @@ public final class JsonMerger {
 
     /**
      * Merges the patch JSON node to the existing source JSON node. If the node already exists in the source, then
-     * it replaces it. If the node is an array, then the the source array's contents are overwritten with the contents
+     * it replaces it. If the node is an array, then the source array's contents are overwritten with the contents
      * from the patch.
      *
      * @param source The source JSON to merge.
@@ -43,9 +43,6 @@ public final class JsonMerger {
         if (JsonUtil.isEmptyStateDocument(patch)) {
             return;
         }
-
-        // If the source node contains keys not present in the patch node, those keys have been deleted
-        removeDeletedFields((ObjectNode) source, (ObjectNode) patch);
 
         // If both nodes are objects then do a recursive patch
         if (source.isObject() && patch.isObject()) {
@@ -104,19 +101,6 @@ public final class JsonMerger {
             // If sourceValue and patchValue are not objects then we just update the source field
             // to point the new patch value.
             source.set(field, patchValue);
-        }
-    }
-
-    private static void removeDeletedFields(final ObjectNode source, final ObjectNode patch) {
-        final Iterator<String> fieldNames = source.fieldNames();
-        while (fieldNames.hasNext()) {
-            final String field = fieldNames.next();
-            final JsonNode patchValue = patch.get(field);
-
-            // If the patch value is null then the field has been deleted, remove from source
-            if (isNullOrMissing(patchValue)) {
-                source.remove(field);
-            }
         }
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/util/SyncNodeMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/SyncNodeMerger.java
@@ -142,10 +142,11 @@ public final class SyncNodeMerger {
             final JsonNode cloudValue = cloud.get(field);
             final JsonNode baseValue = base.get(field);
             JsonNode mergedResult = getMergedNode(localValue, cloudValue, baseValue, owner);
-            if (mergedResult != null) {
-                ((ObjectNode) result).set(field, mergedResult);
+            ((ObjectNode) result).set(field, mergedResult);
+            if (mergedResult == null) {
+                visited.add(field);
             }
-            visited.add(field);
+            //visited.add(field);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/shadowmanager/util/SyncNodeMerger.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/util/SyncNodeMerger.java
@@ -146,7 +146,6 @@ public final class SyncNodeMerger {
             if (mergedResult == null) {
                 visited.add(field);
             }
-            //visited.add(field);
         }
     }
 

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -90,7 +90,10 @@ class FullShadowSyncRequestTest {
     private static final byte[] CLOUD_DOCUMENT_WITH_METADATA = "{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomeOtherThingNew\": 100}}, \"metadata\": {\"reported\": {\"name\": {\"timestamp\": 100}, \"OldField\": {\"timestamp\": 100}}, \"desired\": {\"name\": {\"timestamp\": 100}, \"SomeOtherThingNew\": {\"timestamp\": 100}}}}".getBytes();
     private static final byte[] CLOUD_DOCUMENT_WITH_DELTA = "{\"version\": 5, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomeOtherThingNew\": 100}, \"delta\": {\"name\": \"The Beatles\", \"OldField\": true}}}".getBytes();
     private static final byte[] BASE_DOCUMENT = "{\"version\": 1, \"state\": {\"reported\": {\"name\": \"The Beatles\", \"OldField\": true}, \"desired\": {\"name\": \"The Beatles\"}}}".getBytes();
-    private static final byte[] MERGED_DOCUMENT = "{\"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomethingNew\": true, \"SomeOtherThingNew\": 100}}}".getBytes();
+    // TODO: Refactor class so the null "OldField" can be removed from the merged document. This is present because
+    //  SyncNodeMerger will set removed fields as null, which are then handled by UpdateThingShadowRequestHandler,
+    //  which currently has mocked behavior resulting in null fields not being removed within these tests.
+    private static final byte[] MERGED_DOCUMENT = ("{\"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100, \"OldField\": null}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomethingNew\": true, \"SomeOtherThingNew\": 100}}}").getBytes();
     private static final byte[] BAD_DOCUMENT = "{\"version\": true}".getBytes();
 
     @Mock

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/model/FullShadowSyncRequestTest.java
@@ -93,7 +93,7 @@ class FullShadowSyncRequestTest {
     // TODO: Refactor class so the null "OldField" can be removed from the merged document. This is present because
     //  SyncNodeMerger will set removed fields as null, which are then handled by UpdateThingShadowRequestHandler,
     //  which currently has mocked behavior resulting in null fields not being removed within these tests.
-    private static final byte[] MERGED_DOCUMENT = ("{\"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100, \"OldField\": null}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomethingNew\": true, \"SomeOtherThingNew\": 100}}}").getBytes();
+    private static final byte[] MERGED_DOCUMENT = "{\"state\": {\"reported\": {\"name\": \"The Beach Boys\", \"NewField\": 100, \"OldField\": null}, \"desired\": {\"name\": \"Backstreet Boys\", \"SomethingNew\": true, \"SomeOtherThingNew\": 100}}}".getBytes();
     private static final byte[] BAD_DOCUMENT = "{\"version\": true}".getBytes();
 
     @Mock

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/SyncNodeMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/SyncNodeMergerTest.java
@@ -26,9 +26,9 @@ class SyncNodeMergerTest {
     private static final byte[] CLOUD_DOCUMENT = "{\"name\": \"The Beatles\", \"temperature\": 80, \"OldField\": true}".getBytes();
     private static final byte[] CLOUD_DOCUMENT_CHANGED = "{\"name\": \"Pink Floyd\", \"temperature\": 60, \"OldField\": true, \"SomeOtherThingNew\": 100}".getBytes();
     private static final byte[] BASE_DOCUMENT = "{\"name\": \"The Beatles\", \"temperature\": 70, \"OldField\": true}".getBytes();
-    private static final byte[] MERGED_DOCUMENT = "{\"name\":\"The Beach Boys\", \"temperature\": 80, \"NewField\":100}".getBytes();
-    private static final byte[] MERGED_DOCUMENT_WITH_CLOUD_CHANGED_AND_CLOUD_OWNER = "{\"name\":\"Pink Floyd\", \"temperature\": 60,\"NewField\":100,\"SomeOtherThingNew\":100}".getBytes();
-    private static final byte[] MERGED_DOCUMENT_WITH_CLOUD_CHANGED_AND_LOCAL_OWNER = "{\"name\":\"The Beach Boys\", \"temperature\": 80,\"NewField\":100,\"SomeOtherThingNew\":100}".getBytes();
+    private static final byte[] MERGED_DOCUMENT = ("{\"name\":\"The Beach Boys\", \"temperature\": 80, \"NewField\":100, \"OldField\":null}").getBytes();
+    private static final byte[] MERGED_DOCUMENT_WITH_CLOUD_CHANGED_AND_CLOUD_OWNER = "{\"name\":\"Pink Floyd\", \"temperature\": 60,\"NewField\":100,\"OldField\":null,\"SomeOtherThingNew\":100}".getBytes();
+    private static final byte[] MERGED_DOCUMENT_WITH_CLOUD_CHANGED_AND_LOCAL_OWNER = "{\"name\":\"The Beach Boys\", \"temperature\": 80,\"NewField\":100,\"OldField\":null,\"SomeOtherThingNew\":100}".getBytes();
 
     private final static byte[] LOCAL_WITH_ARRAY_STRING = "{\"id\": 100, \"SomeArrayKey\": [\"SomeValue1\", \"SomeValue2\"]}".getBytes();
     private final static byte[] CLOUD_WITH_ARRAY_STRING = "{\"id\": 100, \"SomeArrayKey\": [\"SomeValue3\", \"SomeValue4\"]}".getBytes();

--- a/src/test/java/com/aws/greengrass/shadowmanager/util/SyncNodeMergerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/util/SyncNodeMergerTest.java
@@ -26,7 +26,7 @@ class SyncNodeMergerTest {
     private static final byte[] CLOUD_DOCUMENT = "{\"name\": \"The Beatles\", \"temperature\": 80, \"OldField\": true}".getBytes();
     private static final byte[] CLOUD_DOCUMENT_CHANGED = "{\"name\": \"Pink Floyd\", \"temperature\": 60, \"OldField\": true, \"SomeOtherThingNew\": 100}".getBytes();
     private static final byte[] BASE_DOCUMENT = "{\"name\": \"The Beatles\", \"temperature\": 70, \"OldField\": true}".getBytes();
-    private static final byte[] MERGED_DOCUMENT = ("{\"name\":\"The Beach Boys\", \"temperature\": 80, \"NewField\":100, \"OldField\":null}").getBytes();
+    private static final byte[] MERGED_DOCUMENT = "{\"name\":\"The Beach Boys\", \"temperature\": 80, \"NewField\":100, \"OldField\":null}".getBytes();
     private static final byte[] MERGED_DOCUMENT_WITH_CLOUD_CHANGED_AND_CLOUD_OWNER = "{\"name\":\"Pink Floyd\", \"temperature\": 60,\"NewField\":100,\"OldField\":null,\"SomeOtherThingNew\":100}".getBytes();
     private static final byte[] MERGED_DOCUMENT_WITH_CLOUD_CHANGED_AND_LOCAL_OWNER = "{\"name\":\"The Beach Boys\", \"temperature\": 80,\"NewField\":100,\"OldField\":null,\"SomeOtherThingNew\":100}".getBytes();
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Previously when a full sync was performed, `SyncNodeMerger` would remove any fields that were set to `null` from the shadow document. Then, once this document was merged during the local update, those removed fields were reintroduced since the merge was unaware they had already been set to `null` before. With this fix we now retain null fields inside of `SyncNodeMerger` so that they can be handled and deleted from the local shadow document during the following merges.
- Updated the integration test framework to allow for setting an initial local shadow state before starting the Nucleus. This allows us to simulate receiving cloud updates while the device is not yet running.

**Why is this change necessary:**
Fixes a bug where customers could delete fields in their cloud shadow while the device was offline, but after starting the device would not remove these fields from the local shadow. 

**How was this change tested:**
Added an integration test which fails without the change and passes with it.

**Any additional information or context required to review the change:**
`FullShadowSyncRequestTest.java` will need to be refactored in a future PR. With this change, any item removed from a shadow document is set to null in `SyncNodeMerger` and then handled accordingly in `UpdateThingShadowRequestHandler`. In the current unit tests, `UpdateThingShadowRequestHandler` has mocked behavior which causes the null values to not be handled as they would be in practice, so the null value has been added into the expected result for now, pending a refactor of the tests.

**Checklist:**
 - [ ] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
