### PR TITLE
Remove bounds on shadow queue size

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,13 +26,13 @@ jobs:
           AWS_REGION: us-west-2
         run: mvn -ntp -U clean verify
       - name: Upload Failed Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Failed Test Report
           path: target/surefire-reports
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage Report

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <shadowmanagerjar.name>aws.greengrass.ShadowManager</shadowmanagerjar.name>
 
         <h2.version>1.4.200</h2.version>
-        <nucleus.version>2.5.0-SNAPSHOT</nucleus.version>
+        <nucleus.version>2.6.0-SNAPSHOT</nucleus.version>
         <junit.version>5.6.2</junit.version>
         <mockito.version>4.3.1</mockito.version>
         <lombok.version>1.18.26</lombok.version>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/NucleusLaunchUtils.java
@@ -18,7 +18,7 @@ import com.aws.greengrass.shadowmanager.ShadowManagerDatabase;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
@@ -121,7 +121,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
         kernel.getContext().put(RealTimeSyncStrategy.class, (RealTimeSyncStrategy) realTimeSyncStrategy);
         ExecutorService es = kernel.getContext().get(ExecutorService.class);
         ScheduledExecutorService ses = kernel.getContext().get(ScheduledExecutorService.class);
-        RequestBlockingQueue queue = kernel.getContext().get(RequestBlockingQueue.class);
+        RequestQueue queue = kernel.getContext().get(RequestQueue.class);
         // set retry config to only try once so we can test failures earlier
 
         if (config.isResetRetryConfig()) {
@@ -216,7 +216,7 @@ public class NucleusLaunchUtils extends GGServiceTestUtil {
 
     protected void assertEmptySyncQueue(Class<? extends BaseSyncStrategy> clazz) {
         BaseSyncStrategy s = kernel.getContext().get(clazz);
-        RequestBlockingQueue q = s.getSyncQueue();
+        RequestQueue q = s.getSyncQueue();
         // queue is eventually empty (full syncs are added and then eventually removed)
         assertThat("sync queue is eventually empty", () -> q.isEmpty() && !s.isExecuting(),
                 eventuallyEval(is(true), Duration.ofSeconds(10)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/RateLimiterTest.java
@@ -12,7 +12,7 @@ import com.aws.greengrass.shadowmanager.exception.IoTDataPlaneClientCreationExce
 import com.aws.greengrass.shadowmanager.exception.ThrottledRequestException;
 import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.strategy.RealTimeSyncStrategy;
 import com.aws.greengrass.shadowmanager.util.JsonUtil;
@@ -106,8 +106,8 @@ class RateLimiterTest extends NucleusLaunchUtils {
                         .lastSyncedDocument(lastSyncedDocument.getBytes())
                         .cloudVersion(0).build()));
         lenient().when(dao.updateSyncInformation(any(SyncInformation.class))).thenReturn(true);
-        RequestBlockingQueue queue = spy(kernel.getContext().get(RequestBlockingQueue.class));
-        kernel.getContext().put(RequestBlockingQueue.class, queue);
+        RequestQueue queue = spy(kernel.getContext().get(RequestQueue.class));
+        kernel.getContext().put(RequestQueue.class, queue);
 
         startNucleusWithConfig(NucleusLaunchUtilsConfig.builder().configFile("rateLimits.yaml").mockCloud(true).mockDao(true).build());
         SyncHandler syncHandler = kernel.getContext().get(SyncHandler.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -21,7 +21,7 @@ import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfi
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientFactory;
 import com.aws.greengrass.shadowmanager.sync.IotDataPlaneClientWrapper;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
@@ -315,8 +315,8 @@ class ShadowManagerTest extends NucleusLaunchUtils {
         ignoreExceptionOfType(context, TLSAuthException.class);
         ignoreExceptionOfType(context, RetryableException.class);
 
-        RequestBlockingQueue syncQueue = spy(new RequestBlockingQueue(new RequestMerger(new DirectionWrapper())));
-        kernel.getContext().put(RequestBlockingQueue.class, syncQueue);
+        RequestQueue syncQueue = spy(new RequestQueue(new RequestMerger(new DirectionWrapper())));
+        kernel.getContext().put(RequestQueue.class, syncQueue);
 
         SecurityService securityService = mock(SecurityService.class);
         when(securityService.getDeviceIdentityKeyManagers()).thenThrow(TLSAuthException.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ShadowManagerTest.java
@@ -341,7 +341,7 @@ class ShadowManagerTest extends NucleusLaunchUtils {
 
         // wait for dataplane client creation retries to fail,
         // and the full sync is put back on the queue
-        verify(syncQueue, timeout(30000L).times(1)).offerAndTake(any(FullShadowSyncRequest.class), eq(false));
+        verify(syncQueue, timeout(30000L).times(1)).putAndTake(any(FullShadowSyncRequest.class), eq(false));
 
         BaseSyncStrategy syncStrategy = kernel.getContext().get(RealTimeSyncStrategy.class);
         assertThat("syncing has started", syncStrategy::isSyncing, eventuallyEval(is(true)));

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/SyncTest.java
@@ -19,7 +19,7 @@ import com.aws.greengrass.shadowmanager.model.ShadowDocument;
 import com.aws.greengrass.shadowmanager.model.UpdateThingShadowHandlerResponse;
 import com.aws.greengrass.shadowmanager.model.configuration.ThingShadowSyncConfiguration;
 import com.aws.greengrass.shadowmanager.model.dao.SyncInformation;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.SyncHandler;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
@@ -135,7 +135,7 @@ class SyncTest extends NucleusLaunchUtils {
     @Mock
     UpdateThingShadowResponse mockUpdateThingShadowResponse;
 
-    RequestBlockingQueue syncQueue;
+    RequestQueue syncQueue;
 
     @Captor
     private ArgumentCaptor<SyncInformation> syncInformationCaptor;
@@ -152,8 +152,8 @@ class SyncTest extends NucleusLaunchUtils {
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
-        syncQueue = spy(new RequestBlockingQueue(new RequestMerger(new DirectionWrapper())));
-        kernel.getContext().put(RequestBlockingQueue.class, syncQueue);
+        syncQueue = spy(new RequestQueue(new RequestMerger(new DirectionWrapper())));
+        kernel.getContext().put(RequestQueue.class, syncQueue);
         syncInfo = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowSyncInformation(MOCK_THING_NAME_1,
                 CLASSIC_SHADOW);
         localShadow = () -> kernel.getContext().get(ShadowManagerDAOImpl.class).getShadowThing(MOCK_THING_NAME_1,

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestQueue.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/RequestQueue.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
  * For the simplest blocking use case, threads can call {@link #take()} and they will wait until items are available.
  * Threads can call {@link #put(SyncRequest)} and they will wait until space is available to insert.
  */
-public class RequestBlockingQueue {
+public class RequestQueue {
 
     /**
      * Default maximum number of queued requests.
@@ -54,12 +54,12 @@ public class RequestBlockingQueue {
     private final int capacity;
 
     /**
-     * Create a new instance with a capacity of {@value RequestBlockingQueue#MAX_CAPACITY}.
+     * Create a new instance with a capacity of {@value RequestQueue#MAX_CAPACITY}.
      *
      * @param merger a merger
      */
     @Inject
-    public RequestBlockingQueue(RequestMerger merger) {
+    public RequestQueue(RequestMerger merger) {
         this(merger, MAX_CAPACITY);
     }
 
@@ -69,11 +69,11 @@ public class RequestBlockingQueue {
      * @param merger   a merger
      * @param capacity the max capacity
      */
-    public RequestBlockingQueue(RequestMerger merger, int capacity) {
+    public RequestQueue(RequestMerger merger, int capacity) {
         this(merger, capacity, new LinkedHashMap<>());
     }
 
-    RequestBlockingQueue(RequestMerger merger, int capacity, Map<String, SyncRequest> requests) {
+    RequestQueue(RequestMerger merger, int capacity, Map<String, SyncRequest> requests) {
         super();
         this.merger = merger;
         this.requests = requests;

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
@@ -162,12 +162,6 @@ public class SyncHandler {
 
         List<Pair<String, String>> shadows = context.getDao().listSyncedShadows();
 
-        if (shadows.size() > overallSyncStrategy.getRemainingCapacity()) {
-            logger.atWarn(SYNC_EVENT_TYPE)
-                    .addKeyValue("syncedShadows", shadows.size())
-                    .addKeyValue("syncQueueCapacity", overallSyncStrategy.getRemainingCapacity())
-                    .log("There are more shadows than space in the sync queue. Syncing will block");
-        }
         Stream<BaseSyncRequest> requestStream = null;
         switch (direction.get()) {
             case BETWEEN_DEVICE_AND_CLOUD:

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/SyncHandler.java
@@ -88,7 +88,7 @@ public class SyncHandler {
     /**
      * Request queue.
      */
-    private final RequestBlockingQueue syncQueue;
+    private final RequestQueue syncQueue;
     // retry wrapper so that requests can be mocked
     // setter is used in integ tests only
     @Setter
@@ -111,7 +111,7 @@ public class SyncHandler {
      */
     @Inject
     public SyncHandler(ExecutorService executorService, ScheduledExecutorService syncScheduledExecutorService,
-                       RequestBlockingQueue syncQueue, DirectionWrapper direction) {
+                       RequestQueue syncQueue, DirectionWrapper direction) {
         this(executorService, syncScheduledExecutorService, retryer, syncQueue, direction);
     }
 
@@ -125,7 +125,7 @@ public class SyncHandler {
      * @param direction                    The sync direction
      */
     private SyncHandler(ExecutorService executorService, ScheduledExecutorService syncScheduledExecutorService,
-                        Retryer retryer, RequestBlockingQueue syncQueue, DirectionWrapper direction) {
+                        Retryer retryer, RequestQueue syncQueue, DirectionWrapper direction) {
         this(new SyncStrategyFactory(retryer, executorService, syncScheduledExecutorService, direction),
                 syncQueue, direction);
     }
@@ -137,7 +137,7 @@ public class SyncHandler {
      * @param syncQueue           a request queue.
      * @param direction           The sync direction
      */
-    SyncHandler(SyncStrategyFactory syncStrategyFactory, RequestBlockingQueue syncQueue, DirectionWrapper direction) {
+    SyncHandler(SyncStrategyFactory syncStrategyFactory, RequestQueue syncQueue, DirectionWrapper direction) {
         this.syncStrategyFactory = syncStrategyFactory;
         this.syncQueue = syncQueue;
         this.direction = direction;

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -424,7 +424,6 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
                 try {
                     syncQueue.put(request);
                 } catch (InterruptedException e) {
-                    // Is swallowing the exception really the right call?
                     logger.atError(SYNC_EVENT_TYPE).log("Interrupted while adding request item back to queue");
                 }
             }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/BaseSyncStrategy.java
@@ -9,7 +9,7 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.FullShadowSyncRequest;
@@ -58,7 +58,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      * @implNote The Setter is only used in unit tests. The Getter is used in integration tests.
      */
     @Getter
-    final RequestBlockingQueue syncQueue;
+    final RequestQueue syncQueue;
 
     /**
      * Interface for executing sync requests.
@@ -136,7 +136,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
         return executing.get();
     }
 
-    protected BaseSyncStrategy(Retryer retryer, RequestBlockingQueue syncQueue, DirectionWrapper syncDirection) {
+    protected BaseSyncStrategy(Retryer retryer, RequestQueue syncQueue, DirectionWrapper syncDirection) {
         this(retryer, DEFAULT_RETRY_CONFIG, syncQueue, syncDirection);
     }
 
@@ -147,7 +147,7 @@ public abstract class BaseSyncStrategy implements SyncStrategy {
      * @param retryConfig The config to be used by the retryer.
      * @param syncQueue   A queue to use for sync requests.
      */
-    protected BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue,
+    protected BaseSyncStrategy(Retryer retryer, RetryUtils.RetryConfig retryConfig, RequestQueue syncQueue,
                                DirectionWrapper syncDirection) {
         this.retryer = (config, request, context) -> {
             try {

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/PeriodicSyncStrategy.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
@@ -40,7 +40,7 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
      * @param  direction  The sync direction
      */
     public PeriodicSyncStrategy(ScheduledExecutorService ses, Retryer retryer, long interval,
-                                RequestBlockingQueue syncQueue, DirectionWrapper direction) {
+                                RequestQueue syncQueue, DirectionWrapper direction) {
         super(retryer, syncQueue, direction);
         this.syncExecutorService = ses;
         this.interval = interval;
@@ -57,7 +57,7 @@ public class PeriodicSyncStrategy extends BaseSyncStrategy {
      * @param  direction  The sync direction
      */
     public PeriodicSyncStrategy(ScheduledExecutorService ses, Retryer retryer, long interval,
-                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue,
+                                RetryUtils.RetryConfig retryConfig, RequestQueue syncQueue,
                                 DirectionWrapper direction) {
         super(retryer, retryConfig, syncQueue, direction);
         this.syncExecutorService = ses;

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategy.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.model.SyncContext;
@@ -39,7 +39,7 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
      * @param syncQueue       The sync queue from the previous strategy if any.
      * @param direction       The sync direction
      */
-    public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer, RequestBlockingQueue syncQueue,
+    public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer, RequestQueue syncQueue,
                                 DirectionWrapper direction) {
         super(retryer, syncQueue, direction);
         this.syncExecutorService = executorService;
@@ -56,7 +56,7 @@ public class RealTimeSyncStrategy extends BaseSyncStrategy {
      * @param direction       The sync direction
      */
     public RealTimeSyncStrategy(ExecutorService executorService, Retryer retryer,
-                                RetryUtils.RetryConfig retryConfig, RequestBlockingQueue syncQueue,
+                                RetryUtils.RetryConfig retryConfig, RequestQueue syncQueue,
                                 DirectionWrapper direction) {
         super(retryer, retryConfig, syncQueue, direction);
         this.syncExecutorService = executorService;

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategy.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategy.java
@@ -44,11 +44,4 @@ public interface SyncStrategy {
      * Clear all the sync requests in the request blocking queue.
      */
     void clearSyncQueue();
-
-    /**
-     * Get the remaining capacity in the request blocking sync queue.
-     *
-     * @return The capacity left in the sync queue.
-     */
-    int getRemainingCapacity();
 }

--- a/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactory.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactory.java
@@ -5,7 +5,7 @@
 
 package com.aws.greengrass.shadowmanager.sync.strategy;
 
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.Strategy;
@@ -49,7 +49,7 @@ public class SyncStrategyFactory {
      * @return The sync strategy client to handle syncing of shadows.
      */
     @SuppressWarnings("PMD.MissingBreakInSwitch")
-    public SyncStrategy createSyncStrategy(Strategy syncStrategy, RequestBlockingQueue syncQueue) {
+    public SyncStrategy createSyncStrategy(Strategy syncStrategy, RequestQueue syncQueue) {
         switch (syncStrategy.getType()) {
             case PERIODIC:
                 return new PeriodicSyncStrategy(syncScheduledExecutorService, retryer, syncStrategy.getDelay(),

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestQueueTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestQueueTest.java
@@ -29,11 +29,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
-class RequestBlockingQueueTest {
+class RequestQueueTest {
 
     private static final long WAIT_SECONDS = 5;
 
-    RequestBlockingQueue queue;
+    RequestQueue queue;
 
     @Mock
     RequestMerger merger;
@@ -53,7 +53,7 @@ class RequestBlockingQueueTest {
 
     @BeforeEach
     void setup() {
-        queue = new RequestBlockingQueue(merger, 3);
+        queue = new RequestQueue(merger, 3);
         setupRequest(thingAShadow1, "A", "1");
         setupRequest(thingAShadow1Again, "A", "1");
         setupRequest(thingAShadow2, "A", "2");
@@ -280,8 +280,8 @@ class RequestBlockingQueueTest {
 
     @Test
     void GIVEN_use_constructor_without_capacity_THEN_default_capacity_used() {
-        RequestBlockingQueue q = new RequestBlockingQueue(merger);
-        assertThat(q.remainingCapacity(), is(RequestBlockingQueue.MAX_CAPACITY));
+        RequestQueue q = new RequestQueue(merger);
+        assertThat(q.remainingCapacity(), is(RequestQueue.MAX_CAPACITY));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestQueueTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/RequestQueueTest.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -53,7 +52,7 @@ class RequestQueueTest {
 
     @BeforeEach
     void setup() {
-        queue = new RequestQueue(merger, 3);
+        queue = new RequestQueue(merger);
         setupRequest(thingAShadow1, "A", "1");
         setupRequest(thingAShadow1Again, "A", "1");
         setupRequest(thingAShadow2, "A", "2");
@@ -76,32 +75,24 @@ class RequestQueueTest {
     void GIVEN_empty_queue_THEN_queue_is_empty() {
         assertThat(queue.size(), is(0));
         assertThat("isEmpty", queue.isEmpty(), is(true));
-        assertThat("isFull", queue.isFull(), is(false));
     }
 
     @Test
-    void GIVEN_empty_queue_WHEN_add_items_THEN_queue_fills() {
+    void GIVEN_empty_queue_WHEN_add_items_THEN_queue_fills() throws InterruptedException {
         assertThat("isEmpty", queue.isEmpty(), is(true));
-        assertThat("isFull", queue.isFull(), is(false));
-        assertThat("capacity", queue.remainingCapacity(), is(3));
 
-        assertThat(queue.offer(thingAShadow1), is(true));
+        queue.put(thingAShadow1);
         assertThat(queue.size(), is(1));
         assertThat("isEmpty", queue.isEmpty(), is(false));
-        assertThat("isFull", queue.isFull(), is(false));
-        assertThat("capacity", queue.remainingCapacity(), is(2));
 
-        assertThat(queue.offer(thingAShadow2), is(true));
+
+        queue.put(thingAShadow2);
         assertThat(queue.size(), is(2));
         assertThat("isEmpty", queue.isEmpty(), is(false));
-        assertThat("isFull", queue.isFull(), is(false));
-        assertThat("capacity", queue.remainingCapacity(), is(1));
 
-        assertThat(queue.offer(thingBShadow1), is(true));
+        queue.put(thingBShadow1);
         assertThat(queue.size(), is(3));
         assertThat("isEmpty", queue.isEmpty(), is(false));
-        assertThat("isFull", queue.isFull(), is(true));
-        assertThat("capacity", queue.remainingCapacity(), is(0));
     }
 
     @Test
@@ -117,9 +108,9 @@ class RequestQueueTest {
 
     @Test
     void GIVEN_non_empty_queue_WHEN_poll_THEN_returns_values_in_order() throws InterruptedException {
-        queue.offer(thingAShadow1);
-        queue.offer(thingAShadow2);
-        queue.offer(thingBShadow1);
+        queue.put(thingAShadow1);
+        queue.put(thingAShadow2);
+        queue.put(thingBShadow1);
         assertThat(queue.poll(), is(thingAShadow1));
         assertThat(queue.poll(), is(thingAShadow2));
         assertThat(queue.poll(), is(thingBShadow1));
@@ -128,9 +119,9 @@ class RequestQueueTest {
 
     @Test
     void GIVEN_non_empty_queue_WHEN_poll_with_timeout_THEN_returns_values_in_order() throws InterruptedException {
-        assertThat(queue.offer(thingAShadow1, WAIT_SECONDS, TimeUnit.SECONDS), is(true));
-        assertThat(queue.offer(thingAShadow2, WAIT_SECONDS, TimeUnit.SECONDS), is(true));
-        assertThat(queue.offer(thingBShadow1, WAIT_SECONDS, TimeUnit.SECONDS), is(true));
+        queue.put(thingAShadow1);
+        queue.put(thingAShadow2);
+        queue.put(thingBShadow1);
         assertThat(queue.poll(WAIT_SECONDS, TimeUnit.SECONDS), is(thingAShadow1));
         assertThat(queue.poll(WAIT_SECONDS, TimeUnit.SECONDS), is(thingAShadow2));
         assertThat(queue.poll(WAIT_SECONDS, TimeUnit.SECONDS), is(thingBShadow1));
@@ -140,19 +131,20 @@ class RequestQueueTest {
     @Test
     void GIVEN_items_added_to_queue_WHEN_peek_THEN_does_not_remove_value() throws InterruptedException {
         assertThat(queue.peek(), is(nullValue()));
-        queue.offer(thingAShadow1);
+        queue.put(thingAShadow1);
         assertThat(queue.peek(), is(thingAShadow1));
-        queue.offer(thingAShadow2);
+        queue.put(thingAShadow2);
         assertThat(queue.peek(), is(thingAShadow1));
 
         queue.poll();
 
         assertThat(queue.peek(), is(thingAShadow2));
-        queue.offer(thingBShadow1);
+        queue.put(thingBShadow1);
         assertThat(queue.peek(), is(thingAShadow2));
     }
+
     @Test
-    void GIVEN_consumer_thread_taking_from_queue_WHEN_producer_thread_offers_item_THEN_consumer_receives_it() {
+    void GIVEN_consumer_thread_taking_from_queue_WHEN_producer_adds_item_THEN_consumer_receives_it() {
         AtomicReference<SyncRequest> received = new AtomicReference<>();
         CountDownLatch consumerLatch = new CountDownLatch(1);
         CountDownLatch producerLatch = new CountDownLatch(1);
@@ -166,8 +158,7 @@ class RequestQueueTest {
 
         Thread producer = new Thread(() -> {
             // wait for consumer to start
-            assertDoesNotThrow((Executable) consumerStartedLatch::await);
-            queue.offer(thingAShadow1);
+            assertDoesNotThrow(() -> queue.put(thingAShadow1));
             producerLatch.countDown();
         });
 
@@ -180,20 +171,8 @@ class RequestQueueTest {
     }
 
     @Test
-    void GIVEN_full_queue_WHEN_add_THEN_item_not_added() {
-        queue.offer(thingAShadow1);
-        queue.offer(thingAShadow2);
-        queue.offer(thingBShadow1);
-        assertThat("queue full", queue.isFull(), is(true));
-
-        assertThat("item added to full queue", queue.offer(thingCShadow1), is(false)) ;
-        assertThat("item added to full queue with timeout",
-                assertDoesNotThrow(() -> queue.offer(thingCShadow1, WAIT_SECONDS, TimeUnit.SECONDS)), is(false));
-    }
-
-    @Test
     void GIVEN_request_exists_in_queue_WHEN_add_request_for_same_shadow_THEN_item_merged() throws InterruptedException {
-        queue.offer(thingAShadow1);
+        queue.put(thingAShadow1);
         assertThat(queue.size(), is(1));
 
         SyncRequest req = mock(SyncRequest.class);
@@ -202,7 +181,7 @@ class RequestQueueTest {
         SyncRequest merged = mock(SyncRequest.class);
         when(merger.merge(any(), any())).thenReturn(merged);
 
-        queue.offer(req);
+        queue.put(req);
         assertThat(queue.size(), is(1));
 
 
@@ -211,9 +190,9 @@ class RequestQueueTest {
     }
 
     @Test
-    void GIVEN_non_empty_queue_WHEN_clear_THEN_queue_empty() {
-        queue.offer(thingAShadow1);
-        queue.offer(thingAShadow2);
+    void GIVEN_non_empty_queue_WHEN_clear_THEN_queue_empty() throws InterruptedException {
+        queue.put(thingAShadow1);
+        queue.put(thingAShadow2);
         assertThat("queue empty", queue.isEmpty(), is(false));
 
         queue.clear();
@@ -221,7 +200,7 @@ class RequestQueueTest {
     }
 
     @Test
-    void GIVEN_put_WHEN_not_full_THEN_returns_immediately() throws InterruptedException {
+    void GIVEN_put_THEN_returns_immediately() {
         CountDownLatch latch = new CountDownLatch(1);
         Thread runner = new Thread(() -> {
             assertDoesNotThrow(() -> queue.put(thingAShadow1));
@@ -236,57 +215,15 @@ class RequestQueueTest {
         assertThat(queue.poll(), is(thingAShadow1));
     }
 
-    @Test
-    void GIVEN_put_WHEN_full_THEN_waits_until_has_space() throws InterruptedException {
-        assertThat("request added", queue.offer(thingAShadow1), is(true));
-        assertThat("request added", queue.offer(thingAShadow2), is(true));
-        assertThat("request added", queue.offer(thingBShadow1), is(true));
-        assertThat("is full", queue.isFull(), is(true));
-
-        CountDownLatch producerLatch = new CountDownLatch(1);
-        Thread producer = new Thread(() -> {
-            assertDoesNotThrow(() -> queue.put(thingCShadow1));
-            producerLatch.countDown();
-        });
-
-        producer.start();
-
-        CountDownLatch consumerLatch = new CountDownLatch(1);
-        AtomicReference<SyncRequest> request = new AtomicReference<>();
-        Thread consumer = new Thread(() -> {
-            SyncRequest r = assertDoesNotThrow(() -> queue.take());
-            request.set(r);
-            consumerLatch.countDown();
-        });
-
-        consumer.start();
-
-        waitLatch(producerLatch);
-        waitLatch(consumerLatch);
-
-        assertThat("is full", queue.isFull(), is(true));
-        assertThat(request.get(), is(thingAShadow1));
-        assertThat(queue.poll(), is(thingAShadow2));
-        assertThat(queue.poll(), is(thingBShadow1));
-        assertThat(queue.poll(), is(thingCShadow1));
-    }
 
     @Test
     void GIVEN_null_request_WHEN_added_THEN_throws() {
         assertThrows(NullPointerException.class, () -> queue.put(null));
-        assertThrows(NullPointerException.class, () -> queue.offer(null));
-        assertThrows(NullPointerException.class, () -> queue.offer(null, WAIT_SECONDS, TimeUnit.SECONDS));
     }
 
     @Test
-    void GIVEN_use_constructor_without_capacity_THEN_default_capacity_used() {
-        RequestQueue q = new RequestQueue(merger);
-        assertThat(q.remainingCapacity(), is(RequestQueue.MAX_CAPACITY));
-    }
-
-    @Test
-    void GIVEN_item_WHEN_remove_THEN_item_removed() {
-        queue.offer(thingAShadow1);
+    void GIVEN_item_WHEN_remove_THEN_item_removed() throws InterruptedException {
+        queue.put(thingAShadow1);
         assertThat("queue empty", queue.isEmpty(), is(false));
 
         queue.remove(thingAShadow2);
@@ -297,39 +234,45 @@ class RequestQueueTest {
     }
 
     @Test
-    void GIVEN_empty_queue_WHEN_offerAndTake_THEN_return_offered() {
-        assertThat(queue.offerAndTake(thingAShadow1, true), is(thingAShadow1));
+    void GIVEN_null_request_WHEN_putAndTake_THEN_throws_null_pointer_exception() {
+        assertThrows(NullPointerException.class, () -> queue.putAndTake(null, false));
+        assertThrows(NullPointerException.class, () -> queue.putAndTake(null, true));
     }
 
     @Test
-    void GIVEN_non_empty_queue_WHEN_offerAndTake_THEN_return_head() throws InterruptedException {
-        queue.offer(thingAShadow2);
-        assertThat(queue.offerAndTake(thingAShadow1, true), is(thingAShadow2));
+    void GIVEN_empty_queue_WHEN_putAndTake_THEN_return_offered() {
+        assertThat(queue.putAndTake(thingAShadow1, true), is(thingAShadow1));
+    }
+
+    @Test
+    void GIVEN_non_empty_queue_WHEN_putAndTake_THEN_return_head() throws InterruptedException {
+        queue.put(thingAShadow2);
+        assertThat(queue.putAndTake(thingAShadow1, true), is(thingAShadow2));
         assertThat(queue.poll(), is(thingAShadow1));
     }
 
     @Test
-    void GIVEN_non_empty_queue_WHEN_offerAndTake_same_shadow_new_THEN_return_merged() {
-        queue.offer(thingAShadow1);
+    void GIVEN_non_empty_queue_WHEN_putAndTake_same_shadow_new_THEN_return_merged() throws InterruptedException {
+        queue.put(thingAShadow1);
         when(merger.merge(thingAShadow1, thingAShadow1Again)).thenReturn(thingAShadow1Merged);
-        assertThat(queue.offerAndTake(thingAShadow1Again, true), is(thingAShadow1Merged));
+        assertThat(queue.putAndTake(thingAShadow1Again, true), is(thingAShadow1Merged));
         assertThat("queue empty", queue.isEmpty(), is(true));
     }
 
     @Test
-    void GIVEN_non_empty_queue_WHEN_offerAndTake_same_shadow_old_THEN_return_merged() {
-        queue.offer(thingAShadow1);
+    void GIVEN_non_empty_queue_WHEN_putAndTake_same_shadow_old_THEN_return_merged() throws InterruptedException {
+        queue.put(thingAShadow1);
         when(merger.merge(thingAShadow1Again, thingAShadow1)).thenReturn(thingAShadow1Merged);
-        assertThat(queue.offerAndTake(thingAShadow1Again, false), is(thingAShadow1Merged));
+        assertThat(queue.putAndTake(thingAShadow1Again, false), is(thingAShadow1Merged));
         assertThat("queue empty", queue.isEmpty(), is(true));
     }
 
     @Test
-    void GIVEN_non_empty_queue_WHEN_offerAndTake_same_shadow_THEN_merge_and_return_head() throws InterruptedException {
-        queue.offer(thingAShadow2);
-        queue.offer(thingAShadow1);
+    void GIVEN_non_empty_queue_WHEN_putAndTake_same_shadow_THEN_merge_and_return_head() throws InterruptedException {
+        queue.put(thingAShadow2);
+        queue.put(thingAShadow1);
         when(merger.merge(thingAShadow1Again, thingAShadow1)).thenReturn(thingAShadow1Merged);
-        assertThat(queue.offerAndTake(thingAShadow1Again, false), is(thingAShadow2));
+        assertThat(queue.putAndTake(thingAShadow1Again, false), is(thingAShadow2));
         assertThat(queue.poll(), is(thingAShadow1Merged));
         assertThat("queue empty", queue.isEmpty(), is(true));
     }

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
@@ -86,7 +86,6 @@ class SyncHandlerTest {
 
         List<Pair<String, String>> shadows = Arrays.asList(new Pair<>("a", "1"), new Pair<>("b", "2"));
         when(context.getDao().listSyncedShadows()).thenReturn(shadows);
-        when(mockSyncStrategy.getRemainingCapacity()).thenReturn(1024);
 
         // WHEN
         syncHandler.start(context, numThreads);

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/SyncHandlerTest.java
@@ -75,7 +75,7 @@ class SyncHandlerTest {
 
     @BeforeEach
     void setup() {
-        syncHandler = new SyncHandler(executorService, scheduledExecutorService, mock(RequestBlockingQueue.class), direction);
+        syncHandler = new SyncHandler(executorService, scheduledExecutorService, mock(RequestQueue.class), direction);
         syncHandler.setOverallSyncStrategy(mockSyncStrategy);
     }
 
@@ -117,7 +117,7 @@ class SyncHandlerTest {
     @Test
     void GIVEN_sync_strategy_WHEN_setSyncStrategy_THEN_calls_sync_factory() {
         // GIVEN
-        syncHandler = new SyncHandler(mockSyncStrategyFactory, mock(RequestBlockingQueue.class), direction);
+        syncHandler = new SyncHandler(mockSyncStrategyFactory, mock(RequestQueue.class), direction);
 
         // WHEN
         syncHandler.setSyncStrategy(mock(Strategy.class));

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/RealTimeSyncStrategyTest.java
@@ -6,7 +6,7 @@
 package com.aws.greengrass.shadowmanager.sync.strategy;
 
 import com.aws.greengrass.shadowmanager.exception.RetryableException;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.RequestMerger;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
@@ -59,14 +59,14 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
 
     @Override
     RealTimeSyncStrategy defaultTestInstance() {
-        return new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue, direction);
+        return new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestQueue, direction);
     }
 
     @Test
     void GIVEN_sync_request_WHEN_putSyncRequest_and_sync_loop_runs_THEN_request_is_executed_successfully()
             throws Exception {
         strategy = new RealTimeSyncStrategy(executorService, mockRetryer,
-                new RequestBlockingQueue(new RequestMerger(direction)), direction);
+                new RequestQueue(new RequestMerger(direction)), direction);
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(mockFullShadowSyncRequest);
 
@@ -78,7 +78,7 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
             throws Exception {
         strategy.putSyncRequest(mock(FullShadowSyncRequest.class));
 
-        verify(mockRequestBlockingQueue, timeout(Duration.ofSeconds(5).toMillis()).times(0)).put(any());
+        verify(mockRequestQueue, timeout(Duration.ofSeconds(5).toMillis()).times(0)).put(any());
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(0)).run(any(), any(), any());
     }
 
@@ -88,18 +88,18 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
         doAnswer(i -> {
             strategy.syncing.set(false);
             return null;
-        }).when(mockRequestBlockingQueue).put(any());
+        }).when(mockRequestQueue).put(any());
 
         lenient().doAnswer(invocation -> {
             TimeUnit.SECONDS.sleep(10);
             return mockFullShadowSyncRequest;
-        }).when(mockRequestBlockingQueue).take();
+        }).when(mockRequestQueue).take();
 
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(mockFullShadowSyncRequest);
 
-        verify(mockRequestBlockingQueue, timeout(Duration.ofSeconds(5).toMillis()).times(1)).put(any());
-        verify(mockRequestBlockingQueue, times(1)).remove(any());
+        verify(mockRequestQueue, timeout(Duration.ofSeconds(5).toMillis()).times(1)).put(any());
+        verify(mockRequestQueue, times(1)).remove(any());
         verify(mockRetryer, timeout(Duration.ofSeconds(5).toMillis()).times(0)).run(any(), any(), any());
     }
 
@@ -107,12 +107,12 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
     void GIVEN_sync_request_WHEN_queue_throws_interrupted_exception_THEN_sync_request_is_not_added(ExtensionContext extensionContext)
             throws Exception {
         ignoreExceptionOfType(extensionContext, InterruptedException.class);
-        doThrow(InterruptedException.class).when(mockRequestBlockingQueue).put(any());
+        doThrow(InterruptedException.class).when(mockRequestQueue).put(any());
 
         lenient().doAnswer(invocation -> {
             TimeUnit.SECONDS.sleep(10);
             return mockFullShadowSyncRequest;
-        }).when(mockRequestBlockingQueue).take();
+        }).when(mockRequestQueue).take();
 
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(mockFullShadowSyncRequest);
@@ -122,14 +122,14 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
         // happens correctly
         assertThat(Thread.interrupted(), is(true));
 
-        verify(mockRequestBlockingQueue, atMostOnce()).offer(any());
+        verify(mockRequestQueue, atMostOnce()).offer(any());
     }
 
     @Test
     void GIVEN_request_queue_WHEN_put_and_clear_THEN_queue_has_correct_number_of_requests() throws InterruptedException {
 
         strategy = new RealTimeSyncStrategy(executorService, mockRetryer,
-                new RequestBlockingQueue(new RequestMerger(direction)), direction);
+                new RequestQueue(new RequestMerger(direction)), direction);
         strategy.syncing.set(true);
         strategy.syncThreadEnd = new CountDownLatch(0); // no sync actually running
 
@@ -175,15 +175,15 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
             takeLatch.countDown();
             FullShadowSyncRequest request = requests.poll();
             return request == null ? mock(FullShadowSyncRequest.class) : request;
-        }).when(mockRequestBlockingQueue).take();
-        when(mockRequestBlockingQueue.offerAndTake(request1, false)).thenReturn(request1);
+        }).when(mockRequestQueue).take();
+        when(mockRequestQueue.offerAndTake(request1, false)).thenReturn(request1);
 
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(new FullShadowSyncRequest("foo", "bar"));
 
         assertThat("executed request", executeLatch.await(5, TimeUnit.SECONDS), is(true));
         assertThat("take all requests", takeLatch.await(5, TimeUnit.SECONDS), is(true));
-        verify(mockRequestBlockingQueue, times(1)).offerAndTake(request1, false);
+        verify(mockRequestQueue, times(1)).offerAndTake(request1, false);
     }
 
     @Test
@@ -204,14 +204,14 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
             return null;
         }).when(mockRetryer).run(any(), any(), any());
 
-        when(mockRequestBlockingQueue.take()).thenReturn(request1);
+        when(mockRequestQueue.take()).thenReturn(request1);
 
         strategy.start(mockSyncContext, 1);
         strategy.putSyncRequest(new FullShadowSyncRequest("foo", "bar"));
 
         assertThat("executed request", executeLatch.await(5, TimeUnit.SECONDS), is(true));
-        verify(mockRequestBlockingQueue, atLeastOnce()).take();
-        verify(mockRequestBlockingQueue, times(0)).offerAndTake(request1, false);
+        verify(mockRequestQueue, atLeastOnce()).take();
+        verify(mockRequestQueue, times(0)).offerAndTake(request1, false);
     }
 
     @ParameterizedTest
@@ -223,7 +223,7 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
         this.direction.setDirection(direction);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
-        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestBlockingQueue, this.direction);
+        strategy = new RealTimeSyncStrategy(executorService, mockRetryer, mockRequestQueue, this.direction);
 
         CloudUpdateSyncRequest request1 = mock(CloudUpdateSyncRequest.class);
         lenient().when(request1.getThingName()).thenReturn("thing1");
@@ -231,7 +231,7 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
 
         CountDownLatch executeLatch = new CountDownLatch(2); // 1 retry to fail, 1 to succeed
 
-        when(mockRequestBlockingQueue.take()).thenAnswer(invocation -> {
+        when(mockRequestQueue.take()).thenAnswer(invocation -> {
             if (executeLatch.getCount() == 2) {
                 return request1;
             }
@@ -251,7 +251,7 @@ class RealTimeSyncStrategyTest extends SyncStrategyTestBase<RealTimeSyncStrategy
         }).when(mockRetryer).run(any(), any(expectedSyncRequest), any());
 
         // return the offered request
-        when(mockRequestBlockingQueue.offerAndTake(any(expectedSyncRequest), eq(true)))
+        when(mockRequestQueue.offerAndTake(any(expectedSyncRequest), eq(true)))
                 .thenAnswer(invocation -> invocation.getArgument(0, expectedSyncRequest));
 
         try {

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyFactoryTest.java
@@ -5,7 +5,7 @@
 
 package com.aws.greengrass.shadowmanager.sync.strategy;
 
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.DirectionWrapper;
 import com.aws.greengrass.shadowmanager.sync.strategy.model.Strategy;
@@ -29,7 +29,7 @@ class SyncStrategyFactoryTest {
     @Mock
     Retryer mockRetryer;
     @Mock
-    private RequestBlockingQueue mockRequestBlockingQueue;
+    private RequestQueue mockRequestQueue;
 
     @Mock
     ExecutorService mockSyncExecutorService;
@@ -41,14 +41,14 @@ class SyncStrategyFactoryTest {
     @Test
     void GIVEN_periodic_sync_strategy_WHEN_getSyncStrategy_THEN_gets_the_correct_sync_strategy_type() {
         SyncStrategyFactory factory = new SyncStrategyFactory(mockRetryer, mockSyncExecutorService, mockScheduledExecutorService, direction);
-        SyncStrategy syncStrategy = factory.createSyncStrategy(Strategy.builder().type(StrategyType.PERIODIC).delay(10L).build(), mockRequestBlockingQueue);
+        SyncStrategy syncStrategy = factory.createSyncStrategy(Strategy.builder().type(StrategyType.PERIODIC).delay(10L).build(), mockRequestQueue);
         assertThat(syncStrategy, is(instanceOf(PeriodicSyncStrategy.class)));
     }
 
     @Test
     void GIVEN_realTime_sync_strategy_WHEN_getSyncStrategy_THEN_gets_the_correct_sync_strategy_type() {
         SyncStrategyFactory factory = new SyncStrategyFactory(mockRetryer, mockSyncExecutorService, mockScheduledExecutorService, direction);
-        SyncStrategy syncStrategy = factory.createSyncStrategy(Strategy.builder().type(StrategyType.REALTIME).build(), mockRequestBlockingQueue);
+        SyncStrategy syncStrategy = factory.createSyncStrategy(Strategy.builder().type(StrategyType.REALTIME).build(), mockRequestQueue);
         assertThat(syncStrategy, is(instanceOf(RealTimeSyncStrategy.class)));
     }
 }

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
@@ -39,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,7 +46,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -115,7 +113,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         }
 
         verify(mockRetryer, never()).run(any(), any(), any());
-        verify(mockRequestQueue, timeout(ofSeconds(5).toMillis())).offer(mockFullShadowSyncRequest);
+        verify(mockRequestQueue).put(mockFullShadowSyncRequest);
     }
 
     @Test
@@ -138,7 +136,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         }
 
         verify(mockRetryer, times(1)).run(any(), eq(mockFullShadowSyncRequest), any());
-        verify(mockRequestQueue, timeout(ofSeconds(5).toMillis())).offer(request2);
+        verify(mockRequestQueue).put(request2);
     }
 
     @Test
@@ -189,7 +187,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         verify(mockRetryer, times(1)).run(any(), eq(mockFullShadowSyncRequest), any());
         verify(mockRetryer, never()).run(any(), eq(request2), any());
 
-        verify(mockRequestQueue, timeout(ofSeconds(5).toMillis()).times(1)).offer(request2);
+        verify(mockRequestQueue).put(request2);
     }
 
     static Stream<Arguments> expectedSyncRequestsOnConflictByDirection() {

--- a/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/sync/strategy/SyncStrategyTestBase.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.shadowmanager.sync.strategy;
 
 import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.shadowmanager.exception.UnknownShadowException;
-import com.aws.greengrass.shadowmanager.sync.RequestBlockingQueue;
+import com.aws.greengrass.shadowmanager.sync.RequestQueue;
 import com.aws.greengrass.shadowmanager.sync.Retryer;
 import com.aws.greengrass.shadowmanager.sync.model.CloudUpdateSyncRequest;
 import com.aws.greengrass.shadowmanager.sync.model.Direction;
@@ -58,7 +58,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
 
     Retryer mockRetryer;
     SyncContext mockSyncContext;
-    RequestBlockingQueue mockRequestBlockingQueue;
+    RequestQueue mockRequestQueue;
     FullShadowSyncRequest mockFullShadowSyncRequest;
     S executorService;
     T strategy;
@@ -74,7 +74,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
     @BeforeEach
     void setup() {
         executorService = executorServiceSupplier.get();
-        mockRequestBlockingQueue = mock(RequestBlockingQueue.class);
+        mockRequestQueue = mock(RequestQueue.class);
         mockSyncContext = mock(SyncContext.class);
         mockRetryer = mock(Retryer.class);
         mockFullShadowSyncRequest = mock(FullShadowSyncRequest.class);
@@ -115,7 +115,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         }
 
         verify(mockRetryer, never()).run(any(), any(), any());
-        verify(mockRequestBlockingQueue, timeout(ofSeconds(5).toMillis())).offer(mockFullShadowSyncRequest);
+        verify(mockRequestQueue, timeout(ofSeconds(5).toMillis())).offer(mockFullShadowSyncRequest);
     }
 
     @Test
@@ -138,7 +138,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         }
 
         verify(mockRetryer, times(1)).run(any(), eq(mockFullShadowSyncRequest), any());
-        verify(mockRequestBlockingQueue, timeout(ofSeconds(5).toMillis())).offer(request2);
+        verify(mockRequestQueue, timeout(ofSeconds(5).toMillis())).offer(request2);
     }
 
     @Test
@@ -189,7 +189,7 @@ public abstract class SyncStrategyTestBase<T extends BaseSyncStrategy, S extends
         verify(mockRetryer, times(1)).run(any(), eq(mockFullShadowSyncRequest), any());
         verify(mockRetryer, never()).run(any(), eq(request2), any());
 
-        verify(mockRequestBlockingQueue, timeout(ofSeconds(5).toMillis()).times(1)).offer(request2);
+        verify(mockRequestQueue, timeout(ofSeconds(5).toMillis()).times(1)).offer(request2);
     }
 
     static Stream<Arguments> expectedSyncRequestsOnConflictByDirection() {


### PR DESCRIPTION
**Description of changes:**
Removes the default shadow queue size limit
of 1024 shadows.

Misc changes:
* Updates to upload-artifact v4 as v3 is deprecated
* Updates nucleus dependency version to allow for local builds on M-series macs

**Why is this change necessary:**
By removing bounds on the shadow queue size
users can now have more than 1024 shadows. 'Take'
operation behaviors remain the same however 'Put'
operations will no longer block as waiting for
space is not a thing.

**How was this change tested:**
Figuring this out now

**Any additional information or context required to review the change:**
The Shadow-Manager has a queue for device shadows. This queue is limited to 1024 shadows by default (but dynamically sized when <1024). This hard limit will prevent customers from having > 1024 shadows. By removing this limit we allow more shadows with likely minimal to no effect for _most_ customers.

For customers with > 1024 shadows this will fix blocking issues which will prevent the device from updating at the cost of additional memory.

**Issue #, if available:**
V1876603400


**Checklist:**
 - [x] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
