### PR TITLE
fix: use nanoseconds instead of milliseconds in rate limiter

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/ipc/IpcRateLimiter.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/ipc/IpcRateLimiter.java
@@ -11,9 +11,11 @@ import lombok.Synchronized;
 
 @Getter(AccessLevel.PACKAGE)
 public class IpcRateLimiter {
+    private static final long RATE_LIMIT_WINDOW_NANOS = 1_000_000_000;
+    
     private int count = 0;
     private int rate;
-    private long timestamp = System.nanoTime() / 1_000_000;
+    private long timestamp = System.nanoTime();
 
     /**
      * Constructor.
@@ -40,9 +42,9 @@ public class IpcRateLimiter {
      */
     @Synchronized
     public boolean tryAcquire() {
-        long currentTime = System.nanoTime() / 1_000_000;
+        long currentTime = System.nanoTime();
 
-        if (currentTime - timestamp >= 1000) {
+        if (currentTime - timestamp >= RATE_LIMIT_WINDOW_NANOS) {
             count = 1;
             timestamp = currentTime;
             return true;

--- a/src/test/java/com/aws/greengrass/shadowmanager/ipc/IpcRateLimiterTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/ipc/IpcRateLimiterTest.java
@@ -62,6 +62,6 @@ public class IpcRateLimiterTest {
 
         assertThat("lock acquired", ipcRateLimiter.tryAcquire(), is(true));
         assertThat("count reset", ipcRateLimiter.getCount(), is(1));
-        assertThat(ipcRateLimiter.getTimestamp(), greaterThanOrEqualTo(initialTimestamp + 1000));
+        assertThat(ipcRateLimiter.getTimestamp(), greaterThanOrEqualTo(initialTimestamp + 1_000_000_000));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Consider a very rare edge case if the long value for System.nanoTime() overflows. The spec for System.nanoTime() does not guarantee what the origin point of the monotonic timer is.

Typically the math of doing time1 - time0 will handle this overflow, but we were dividing by 1 million to hit millis, so the math will not 'fix' itself via overflow as we will be well within the bounds of a long at values where the original System.nanoTime is near max.

Changing to use the original nanos allows us to avoid this edge case as the long arithmetic will work out even in overflow cases, while keeping the logic simpler.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**


**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
