### PR TITLE
fix: just synchronize all DAO operations to avoid H2 threading problems

### DIFF
--- a/.github/workflows/uat.yaml
+++ b/.github/workflows/uat.yaml
@@ -31,6 +31,7 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           role-session-name: shadowManagerCI
           aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 7200
       - name: Run UAT on linux
         uses: aws-actions/aws-codebuild-run-build@v1
         with:

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/UnhappyUpdateIPCTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/UnhappyUpdateIPCTest.java
@@ -85,7 +85,7 @@ class UnhappyUpdateIPCTest extends NucleusLaunchUtils {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, InvalidRequestParametersException.class);
 
-        startNucleusWithConfig("shadow.yaml");
+        startNucleusWithConfig("shadowUnhappy.yaml");
 
         int sizeLimit = 20 * 1024;
         shadowManager.getConfig().lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC).withValue(
@@ -112,7 +112,7 @@ class UnhappyUpdateIPCTest extends NucleusLaunchUtils {
         ignoreExceptionOfType(context, InterruptedException.class);
         ignoreExceptionOfType(context, InvalidRequestParametersException.class);
 
-        startNucleusWithConfig("shadow.yaml");
+        startNucleusWithConfig("shadowUnhappy.yaml");
 
         shadowManager.getConfig().lookup(CONFIGURATION_CONFIG_KEY, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC).withValue(20 * 1024);
         UpdateThingShadowRequestHandler updateHandler = shadowManager.getUpdateThingShadowRequestHandler();

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/shadow.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/shadow.yaml
@@ -6,8 +6,18 @@ services:
         posixUser: nobody
   aws.greengrass.ShadowManager:
     configuration:
+      strategy:
+        type: realTime
+      synchronize:
+        direction: betweenDeviceAndCloud
+        shadowDocuments:
+          - thingName: "mockThing"
+            classic: false
+            namedShadows:
+              - testShadowName
       rateLimits:
-        maxLocalRequestsPerSecondPerThing: 100
+        maxLocalRequestsPerSecondPerThing: 10000
+        maxTotalLocalRequestsRate: 10000
   main:
     dependencies:
       - DoAll

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/shadowUnhappy.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/shadowUnhappy.yaml
@@ -1,0 +1,43 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+  aws.greengrass.ShadowManager:
+    configuration:
+      rateLimits:
+        maxLocalRequestsPerSecondPerThing: 100
+  main:
+    dependencies:
+      - DoAll
+  DoAll:
+    lifecycle:
+      startup: echo "Running"
+      shutdown: echo "Stopping"
+    dependencies:
+      - aws.greengrass.ShadowManager
+    configuration:
+      accessControl:
+        aws.greengrass.ShadowManager:
+          policyId1:
+            policyDescription: access to CRUD shadow operations
+            operations:
+              - 'aws.greengrass#GetThingShadow'
+              - 'aws.greengrass#UpdateThingShadow'
+              - 'aws.greengrass#DeleteThingShadow'
+            resources:
+              - '*'
+          policyId2:
+            policyDescription: access to list named shadows
+            operations:
+              - 'aws.greengrass#ListNamedShadowsForThing'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId3:
+            policyDescription: access to pubsub topics
+            operations:
+              - 'aws.greengrass#SubscribeToTopic'
+            resources:
+              - '*'

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManagerDatabase.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -51,7 +49,6 @@ public class ShadowManagerDatabase implements Closeable {
 
     private static final Logger logger = LogManager.getLogger(ShadowManagerDatabase.class);
     private final Path databasePath;
-    private ExecutorService dbWriteThreadPool;
     @Getter
     private boolean initialized = false;
 
@@ -159,24 +156,9 @@ public class ShadowManagerDatabase implements Closeable {
     @SuppressWarnings("PMD.NullAssignment")
     @SuppressFBWarnings(value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", justification = "Field gated by flag")
     public void close() {
-        if (dbWriteThreadPool != null) {
-            dbWriteThreadPool.shutdown();
-        }
         if (pool != null) {
             pool.dispose();
             pool = null;
         }
-    }
-
-    /**
-     * Get the thread pool used for writing to the DB.
-     *
-     * @return a running thread pool
-     */
-    public synchronized ExecutorService getDbWriteThreadPool() {
-        if (dbWriteThreadPool == null || dbWriteThreadPool.isShutdown()) {
-            dbWriteThreadPool = Executors.newCachedThreadPool();
-        }
-        return dbWriteThreadPool;
     }
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/configuration/ShadowDocSizeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/configuration/ShadowDocSizeConfiguration.java
@@ -35,7 +35,10 @@ public final class ShadowDocSizeConfiguration {
     private static int getMaxShadowDocSizeFromConfig(Topics topics) {
         int newMaxShadowSize = Coerce.toInt(
                 topics.findOrDefault(DEFAULT_DOCUMENT_SIZE, CONFIGURATION_MAX_DOC_SIZE_LIMIT_B_TOPIC));
-        if (MAX_SHADOW_DOCUMENT_SIZE < newMaxShadowSize || newMaxShadowSize <= 0) {
+        if (newMaxShadowSize == 0) {
+            return DEFAULT_DOCUMENT_SIZE;
+        }
+        if (MAX_SHADOW_DOCUMENT_SIZE < newMaxShadowSize || newMaxShadowSize < 0) {
             throw new InvalidConfigurationException(String.format(
                     "Maximum shadow size provided %d is either less than 0 "
                             + "or exceeds default maximum shadow size of %d",

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/model/BaseSyncRequest.java
@@ -135,7 +135,7 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
     protected Optional<Long> getUpdatedVersion(byte[] payload) {
         try {
             ShadowDocument document = new ShadowDocument(payload, false);
-            return Optional.of(document.getVersion());
+            return Optional.ofNullable(document.getVersion());
         } catch (InvalidRequestParametersException | IOException e) {
             logger.atDebug()
                     .kv(LOG_THING_NAME_KEY, getThingName())
@@ -377,7 +377,9 @@ public abstract class BaseSyncRequest extends ShadowRequest implements SyncReque
         try {
             GetThingShadowResponse getThingShadowResponse = context.getIotDataPlaneClientWrapper()
                     .getThingShadow(getThingName(), getShadowName());
-            if (getThingShadowResponse != null && getThingShadowResponse.payload() != null) {
+            // Check asByteArray for null to account for mocking in tests
+            if (getThingShadowResponse != null && getThingShadowResponse.payload() != null
+                    && getThingShadowResponse.payload().asByteArray() != null) {
                 return Optional.of(new ShadowDocument(getThingShadowResponse.payload().asByteArray()));
             }
         } catch (ResourceNotFoundException e) {

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerDAOImplTest.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.shadowmanager.util.JsonUtil;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Pair;
 import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,8 +28,6 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,7 +46,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
@@ -57,8 +53,6 @@ class ShadowManagerDAOImplTest {
     private static final byte[] BASE_DOCUMENT = "{\"version\": 1, \"state\": {\"reported\": {\"name\": \"The Beatles\"}}}".getBytes();
     private static final String THING_NAME = "thingName";
     private static final String SHADOW_NAME = "shadowName";
-
-    private ExecutorService es;
 
     @Mock
     private ShadowManagerDatabase mockDatabase;
@@ -89,16 +83,10 @@ class ShadowManagerDAOImplTest {
     @BeforeEach
     void setup() throws SQLException, IOException {
         when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
-        es = Executors.newCachedThreadPool();
-        lenient().when(mockDatabase.getDbWriteThreadPool()).thenReturn(es);
         when(mockDatabase.getPool()).thenReturn(mockPool);
         when(mockPool.getConnection()).thenReturn(mockConnection);
         when(mockDatabase.isInitialized()).thenReturn(true);
         JsonUtil.loadSchema();
-    }
-    @AfterEach
-    void after()  {
-        es.shutdownNow();
     }
 
     private void assertUpdateShadowStatementMocks(long epochNow) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added a stress test that updates shadow over IPC 1,000 times as fast as possible, causing shadow manager to need to sync to cloud quickly as well. This replicated a customer issue where they saw a nullpointerexception coming from H2. The fix is to simply synchronize all DB access.

I auto-formatted src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/ShadowIPCTest.java, so forgive the large change there. The meaningful change is the addition of test 0 which is the stress test.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [x] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
