### PR TITLE
Guard against null metadata node in ShadowStateMetadata.buildMetadata (fixes NPE)

### DIFF
--- a/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadata.java
+++ b/src/main/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadata.java
@@ -268,6 +268,13 @@ public class ShadowStateMetadata {
             return metadataNode;
         }
 
+        // If there is no metadata for this subtree, there is nothing to build. This can happen when the delta and the
+        // desired metadata are structurally inconsistent (e.g. a delta node exists at a path where the desired metadata
+        // is null/missing). Guard against it here instead of dereferencing null in the array/object handling below.
+        if (isNullOrMissing(metadataNode)) {
+            return null;
+        }
+
         // If the deltaNode is an array then recurse on each index
         if (deltaNode.isArray()) {
             final ArrayNode result = JsonUtil.OBJECT_MAPPER.createArrayNode();

--- a/src/test/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadataTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/model/ShadowStateMetadataTest.java
@@ -26,6 +26,7 @@ import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_S
 import static com.aws.greengrass.shadowmanager.model.Constants.SHADOW_DOCUMENT_TIMESTAMP;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -317,6 +318,29 @@ class ShadowStateMetadataTest {
 
     }
 
+
+    @Test
+    void GIVEN_delta_field_missing_from_metadata_WHEN_getDeltaMetadata_THEN_does_not_throw() throws IOException {
+        // Regression test: the delta contains an array field ("SomeArray") for which the desired metadata has no
+        // corresponding node. buildMetadata must not dereference the null metadata node. Previously this threw a
+        // NullPointerException at ShadowStateMetadata.buildMetadata when casting/indexing the null metadata array.
+        final String deltaString = "{\"id\": 100, \"SomeArray\": [100, 200]}";
+        final String patchMetadataString = "{\"id\": {\"timestamp\": 12345}}";
+        Optional<JsonNode> patchMetadataJson = JsonUtil.getPayloadJson(patchMetadataString.getBytes());
+        assertTrue(patchMetadataJson.isPresent());
+        Optional<JsonNode> deltaJson = JsonUtil.getPayloadJson(deltaString.getBytes());
+        assertTrue(deltaJson.isPresent());
+        ShadowStateMetadata shadowStateMetadata = new ShadowStateMetadata(patchMetadataJson.get(), null, mockClock);
+
+        JsonNode deltaMetadata = assertDoesNotThrow(() -> shadowStateMetadata.getDeltaMetadata(deltaJson.get()));
+
+        assertFalse(JsonUtil.isNullOrMissing(deltaMetadata));
+        // The field that had corresponding metadata is still present.
+        assertTrue(deltaMetadata.has("id"));
+        assertThat(deltaMetadata.get("id").get(SHADOW_DOCUMENT_TIMESTAMP).asLong(), is(12345L));
+        // The field with no corresponding metadata is handled gracefully instead of throwing.
+        assertTrue(JsonUtil.isNullOrMissing(deltaMetadata.get("SomeArray")));
+    }
 
     @Test
     void GIVEN_metadata_WHEN_deepCopy_THEN_gets_new_instance_of_metadata() throws IOException {


### PR DESCRIPTION
### Issue

Fixes the `NullPointerException` reported in #222.

### Problem

`ShadowStateMetadata.getDeltaMetadata(delta)` calls `buildMetadata(delta, desired)`. `buildMetadata` recurses the delta tree and dereferences the corresponding metadata node without a null guard:

```java
// array branch
final ArrayNode metadataArray = (ArrayNode) metadataNode;   // metadataNode may be null
... metadataArray.get(i)                                    // -> NullPointerException

// object branch
final ObjectNode metadataObjectNode = (ObjectNode) metadataNode;   // metadataNode may be null
... metadataObjectNode.get(fieldName)                              // -> NullPointerException
```

When a delta node exists at a path where the `desired` metadata subtree is `null`/missing (a state vs. metadata structural inconsistency), `metadataNode` is `null` and the array/object handling throws NPE.

Observed on a production Greengrass device (Nucleus 2.16.1 / ShadowManager 2.3.12): a local pub/sub shadow `update` fails with:

```
java.lang.NullPointerException
    at com.aws.greengrass.shadowmanager.model.ShadowStateMetadata.buildMetadata(ShadowStateMetadata.java:294)
    at com.aws.greengrass.shadowmanager.model.ShadowStateMetadata.getDeltaMetadata(ShadowStateMetadata.java:254)
    at com.aws.greengrass.shadowmanager.model.ShadowDocument.getDelta(ShadowDocument.java:202)
    at com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler.publishDeltaMessage(UpdateThingShadowRequestHandler.java:309)
    at com.aws.greengrass.shadowmanager.ipc.UpdateThingShadowRequestHandler.handleRequest(UpdateThingShadowRequestHandler.java:94)
    at com.aws.greengrass.shadowmanager.PubSubIntegrator.handlePublishedMessage(PubSubIntegrator.java:121)
    ...
```

The exception is unhandled at the IPC layer, so the update is dropped (`PubSubIntegrator: Unable to perform shadow operation`), the delta is never published, and every subsequent update to the affected shadow repeats the NPE.

### Fix

Add an `isNullOrMissing(metadataNode)` guard in `buildMetadata` right after the value-node check. If there is no metadata for a delta subtree, the subtree is skipped (returns `null`) instead of dereferencing null in the array/object handling. This also naturally covers the array-index case where the metadata array is shorter than the delta array (`ArrayNode.get(i)` returns `null` for an out-of-range index, which now recurses into the guarded branch).

### Test

Added `GIVEN_delta_field_missing_from_metadata_WHEN_getDeltaMetadata_THEN_does_not_throw`: a delta with an array field whose desired metadata has no corresponding node. Before the fix this threw NPE; after the fix `getDeltaMetadata` completes, keeps fields that do have metadata, and treats the field with missing metadata as null/missing.

### Notes

- I was unable to run the Maven build/tests locally (no Maven/toolchain in my environment), so the change is verified by code inspection and follows the existing test style. Please run CI.
- I have not been able to capture a minimal reproduction of the exact document that produces the state/metadata mismatch in the field (the shadow reconciles too quickly to capture the offending state live), but the missing null guard is evident from the source and the stack trace above is from a production device.
