### PR TITLE
test: add regression coverage for null metadata with empty state objects

### DIFF
--- a/src/test/java/com/aws/greengrass/shadowmanager/model/ShadowDocumentMetadataInvariantTest.java
+++ b/src/test/java/com/aws/greengrass/shadowmanager/model/ShadowDocumentMetadataInvariantTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.shadowmanager.model;
+
+import com.aws.greengrass.shadowmanager.util.JsonUtil;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for issue #212. After any {@link ShadowDocument#update(JsonNode)}, the state and metadata
+ * trees must stay in step: a non-null {@code state.desired} (or {@code state.reported}) must be matched by a
+ * non-null metadata counterpart, and {@link ShadowDocument#getDelta()} must be safe to call. Updates containing
+ * empty objects (directly, or left behind after all children of a node are removed) used to strip the
+ * corresponding metadata nodes, leaving the metadata tree null while the state tree was not, and a later
+ * {@code getDelta()} then threw a {@code NullPointerException}.
+ */
+@ExtendWith({GGExtension.class})
+class ShadowDocumentMetadataInvariantTest {
+    private static final String FRESH_DOCUMENT = "{\"state\":{},\"version\":1}";
+
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    private static Stream<Arguments> updateCases() {
+        return Stream.of(
+                Arguments.of("empty object as only desired node",
+                        FRESH_DOCUMENT,
+                        "{\"state\":{\"desired\":{\"node\":{}}}}"),
+                Arguments.of("empty object beside a populated sibling",
+                        FRESH_DOCUMENT,
+                        "{\"state\":{\"desired\":{\"empty\":{},\"populated\":{\"on\":true}}}}"),
+                Arguments.of("all children of a node removed by a null patch",
+                        "{\"state\":{\"desired\":{\"node\":{\"a\":1,\"b\":2}}},"
+                                + "\"metadata\":{\"desired\":{\"node\":{\"a\":{\"timestamp\":1},"
+                                + "\"b\":{\"timestamp\":1}}}},\"version\":5}",
+                        "{\"state\":{\"desired\":{\"node\":{\"a\":null,\"b\":null}}}}"),
+                Arguments.of("empty object nested two levels down",
+                        FRESH_DOCUMENT,
+                        "{\"state\":{\"desired\":{\"outer\":{\"inner\":{}}}}}"),
+                Arguments.of("empty object on the reported side",
+                        FRESH_DOCUMENT,
+                        "{\"state\":{\"reported\":{\"node\":{}},\"desired\":{\"x\":1}}}"),
+                Arguments.of("populated desired node",
+                        FRESH_DOCUMENT,
+                        "{\"state\":{\"desired\":{\"node\":{\"on\":true}}}}"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("updateCases")
+    void GIVEN_document_WHEN_update_THEN_metadata_is_non_null_wherever_state_is(
+            String name, String initialDocument, String updateRequest) throws IOException {
+        ShadowDocument document = updatedDocument(initialDocument, updateRequest);
+
+        if (document.getState().getDesired() != null) {
+            assertNotNull(document.getMetadata().getDesired(),
+                    "metadata.desired is null while state.desired is not");
+        }
+        if (document.getState().getReported() != null) {
+            assertNotNull(document.getMetadata().getReported(),
+                    "metadata.reported is null while state.reported is not");
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("updateCases")
+    void GIVEN_document_WHEN_update_THEN_get_delta_does_not_throw(
+            String name, String initialDocument, String updateRequest) throws IOException {
+        ShadowDocument document = updatedDocument(initialDocument, updateRequest);
+
+        assertDoesNotThrow(document::getDelta);
+    }
+
+    private static ShadowDocument updatedDocument(String initialDocument, String updateRequest) throws IOException {
+        ShadowDocument document = new ShadowDocument(initialDocument.getBytes(StandardCharsets.UTF_8), false);
+        Optional<JsonNode> update = JsonUtil.getPayloadJson(updateRequest.getBytes(StandardCharsets.UTF_8));
+        assertTrue(update.isPresent());
+        document.update(update.get());
+        return document;
+    }
+}


### PR DESCRIPTION
Adds regression tests for the state/metadata consistency invariant that #213 fixes.

## What this tests

After `ShadowDocument.update(patch)`, both sides of the document must satisfy: if `state.{desired,reported}` is non-null, then `metadata.{desired,reported}` is non-null. A desired-side violation of this invariant causes `getDelta()` to throw NullPointerException in `buildMetadata` (one frame deep).

The root cause is `JsonUtil.isMissing()` treating empty objects (`{}`) as missing, which leads `ShadowStateMetadata.merge()` to remove metadata keys while the corresponding state nodes remain. When that removal empties the metadata tree, `nullIfEmpty` converts it to `null`.

Six cases cover the invariant from different angles. Case 5 exercises the same empty-object handling on the reported side, where it leaves the metadata tree inconsistent without surfacing as a crash — delta metadata is derived from the desired tree alone, so the reported-side violation is silent. Case 6 is the control (populated node, must pass everywhere).

## Verification results

All assertions check the invariant (state non-null → metadata non-null) and safety (`getDelta()` does not throw). No assertions on metadata contents.

| Case | Description | `release_2.3.x` | `v2.3.13` |
|------|-------------|:---:|:---:|
| 1 | empty object as only desired node | ✓ | ✗ |
| 2 | empty object beside a populated sibling | ✓ | ✓ |
| 3 | all children of a node removed by a null patch | ✓ | ✗ |
| 4 | empty object nested two levels down | ✓ | ✓ |
| 5 | empty object on the reported side | ✓ | ✗ |
| 6 | populated desired node (control) | ✓ | ✓ |

**`release_2.3.x`: 12 tests, 0 failures.**
**`v2.3.13`: 12 tests, 5 failures** — the invariant assertion fails for cases 1, 3, and 5 (metadata null while state is non-null), and the `getDelta()` safety assertion additionally fails for cases 1 and 3 with the NPE from `ShadowStateMetadata.buildMetadata`. Case 5's violation is on the reported side, so it does not trigger the NPE.

The failures on the pre-fix tag confirm the tests are meaningful: they detect the condition #213 addresses.

## Notes

- This PR targets `main`, which carries the #213 fix as of #225. The tests also pass on `release_2.3.x` (where #213 originally landed) and fail on any branch without it.
- Tests are in a new class (`ShadowDocumentMetadataInvariantTest`) rather than extending `ShadowStateMetadataTest`, because the latter differs between tags.
- The `getDelta()` safety assertion is a separate parameterized test method so failures report independently from the invariant assertion.
