### PR TITLE
[Fix] Leave empty objects in metadata

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadata.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadata.java
@@ -70,8 +70,7 @@ public class ShadowStateMetadata {
      */
     @SuppressWarnings("PMD.NullAssignment")
     public JsonNode update(JsonNode patch, ShadowState state) {
-        // Create the patch metadata tree. This will transform nulls to metadata nodes.
-        final JsonNode metadataPatchWithRemovedFields = createMetadataPatch(patch, false);
+        // The persisted metadata should have all removed fields (aka value null) actually removed
         final JsonNode metadataPatchWithoutRemovedFields = createMetadataPatch(patch, true);
 
         // If the thing now has null state after the update then the metadata should also be null
@@ -80,6 +79,9 @@ public class ShadowStateMetadata {
             reported = null;
             return metadataPatchWithoutRemovedFields;
         }
+
+        // Removed field null values need to be kept when merging so that the field is removed from metadata
+        final JsonNode metadataPatchWithRemovedFields = createMetadataPatch(patch, false);
 
         // Merge in the desired metadata
         final JsonNode patchDesired = metadataPatchWithRemovedFields.get(SHADOW_DOCUMENT_STATE_DESIRED);

--- a/src/test/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadataTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadataTest.java
@@ -228,13 +228,103 @@ class ShadowStateMetadataTest {
 
         JsonNode patchMetadata = shadowStateMetadata.update(patchJson.get(), state);
 
-        assertTrue(JsonUtil.isNullOrMissing(shadowStateMetadata.getDesired()));
+        assertFalse(JsonUtil.isNullOrMissing(shadowStateMetadata.getDesired()));
         assertTrue(JsonUtil.isNullOrMissing(shadowStateMetadata.getReported()));
 
         assertFalse(JsonUtil.isNullOrMissing(patchMetadata));
         assertTrue(patchMetadata.has(SHADOW_DOCUMENT_STATE_DESIRED));
         assertTrue(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).has("SomObject"));
         assertThat(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).get("SomObject").get(SHADOW_DOCUMENT_TIMESTAMP).asLong(), is(timestamp));
+    }
+
+    @Test
+    void GIVEN_non_empty_state_with_nested_empty_object_and_non_empty_patch_WHEN_update_THEN_metadata_is_correctly_updated() throws IOException {
+        String stateString = "{\"SomeObject\": {\"SomeVal\": \"123\"}}";
+        JsonNode stateJson = JsonUtil.getPayloadJson(stateString.getBytes()).get();
+        String patchString = "{\"desired\": {\"SomeObject\": {\"SomeVal\": null}}}";
+        Optional<JsonNode> patchJson = JsonUtil.getPayloadJson(patchString.getBytes());
+        String patchMetadataString = "{\"SomeObject\": {\"SomeVal\": \"123\"}}";
+        Optional<JsonNode> patchMetadataJson = JsonUtil.getPayloadJson(patchMetadataString.getBytes());
+
+        ShadowStateMetadata shadowStateMetadata = new ShadowStateMetadata(patchMetadataJson.get(), null, mockClock);
+        ShadowState state = new ShadowState(stateJson, null);
+
+        JsonNode patchMetadata = shadowStateMetadata.update(patchJson.get(), state);
+
+        // The desired field will be present because of the nested object but the object will be empty
+        assertFalse(JsonUtil.isNullOrMissing(shadowStateMetadata.getDesired()));
+        String expectedDesired = "{\"SomeObject\": {}}";
+        assertThat(shadowStateMetadata.getDesired(), is(JsonUtil.getPayloadJson(expectedDesired.getBytes()).get()));
+
+        assertTrue(JsonUtil.isNullOrMissing(shadowStateMetadata.getReported()));
+
+        assertFalse(JsonUtil.isNullOrMissing(patchMetadata));
+        assertTrue(patchMetadata.has(SHADOW_DOCUMENT_STATE_DESIRED));
+        assertTrue(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).has("SomeObject"));
+        assertThat(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).get("SomeObject"), is(JsonUtil.OBJECT_MAPPER.createObjectNode()));
+    }
+
+    @Test
+    void GIVEN_non_empty_state_with_nested_object_and_nested_field_removed_WHEN_update_THEN_metadata_is_correctly_updated() throws IOException {
+        String stateString = "{\"SomeObject\": {\"SomeVal\": \"123\", \"AnotherVal\": \"testingValue\"}}";
+        JsonNode stateJson = JsonUtil.getPayloadJson(stateString.getBytes()).get();
+        String patchString = "{\"desired\": {\"SomeObject\": {\"SomeVal\": null, \"AnotherVal\": \"testingValue\"}}}";
+        Optional<JsonNode> patchJson = JsonUtil.getPayloadJson(patchString.getBytes());
+        String patchMetadataString = "{\"SomeObject\": {\"SomeVal\": \"123\", \"AnotherVal\": \"4567\"}}";
+        Optional<JsonNode> patchMetadataJson = JsonUtil.getPayloadJson(patchMetadataString.getBytes());
+
+        ShadowStateMetadata shadowStateMetadata = new ShadowStateMetadata(patchMetadataJson.get(), null, mockClock);
+        ShadowState state = new ShadowState(stateJson, null);
+
+        JsonNode patchMetadata = shadowStateMetadata.update(patchJson.get(), state);
+
+        // The desired field will be present because of the nested object but the object will be empty
+        assertFalse(JsonUtil.isNullOrMissing(shadowStateMetadata.getDesired()));
+        assertTrue(shadowStateMetadata.getDesired().has("SomeObject"));
+        assertTrue(shadowStateMetadata.getDesired().get("SomeObject").has("AnotherVal"));
+        assertTrue(shadowStateMetadata.getDesired().get("SomeObject").get("AnotherVal").has(SHADOW_DOCUMENT_TIMESTAMP));
+        assertThat(shadowStateMetadata.getDesired().get("SomeObject").get("AnotherVal").get(SHADOW_DOCUMENT_TIMESTAMP).asLong(),
+                is(timestamp));
+
+        assertTrue(JsonUtil.isNullOrMissing(shadowStateMetadata.getReported()));
+
+        assertFalse(JsonUtil.isNullOrMissing(patchMetadata));
+        assertTrue(patchMetadata.has(SHADOW_DOCUMENT_STATE_DESIRED));
+        assertTrue(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).has("SomeObject"));
+        assertThat(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).get("SomeObject").get("AnotherVal").get(SHADOW_DOCUMENT_TIMESTAMP).asLong(), is(timestamp));
+        assertFalse(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).get("SomeObject").has("SomeVal"));
+    }
+
+    @Test
+    void GIVEN_non_empty_state_with_nested_object_and_nested_field_added_WHEN_update_THEN_metadata_is_correctly_updated() throws IOException {
+        String stateString = "{\"SomeObject\": {\"SomeVal\": \"123\"}}";
+        JsonNode stateJson = JsonUtil.getPayloadJson(stateString.getBytes()).get();
+        String patchString = "{\"desired\": {\"SomeObject\": {\"SomeVal\": \"456\", \"AnotherVal\": " +
+                "\"testingValue\"}}}";
+        Optional<JsonNode> patchJson = JsonUtil.getPayloadJson(patchString.getBytes());
+        String patchMetadataString = "{\"SomeObject\": {\"SomeVal\": \"456\", \"AnotherVal\": \"testingValue\"}}";
+        Optional<JsonNode> patchMetadataJson = JsonUtil.getPayloadJson(patchMetadataString.getBytes());
+
+        ShadowStateMetadata shadowStateMetadata = new ShadowStateMetadata(patchMetadataJson.get(), null, mockClock);
+        ShadowState state = new ShadowState(stateJson, null);
+
+        JsonNode patchMetadata = shadowStateMetadata.update(patchJson.get(), state);
+
+        // The desired field will be present because of the nested object but the object will be empty
+        assertFalse(JsonUtil.isNullOrMissing(shadowStateMetadata.getDesired()));
+        assertTrue(shadowStateMetadata.getDesired().has("SomeObject"));
+        assertTrue(shadowStateMetadata.getDesired().get("SomeObject").has("AnotherVal"));
+        assertTrue(shadowStateMetadata.getDesired().get("SomeObject").get("AnotherVal").has(SHADOW_DOCUMENT_TIMESTAMP));
+        assertThat(shadowStateMetadata.getDesired().get("SomeObject").get("AnotherVal").get(SHADOW_DOCUMENT_TIMESTAMP).asLong(),
+                is(timestamp));
+
+        assertTrue(JsonUtil.isNullOrMissing(shadowStateMetadata.getReported()));
+
+        assertFalse(JsonUtil.isNullOrMissing(patchMetadata));
+        assertTrue(patchMetadata.has(SHADOW_DOCUMENT_STATE_DESIRED));
+        assertTrue(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).has("SomeObject"));
+        assertThat(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).get("SomeObject").get("SomeVal").get(SHADOW_DOCUMENT_TIMESTAMP).asLong(), is(timestamp));
+        assertThat(patchMetadata.get(SHADOW_DOCUMENT_STATE_DESIRED).get("SomeObject").get("AnotherVal").get(SHADOW_DOCUMENT_TIMESTAMP).asLong(), is(timestamp));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-shadow-manager/issues/212

**Description of changes:**
This change updates how Shadow document metadata is calculated. For a simple document updates which remove only top key value pairs, the behavior will not change. For a more complicated document where nested objects are removed, the behavior is updated to keep the empty parent object (which matches IoT Shadow). 

**Why is this change necessary:**
By removing empty objects from the metadata the shadow manager is calculating the ShadowDocMetadata.desired (or reported) field to null which results in a later NullPointerException when building the updated metadata later.

**How was this change tested:**
Added unit tests as well as performed manual testing against the case mentioned in the issue.

**Any additional information or context required to review the change:**
It's useful to know how Jackson JsonNode's function

**Checklist:**
 - [N/A] Updated the README if applicable
 - [x] Updated or added new unit tests
 - [Pending] Updated or added new integration tests
 - [N/A] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
