### PR TITLE
fix: synchronize cloud data client operations properly

### DIFF
--- a/gdk-config.json
+++ b/gdk-config.json
@@ -1,0 +1,16 @@
+{
+  "component": {
+    "aws.greengrass.ShadowManager": {
+      "author": "Me",
+      "version": "NEXT_PATCH",
+      "build": {
+        "build_system": "maven"
+      },
+      "publish": {
+        "bucket": "ggv2componentartifacts",
+        "region": "us-east-1"
+      }
+    }
+  },
+  "gdk_version": "1.0.0"
+}

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -111,17 +111,15 @@ public class ShadowManager extends PluginService {
     public final MqttClientConnectionEvents callbacks = new MqttClientConnectionEvents() {
         @Override
         public void onConnectionInterrupted(int errorCode) {
-            handleAsync(() -> stopSyncingShadows(true));
+            stopSyncingShadows(true);
         }
 
         @Override
         public void onConnectionResumed(boolean sessionPresent) {
-            handleAsync(() -> {
-                if (inState(State.RUNNING)) {
-                    startSyncingShadows(
-                            StartSyncInfo.builder().startSyncStrategy(true).updateCloudSubscriptions(true).build());
-                }
-            });
+            if (inState(State.RUNNING)) {
+                handleAsync(() -> startSyncingShadows(
+                        StartSyncInfo.builder().startSyncStrategy(true).updateCloudSubscriptions(true).build()));
+            }
         }
 
         private void handleAsync(Runnable runnable) {

--- a/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java
@@ -63,6 +63,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -101,22 +104,34 @@ public class ShadowManager extends PluginService {
     private final CloudDataClient cloudDataClient;
     private final MqttClient mqttClient;
     private final PubSubIntegrator pubSubIntegrator;
+    private final ExecutorService executorService;
     private final AtomicReference<Strategy> currentStrategy = new AtomicReference<>(DEFAULT_STRATEGY);
+    // This is used from within the mqtt thread only
+    private Future<?> mqttCallbackFuture = new CompletableFuture<>();
     public final MqttClientConnectionEvents callbacks = new MqttClientConnectionEvents() {
         @Override
         public void onConnectionInterrupted(int errorCode) {
-            stopSyncingShadows(true);
+            handleAsync(() -> stopSyncingShadows(true));
         }
 
         @Override
         public void onConnectionResumed(boolean sessionPresent) {
-            if (inState(State.RUNNING)) {
-                startSyncingShadows(StartSyncInfo.builder().startSyncStrategy(true)
-                        .updateCloudSubscriptions(true).build());
+            handleAsync(() -> {
+                if (inState(State.RUNNING)) {
+                    startSyncingShadows(
+                            StartSyncInfo.builder().startSyncStrategy(true).updateCloudSubscriptions(true).build());
+                }
+            });
+        }
 
+        private void handleAsync(Runnable runnable) {
+            if (!mqttCallbackFuture.isDone() && !mqttCallbackFuture.isCancelled()) {
+                mqttCallbackFuture.cancel(true);
             }
+            mqttCallbackFuture = executorService.submit(runnable);
         }
     };
+
     private final CallbackEventManager.OnConnectCallback onConnect = callbacks::onConnectionResumed;
 
     @Getter(AccessLevel.PUBLIC)
@@ -147,23 +162,18 @@ public class ShadowManager extends PluginService {
      * @param cloudDataClient             the data client subscribing to cloud shadow topics
      * @param mqttClient                  the mqtt client connected to IoT Core
      * @param direction                   The sync direction
+     * @param executorService             Executor service
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     @Inject
     public ShadowManager(
             Topics topics,
-            ShadowManagerDatabase database,
-            ShadowManagerDAOImpl dao,
-            AuthorizationHandlerWrapper authorizationHandlerWrapper,
-            PubSubClientWrapper pubSubClientWrapper,
-            InboundRateLimiter inboundRateLimiter,
-            DeviceConfiguration deviceConfiguration,
-            ShadowWriteSynchronizeHelper synchronizeHelper,
-            IotDataPlaneClientWrapper iotDataPlaneClientWrapper,
-            SyncHandler syncHandler,
-            CloudDataClient cloudDataClient,
-            MqttClient mqttClient,
-            DirectionWrapper direction) {
+            ShadowManagerDatabase database, ShadowManagerDAOImpl dao,
+            AuthorizationHandlerWrapper authorizationHandlerWrapper, PubSubClientWrapper pubSubClientWrapper,
+            InboundRateLimiter inboundRateLimiter, DeviceConfiguration deviceConfiguration,
+            ShadowWriteSynchronizeHelper synchronizeHelper, IotDataPlaneClientWrapper iotDataPlaneClientWrapper,
+            SyncHandler syncHandler, CloudDataClient cloudDataClient, MqttClient mqttClient, DirectionWrapper direction,
+            ExecutorService executorService) {
         super(topics);
         this.database = database;
         this.authorizationHandlerWrapper = authorizationHandlerWrapper;
@@ -184,6 +194,7 @@ public class ShadowManager extends PluginService {
         this.pubSubIntegrator = new PubSubIntegrator(pubSubClientWrapper, deleteThingShadowRequestHandler,
                 updateThingShadowRequestHandler, getThingShadowRequestHandler);
         this.direction = direction;
+        this.executorService = executorService;
     }
 
     private void registerHandlers() {

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
@@ -145,7 +145,7 @@ public class CloudDataClient {
      * @param updateTopics Set of update shadow topics to subscribe to
      * @param deleteTopics Set of delete shadow topics to subscribe to
      */
-    private synchronized void updateSubscriptions(Set<String> updateTopics, Set<String> deleteTopics) {
+    private void updateSubscriptions(Set<String> updateTopics, Set<String> deleteTopics) {
         if (!mqttClient.connected()) {
             logger.atWarn()
                     .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java
@@ -24,6 +24,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -48,9 +49,9 @@ public class CloudDataClient {
     private final MqttClient mqttClient;
     private final ExecutorService executorService;
     @Getter(AccessLevel.PACKAGE)
-    private final Set<String> subscribedUpdateShadowTopics = new HashSet<>();
+    private final Set<String> subscribedUpdateShadowTopics = ConcurrentHashMap.newKeySet();
     @Getter(AccessLevel.PACKAGE)
-    private final Set<String> subscribedDeleteShadowTopics = new HashSet<>();
+    private final Set<String> subscribedDeleteShadowTopics = ConcurrentHashMap.newKeySet();
     private final Pattern shadowPattern = Pattern.compile("\\$aws\\/things\\/(.*)\\/shadow(\\/name\\/(.*))?"
             + "\\/(update|delete)\\/(accepted|rejected|delta|documents)");
     private static final RetryUtils.RetryConfig RETRY_CONFIG = RetryUtils.RetryConfig.builder()
@@ -60,6 +61,7 @@ public class CloudDataClient {
             .retryableExceptions(Collections.singletonList(SubscriptionRetryException.class))
             .build();
     private Future<?> syncLoopFuture;
+    private final Object subscriptionLock = new Object();
 
     /**
      * Ctr for CloudDataClient.
@@ -87,37 +89,10 @@ public class CloudDataClient {
     /**
      * Unsubscribe to all shadow topics.
      */
-    public synchronized void unsubscribeForAllShadowsTopics() {
-        unsubscribeForAllShadowsTopics(subscribedUpdateShadowTopics, this::handleUpdate);
-        unsubscribeForAllShadowsTopics(subscribedDeleteShadowTopics, this::handleDelete);
-    }
-
-    /**
-     * Unsubscribe from all the shadow topics.
-     *
-     * @param topics   topics to unsubscribe
-     * @param callback Callback function applied to shadow topic
-     */
-    private synchronized void unsubscribeForAllShadowsTopics(Set<String> topics, Consumer<MqttMessage> callback) {
-        Set<String> topicsToUnsubscribe = new HashSet<>(topics);
-        for (String topic : topicsToUnsubscribe) {
-            try {
-                mqttClient.unsubscribe(UnsubscribeRequest.builder().callback(callback).topic(topic).build());
-                logger.atDebug().log("Unsubscribed from {}", topic);
-                topics.remove(topic);
-            } catch (TimeoutException | ExecutionException e) {
-                logger.atWarn()
-                        .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
-                        .kv(LOG_TOPIC, topic)
-                        .setCause(e)
-                        .log("Failed to unsubscribe from shadow topic");
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                logger.atError()
-                        .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
-                        .log("Failed from unsubscribe to all shadow topics");
-            }
-        }
+    public void unsubscribeForAllShadowsTopics() {
+        // There are no new topics to add to update/delete sets, so no new topics are subscribed.
+        // There are no new topics to remove from update/delete sets, so all the existing topics are unsubscribed.
+        updateSubscriptions(new HashSet<>());
     }
 
     /**
@@ -152,67 +127,64 @@ public class CloudDataClient {
                     .log("Attempting to update subscriptions when offline");
             return;
         }
+        // It is possible for a thread to hold the lock indefinitely as updating subscriptions is retried forever.
+        // The lock is released only when updating the subscriptions is successful or when the thread is interrupted
+        // (happens when we cancel the syncLoopFuture)
+        synchronized (subscriptionLock) {
+            // get update topics to remove and subscribe
+            Set<String> updateTopicsToRemove = new HashSet<>(subscribedUpdateShadowTopics);
+            updateTopicsToRemove.removeAll(updateTopics);
 
-        // get update topics to remove and subscribe
-        Set<String> updateTopicsToRemove = new HashSet<>(subscribedUpdateShadowTopics);
-        updateTopicsToRemove.removeAll(updateTopics);
+            Set<String> updateTopicsToSubscribe = new HashSet<>(updateTopics);
+            updateTopicsToSubscribe.removeAll(subscribedUpdateShadowTopics);
 
-        Set<String> updateTopicsToSubscribe = new HashSet<>(updateTopics);
-        updateTopicsToSubscribe.removeAll(subscribedUpdateShadowTopics);
+            Set<String> deleteTopicsToRemove = new HashSet<>(subscribedDeleteShadowTopics);
+            deleteTopicsToRemove.removeAll(deleteTopics);
 
-        Set<String> deleteTopicsToRemove = new HashSet<>(subscribedDeleteShadowTopics);
-        deleteTopicsToRemove.removeAll(deleteTopics);
+            Set<String> deleteTopicsToSubscribe = new HashSet<>(deleteTopics);
+            deleteTopicsToSubscribe.removeAll(subscribedDeleteShadowTopics);
 
-        Set<String> deleteTopicsToSubscribe = new HashSet<>(deleteTopics);
-        deleteTopicsToSubscribe.removeAll(subscribedDeleteShadowTopics);
+            boolean success;
+            try {
+                success = RetryUtils.runWithRetry(RETRY_CONFIG, () -> {
+                    if (Thread.currentThread().isInterrupted()) {
+                        Thread.currentThread().interrupt();
+                        logger.atWarn()
+                                .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
+                                .log("Could not update the shadow subscriptions as the thread is interrupted");
+                        return false;
+                    }
+                    unsubscribeToShadows(subscribedUpdateShadowTopics, updateTopicsToRemove, this::handleUpdate);
+                    subscribeToShadows(subscribedUpdateShadowTopics, updateTopicsToSubscribe, this::handleUpdate);
 
-        boolean success;
-        try {
-            success = RetryUtils.runWithRetry(RETRY_CONFIG, () -> {
-                unsubscribeToShadows(subscribedUpdateShadowTopics, updateTopicsToRemove, this::handleUpdate);
-                subscribeToShadows(subscribedUpdateShadowTopics, updateTopicsToSubscribe, this::handleUpdate);
+                    unsubscribeToShadows(subscribedDeleteShadowTopics, deleteTopicsToRemove, this::handleDelete);
+                    subscribeToShadows(subscribedDeleteShadowTopics, deleteTopicsToSubscribe, this::handleDelete);
 
-                unsubscribeToShadows(subscribedDeleteShadowTopics, deleteTopicsToRemove, this::handleDelete);
-                subscribeToShadows(subscribedDeleteShadowTopics, deleteTopicsToSubscribe, this::handleDelete);
+                    if (!updateTopicsToRemove.isEmpty() || !updateTopicsToSubscribe.isEmpty()
+                            || !deleteTopicsToRemove.isEmpty() || !deleteTopicsToSubscribe.isEmpty()) {
+                        throw new SubscriptionRetryException("Missed shadow topics to (un)subscribe to");
+                    }
+                    return true;
+                }, LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code(), logger);
 
-                if (!updateTopicsToRemove.isEmpty() || !updateTopicsToSubscribe.isEmpty()
-                        || !deleteTopicsToRemove.isEmpty() || !deleteTopicsToSubscribe.isEmpty()
-                        && !Thread.currentThread().isInterrupted()) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.atError().setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code()).setCause(e)
+                        .log("Got interrupted while updating the shadow subscriptions");
+                return;
+            } catch (Exception e) { // NOPMD - thrown by RetryUtils.runWithRetry()
+                logger.atError()
+                        .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
+                        .setCause(e)
+                        .log("Failed to update subscriptions");
+                return;
+            }
 
-                    throw new SubscriptionRetryException("Missed shadow topics to (un)subscribe to");
-                }
-
-                // if interrupted then handle
-                if (Thread.currentThread().isInterrupted()) {
-                    Thread.currentThread().interrupt();
-                    logger.atError()
-                            .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
-                            .log("Failed to update subscriptions");
-                    return false;
-                }
-
-                return true;
-            }, LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code(), logger);
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            logger.atError()
-                    .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
-                    .setCause(e)
-                    .log("Failed to update subscriptions");
-            return;
-        } catch (Exception e) { // NOPMD - thrown by RetryUtils.runWithRetry()
-            logger.atError()
-                    .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
-                    .setCause(e)
-                    .log("Failed to update subscriptions");
-            return;
-        }
-
-        if (success) {
-            logger.atDebug()
-                    .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
-                    .log("Finished updating subscriptions");
+            if (success) {
+                logger.atDebug()
+                        .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
+                        .log("Finished updating subscriptions");
+            }
         }
     }
 
@@ -224,8 +196,9 @@ public class CloudDataClient {
      * @param callback            Callback function applied to shadow topic
      * @throws InterruptedException Interrupt occurred while trying to unsubscribe to shadows
      */
-    private synchronized void unsubscribeToShadows(Set<String> currentTopics, Set<String> topicsToUnsubscribe,
-                                                   Consumer<MqttMessage> callback) throws InterruptedException {
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    private void unsubscribeToShadows(Set<String> currentTopics, Set<String> topicsToUnsubscribe,
+                                               Consumer<MqttMessage> callback) throws InterruptedException {
         Set<String> tempHashSet = new HashSet<>(topicsToUnsubscribe);
         for (String topic : tempHashSet) {
             try {
@@ -251,10 +224,9 @@ public class CloudDataClient {
      * @param callback          Callback function applied to shadow topic
      * @throws InterruptedException Interrupt occurred while trying to subscribe to shadows
      */
-    private synchronized void subscribeToShadows(Set<String> currentTopics, Set<String> topicsToSubscribe,
-                                                 Consumer<MqttMessage> callback) throws InterruptedException {
+    private void subscribeToShadows(Set<String> currentTopics, Set<String> topicsToSubscribe,
+                                    Consumer<MqttMessage> callback) throws InterruptedException {
         Set<String> tempHashSet = new HashSet<>(topicsToSubscribe);
-
         for (String topic : tempHashSet) {
             try {
                 mqttClient.subscribe(SubscribeRequest.builder().topic(topic).callback(callback).build());
@@ -262,11 +234,8 @@ public class CloudDataClient {
                 currentTopics.add(topic);
                 logger.atDebug().log("Subscribed to {}", topic);
             } catch (TimeoutException | ExecutionException e) {
-                logger.atWarn()
-                        .setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code())
-                        .kv(LOG_TOPIC, topic)
-                        .setCause(e)
-                        .log("Failed to subscribe to shadow topic");
+                logger.atWarn().setEventType(LogEvents.CLOUD_DATA_CLIENT_SUBSCRIPTION_ERROR.code()).kv(LOG_TOPIC, topic)
+                        .setCause(e).log("Failed to subscribe to shadow topic");
             }
         }
     }

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -141,8 +140,6 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
     @Mock
     private MqttClient mockMqttClient;
     @Mock
-    private ExecutorService executorService;
-    @Mock
     private GreengrassCoreIPCService mockGreengrassCoreIPCService;
 
     @Captor
@@ -160,8 +157,7 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         initializeMockedConfig();
         shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper,
                 mockPubSubClientWrapper, mockInboundRateLimiter, mockDeviceConfiguration, mockSynchronizeHelper,
-                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient, direction,
-                executorService);
+                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient, direction);
         lenient().when(config.lookupTopics(CONFIGURATION_CONFIG_KEY))
                 .thenReturn(Topics.of(context, CONFIGURATION_CONFIG_KEY, null));
         // These are added to not break the existing unit tests. Will be removed later.

--- a/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ShadowManagerUnitTest.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -140,6 +141,8 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
     @Mock
     private MqttClient mockMqttClient;
     @Mock
+    private ExecutorService executorService;
+    @Mock
     private GreengrassCoreIPCService mockGreengrassCoreIPCService;
 
     @Captor
@@ -157,7 +160,8 @@ class ShadowManagerUnitTest extends GGServiceTestUtil {
         initializeMockedConfig();
         shadowManager = new ShadowManager(config, mockDatabase, mockDao, mockAuthorizationHandlerWrapper,
                 mockPubSubClientWrapper, mockInboundRateLimiter, mockDeviceConfiguration, mockSynchronizeHelper,
-                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient, direction);
+                mockIotDataPlaneClientWrapper, mockSyncHandler, mockCloudDataClient, mockMqttClient, direction,
+                executorService);
         lenient().when(config.lookupTopics(CONFIGURATION_CONFIG_KEY))
                 .thenReturn(Topics.of(context, CONFIGURATION_CONFIG_KEY, null));
         // These are added to not break the existing unit tests. Will be removed later.

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/CloudDataClientTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/CloudDataClientTest.java
@@ -290,6 +290,7 @@ class CloudDataClientTest {
         }
 
         cloudDataClient.unsubscribeForAllShadowsTopics();
+        TimeUnit.MILLISECONDS.sleep(5000);
 
         verify(mockMqttClient, times(200)).unsubscribe(any());
         assertThat(cloudDataClient.getSubscribedUpdateShadowTopics().size(), is(0));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Run mqtt callbacks in a separate thread to avoid a deadlock situation that happens when the Shadow manager component enters into RUNNING state before the MQTT client connection is successfully created acc to GG. 

Mqtt connect future will be completed with the client only after the first on connect callbacks are triggered. Shadow manager onConnect callback needs the client to be fully formed (connect future to be completed with the mqtt client) for it to use subscribe with it.  Hence, the subscriptions triggered from the callback timeout waiting for the client.

During SM start up, startSyncingShadows is called which calls [updateSubscriptions](https://github.com/aws-greengrass/aws-greengrass-shadow-manager/blob/315d1b9cdf7573f8ad4d995835320c5477f9e3ff/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java#L561) on the cloudDataClient. That spins up a new thread from the executor service pool which run this private synchronized  [updateSubscriptions](https://github.com/aws-greengrass/aws-greengrass-shadow-manager/blob/36bb2636d35b3dfd0719e12ab5d3f20562157056/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java#L148) on the cloudDataClient. This runs [indefinitely](https://github.com/aws-greengrass/aws-greengrass-shadow-manager/blob/36bb2636d35b3dfd0719e12ab5d3f20562157056/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java#L56) as mqtt subscribe op was never  [successful](https://github.com/aws-greengrass/aws-greengrass-shadow-manager/blob/36bb2636d35b3dfd0719e12ab5d3f20562157056/src/main/java/com/aws/greengrass/shadowmanager/sync/CloudDataClient.java#L182).
Now, mqtt callback thread is blocked at [updateSubscriptions](https://github.com/aws-greengrass/aws-greengrass-shadow-manager/blob/315d1b9cdf7573f8ad4d995835320c5477f9e3ff/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java#L561) in startSyncShadows because that method is also synchronized on the cloudDataClient instance and we can't have two synchronized methods interleaving  on the same instance.

**Why is this change necessary:**
More info:
When the MQTT client is created for the first time, onConnect (one-time) callbacks are run before the [connectFuture is completed with the client](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/a24441f08bf9e08553b8b029da171e702204bc32/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java#L127-L132).  Only when these callbacks are completed, the `connectFuture` is completed. 

But, in the case where Shadow manager component enters into RUNNING state before the MQTT client connection is successfully created for the first time, [onConnectionResumed](https://github.com/aws-greengrass/aws-greengrass-shadow-manager/blob/bbb5cfa939a63ca2f2f0935f816ef1859cb12c7c/src/main/java/com/aws/greengrass/shadowmanager/ShadowManager.java#L112-L117) callback is triggered when the mqtt client is created for the first time.  This callback uses subscribes to topics using mqtt client. However, in order to subscribe using the mqtt client, the [`connectFuture`](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/a24441f08bf9e08553b8b029da171e702204bc32/src/main/java/com/aws/greengrass/mqttclient/AwsIotMqtt5Client.java#L282) should be fully completed resulting in a deadlock situation. 

The fix is to run the callback in a separate thread, so the `connectFuture` is completed without being blocked.  

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
